### PR TITLE
Track and embed version number

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,18 +2,24 @@ ci:
   autoupdate_schedule: monthly
 
 repos:
-- repo: https://github.com/pre-commit/mirrors-clang-format
-  rev: v19.1.6
-  hooks:
-  - id: clang-format
-    files: \.c(c|pp|xx|u|uh)?$|\.h(pp)?$
-- repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.9.1
-  hooks:
-    - id: ruff
-      args: [--fix, --exit-non-zero-on-fix]
-    - id: ruff-format
-- repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v1.14.1
-  hooks:
-    - id: mypy
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v19.1.6
+    hooks:
+      - id: clang-format
+        files: \.c(c|pp|xx|u|uh)?$|\.h(pp)?$
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.9.1
+    hooks:
+      - id: ruff
+        args: [--fix, --exit-non-zero-on-fix]
+      - id: ruff-format
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.14.1
+    hooks:
+      - id: mypy
+  - repo: https://github.com/jumanjihouse/pre-commit-hook-yamlfmt
+    rev: 0.2.3
+    hooks:
+      - id: yamlfmt
+        exclude: ".clang-format"
+        args: ["--mapping", "2", "--sequence", "4", "--offset", "2", "--preserve-quotes", "--implicit_start", "--preserve_null"]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,17 +2,19 @@ cmake_minimum_required(VERSION 3.20...3.30)
 # Constraints on minimum version:
 # - h5read: FindHDF5 only creates interface targets on 3.20+
 
-project(fast-feedback-service LANGUAGES NONE)
+# Get version at start so that we can set it at root level
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules")
+include(ResolveGitVersion)
+
+project(fast-feedback-service LANGUAGES NONE VERSION ${FFS_VERSION_CMAKE})
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CUDA_STANDARD 20)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS yes)
-set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules")
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
 include(SetDefaultBuildRelWithDebInfo)
 include(AlwaysColourCompilation)
-
 
 include_directories(include)
 
@@ -40,6 +42,10 @@ FetchContent_Declare(
 )
 FetchContent_MakeAvailable(argparse)
 
+# Make a small library that we can link to to get the version
+project(version CXX)
+configure_file(version.cc.in version.cc @ONLY)
+add_library(version STATIC version.cc)
 
 add_subdirectory(h5read)
 add_subdirectory(baseline)

--- a/cmake/Modules/ResolveGitVersion.cmake
+++ b/cmake/Modules/ResolveGitVersion.cmake
@@ -1,0 +1,58 @@
+# Resolve the version by querying git and turn into a PEP-440 number
+#
+# Exports:
+#   FFS_VERSION
+#       Either X.Y.Z or X.Y.0.devN
+#   FFS_VERSION_FULL
+#           Either X.Y.Z+gSHA or X.Y.0.devZ+gSHA depending on 
+#   FFS_VERSION_CMAKE
+#       A limited-detail expression of the version number, suitable for
+#       the internal CMake version handling (which knows nothing about
+#       things like dev, rc, prerelease). Dev versions will have the
+#       X.Y.0 of the next release, and non-dev branches will be plain
+#       X.Y.Z.
+
+find_package(Git QUIET)
+
+if(NOT Git_FOUND)
+    set(FFS_VERSION "0.0.0.dev0+g000000")
+    set(FFS_VERSION_CMAKE "0.0.0")
+    message(WARNING "No git, could not determine repository version")
+else()
+    execute_process(
+        COMMAND
+        "${GIT_EXECUTABLE}" describe --tags --long --first-parent --dirty
+        WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+        RESULT_VARIABLE res
+        OUTPUT_VARIABLE REPO_VERSION
+        ERROR_QUIET
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+    message(STATUS "Out: |${REPO_VERSION}|")
+    # # Uncomment to recalculate version number on every commit... this might
+    # # be annoying, so "live" with the lagging number on developer installs,
+    # # but in places where we care (e.g. compiling for deployment) this will work
+    # set_property(GLOBAL APPEND
+    #     PROPERTY CMAKE_CONFIGURE_DEPENDS
+    #     "${CMAKE_SOURCE_DIR}/.git/index"
+    # )
+    
+    # Extract parts from the version number
+    string(REGEX REPLACE "^v([0-9]+)\\.([0-9]+)(.*)-([0-9]+)-(g.+)$" "\\1;\\2;\\3;\\4;\\5" _ver_parts "${REPO_VERSION}")
+    list(GET _ver_parts 0 _ver_version_major)
+    list(GET _ver_parts 1 _ver_version_minor)
+    list(GET _ver_parts 2 _ver_version_dev)
+    list(GET _ver_parts 3 _ver_commits)
+    list(GET _ver_parts 4 _ver_shasum)
+    message(STATUS "${_ver_version_dev}")
+    if (_ver_version_dev STREQUAL ".dev")
+        # A dev build
+        set(FFS_VERSION_FULL "${_ver_version_major}.${_ver_version_minor}.0.dev${_ver_commits}+${_ver_shasum}")
+        set(FFS_VERSION_CMAKE "${_ver_version_major}.${_ver_version_minor}.0")
+    else()
+        # Is not a dev build, so a release or release branch
+        set(FFS_VERSION_FULL "${_ver_version_major}.${_ver_version_minor}.${_ver_commits}+${_ver_shasum}")
+        set(FFS_VERSION_CMAKE "${_ver_version_major}.${_ver_version_minor}.${_ver_commits}")
+    endif()
+    
+endif()

--- a/include/cuda_common.hpp
+++ b/include/cuda_common.hpp
@@ -71,6 +71,15 @@ class CUDAArgumentParser : public argparse::ArgumentParser {
   public:
     CUDAArgumentParser(std::string version = "0.1.0")
         : ArgumentParser("", version, argparse::default_arguments::help) {
+        this->add_argument("--version")
+          .help("print version information and exits")
+          .action([=](const auto & /*unused*/) {
+              fmt::print("{}\n", version);
+              std::exit(0);
+          })
+          .default_value(false)
+          .implicit_value(true)
+          .nargs(0);
         this->add_argument("-v", "--verbose")
           .help("Verbose output")
           .implicit_value(false)

--- a/include/version.hpp
+++ b/include/version.hpp
@@ -1,0 +1,3 @@
+#pragma once
+
+extern const char *FFS_VERSION;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,32 +1,35 @@
-[tool.poetry]
+[build-system]
+requires = ["setuptools>=64", "setuptools_scm>=8"]
+build-backend = "setuptools.build_meta"
+
+[project]
 name = "ffs"
-version = "0.1.0"
-description = ""
-authors = ["Nicholas Devenish <ndevenish@gmail.com>"]
+dynamic = ["version"]
+description = "Add your description here"
+readme = "README.md"
+authors = [
+    { name = "Nicholas Devenish", email = "ndevenish@gmail.com" },
+    { name = "Dimitri Vlachos", email = "dimitrios.vlachos@diamond.ac.uk" },
+]
 
-[tool.poetry.dependencies]
-python = "^3.11"
-requests = "^2.30.0"
-watchdir = "^1.0.0"
-pyepics = "^3.5.2"
-zocalo = "^1.1"
-rich = "^13.7.1"
-pydantic = "^2"
+requires-python = ">=3.12"
+dependencies = [
+    "pydantic>2",
+    "pyepics>=3.5.7",
+    "requests>=2.32.3",
+    "rich>=13.9.4",
+    "watchdir>=1.0.0",
+    "zocalo>=1.2.0",
+]
 
-[tool.poetry.plugins."workflows.services"]
+[tool.setuptools_scm]
+
+[project.entry-points."workflows.services"]
 "GPUPerImageAnalysis" = "ffs.service:GPUPerImageAnalysis"
 "XRCResultCompare" = "compare_service:XRCResultCompare"
 
-
-[tool.poetry.group.dev.dependencies]
-mypy = "^1.10.0"
-
-[build-system]
-requires = ["poetry-core"]
-build-backend = "poetry.core.masonry.api"
-
 [tool.ruff]
 lint.ignore = ["E501", "E741"]
-line-length = 88
 lint.select = ["C9", "E", "F", "W", "I"]
 lint.unfixable = ["F841"]
+line-length = 88

--- a/spotfinder/CMakeLists.txt
+++ b/spotfinder/CMakeLists.txt
@@ -28,6 +28,7 @@ target_link_libraries(spotfinder
     Boost::graph
     lodepng
     nlohmann_json::nlohmann_json
+    version
 )
 target_compile_options(spotfinder PRIVATE "$<$<AND:$<CONFIG:Debug>,$<COMPILE_LANGUAGE:CUDA>>:-G>")
 target_compile_options(spotfinder PRIVATE "$<$<AND:$<COMPILE_LANGUAGE:CUDA>,$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>>:--generate-line-info>")

--- a/spotfinder/spotfinder.cc
+++ b/spotfinder/spotfinder.cc
@@ -30,6 +30,7 @@
 #include "kernels/masking.cuh"
 #include "shmread.hpp"
 #include "standalone.h"
+#include "version.hpp"
 
 using namespace fmt;
 using namespace std::chrono_literals;
@@ -266,7 +267,7 @@ class PipeHandler {
 int main(int argc, char **argv) {
 #pragma region Argument Parsing
     // Parse arguments and get our H5Reader
-    auto parser = CUDAArgumentParser();
+    auto parser = CUDAArgumentParser(FFS_VERSION);
     parser.add_h5read_arguments();
     parser.add_argument("-n", "--threads")
       .help("Number of parallel reader threads")

--- a/src/ffs/__init__.py
+++ b/src/ffs/__init__.py
@@ -1,0 +1,6 @@
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("ffs")
+except PackageNotFoundError:
+    pass

--- a/version.cc.in
+++ b/version.cc.in
@@ -1,0 +1,2 @@
+#include "version.hpp"
+const char *FFS_VERSION = "@FFS_VERSION_FULL@";


### PR DESCRIPTION
This works both in python and C++, and the CMake scaffolding has been updated to pass through into C++. At the moment, this is only refreshed on configure, which means it won't always update when your commit changes. We can turn this on if we want, but at the moment this is to allow us to have identifiable release builds, so the development story probably doesn't matter so much.