### PR TITLE
Adding thread-safe logging to Spotfinder

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,9 +6,9 @@ cmake_minimum_required(VERSION 3.20...3.30)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules")
 include(ResolveGitVersion)
 
-project(fast-feedback-service LANGUAGES NONE VERSION ${FFS_VERSION_CMAKE})
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CUDA_STANDARD 20)
+project(fast-feedback-service LANGUAGES CXX VERSION ${FFS_VERSION_CMAKE})
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS yes)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
@@ -41,6 +41,13 @@ FetchContent_Declare(
     GIT_TAG f362c4647e7b4bbfef8320040409560b5f90e9e0
 )
 FetchContent_MakeAvailable(argparse)
+FetchContent_Declare(
+    spdlog
+    GIT_REPOSITORY https://github.com/gabime/spdlog
+    GIT_TAG        v1.15.0
+    FIND_PACKAGE_ARGS
+)
+FetchContent_MakeAvailable(spdlog)
 
 # Make a small library that we can link to to get the version
 project(version CXX)

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ This will create the executable `spotfinder` in the [`build/bin/`] directory.
 The service uses the following environment variables:
 - `SPOTFINDER`: The path to the compiled spotfinder executable.
   - If not set, the service will look for the executable in the `build/bin/` or `_build/bin` directories.
+- `LOG_LEVEL`: The level of logging to use provided by `spdlog`. Not setting this will default to `info`.
+  - Other levels are: `trace`, `debug`, `info`, `warn`, `error`, `critical`, `off`.
 
 ### Running the service
 To run the service, you need to be on a machine with an NVIDIA GPU and the CUDA toolkit installed.

--- a/include/common.hpp
+++ b/include/common.hpp
@@ -5,6 +5,7 @@
 
 #include <algorithm>
 #include <cinttypes>
+#include <ffs_logger.hpp>
 #include <memory>
 #include <span>
 #include <stdexcept>
@@ -14,6 +15,9 @@
 
 #define VALID_PIXEL 1
 #define MASKED_PIXEL 0
+
+// Global static access to the logger
+static auto &logger = FFSLogger::getInstance();
 
 template <typename T1, typename... TS>
 auto with_formatting(const std::string &code, const T1 &first, TS... args)

--- a/include/ffs_logger.hpp
+++ b/include/ffs_logger.hpp
@@ -67,10 +67,12 @@ class FFSLogger {
             // Create a rotating file sink (max 5MB per file, 3 rotated files)
             auto file_sink = std::make_shared<spdlog::sinks::rotating_file_sink_mt>(
               "logs/ffs_log.txt", 5 * 1024 * 1024, 3);
+            file_sink->set_pattern(
+              "[%Y-%m-%d %H:%M:%S] [PID:%P Thread:%t] [%^%l%$] [%s:%#] %v");
 
             // Create a colored console sink
             auto console_sink = std::make_shared<spdlog::sinks::stdout_color_sink_mt>();
-            console_sink->set_pattern("[%^%l%$] %v");
+            console_sink->set_pattern("[%Y-%m-%d %H:%M:%S] [thread %t] [%^%l%$] %v");
 
             // Combine sinks into one asynchronous logger
             std::vector<spdlog::sink_ptr> sinks{console_sink, file_sink};
@@ -84,7 +86,6 @@ class FFSLogger {
 
             // Set default log level and pattern
             async_logger->set_level(spdlog::level::info);
-            async_logger->set_pattern("[%Y-%m-%d %H:%M:%S] [%^%l%$] %v");
 
             // Register the logger globally
             spdlog::register_logger(async_logger);

--- a/include/ffs_logger.hpp
+++ b/include/ffs_logger.hpp
@@ -107,4 +107,7 @@ class FFSLogger {
     }
 };
 
+// Global static access to the logger
+static auto& logger = FFSLogger::getInstance();
+
 #endif  // FFS_LOGGER_HPP

--- a/include/ffs_logger.hpp
+++ b/include/ffs_logger.hpp
@@ -93,9 +93,6 @@ class FFSLogger {
                 async_logger->set_level(spdlog::level::info);  // Default log level
             }
 
-            // Set default log level and pattern
-            async_logger->set_level(spdlog::level::info);
-
             // Register the logger globally
             spdlog::register_logger(async_logger);
 

--- a/include/ffs_logger.hpp
+++ b/include/ffs_logger.hpp
@@ -65,17 +65,18 @@ class FFSLogger {
             spdlog::init_thread_pool(queue_size, 1);
 
             // Create a rotating file sink (max 5MB per file, 3 rotated files)
-            auto file_sink = std::make_shared<spdlog::sinks::rotating_file_sink_mt>(
-              "logs/ffs_log.txt", 5 * 1024 * 1024, 3);
-            file_sink->set_pattern(
-              "[%Y-%m-%d %H:%M:%S] [PID:%P Thread:%t] [%^%l%$] [%s:%#] %v");
+            // auto file_sink = std::make_shared<spdlog::sinks::rotating_file_sink_mt>(
+            //   "ffs_log.txt", 5 * 1024 * 1024, 3);
+            // file_sink->set_pattern(
+            //   "[%Y-%m-%d %H:%M:%S] [PID:%P Thread:%t] [%^%l%$] [%s:%#] %v");
 
             // Create a colored console sink
             auto console_sink = std::make_shared<spdlog::sinks::stdout_color_sink_mt>();
             console_sink->set_pattern("[%Y-%m-%d %H:%M:%S] [thread %t] [%^%l%$] %v");
 
             // Combine sinks into one asynchronous logger
-            std::vector<spdlog::sink_ptr> sinks{console_sink, file_sink};
+            // std::vector<spdlog::sink_ptr> sinks{console_sink, file_sink};
+            std::vector<spdlog::sink_ptr> sinks{console_sink};
             auto async_logger = std::make_shared<spdlog::async_logger>(
               "FFSLogger",
               sinks.begin(),

--- a/include/ffs_logger.hpp
+++ b/include/ffs_logger.hpp
@@ -84,6 +84,14 @@ class FFSLogger {
               spdlog::async_overflow_policy::block  // Block if queue is full
             );
 
+            // Get logging level from environment variable (if set)
+            const char* logLevelEnv = std::getenv("LOG_LEVEL");
+            if (logLevelEnv) {
+                async_logger->set_level(spdlog::level::from_str(logLevelEnv));
+            } else {
+                async_logger->set_level(spdlog::level::info);  // Default log level
+            }
+
             // Set default log level and pattern
             async_logger->set_level(spdlog::level::info);
 

--- a/include/ffs_logger.hpp
+++ b/include/ffs_logger.hpp
@@ -1,0 +1,100 @@
+#ifndef FFS_LOGGER_HPP
+#define FFS_LOGGER_HPP
+
+#include <spdlog/async.h>
+#include <spdlog/sinks/rotating_file_sink.h>
+#include <spdlog/sinks/stdout_color_sinks.h>
+#include <spdlog/spdlog.h>
+
+#include <memory>
+
+/**
+ * @brief Thread-safe singleton logger class.
+ * 
+ * This class provides a single point of access to the logger instance
+ * throughout the application, ensuring that all log messages are
+ * written to the same log file and console sink while utilizing
+ * asynchronous logging for multi-threaded logging.
+ */
+class FFSLogger {
+  public:
+    // Get the singleton instance of the logger (thread-safe and lazy initialization)
+    /**
+     * @brief Retrieves the singleton instance of the logger.
+     * 
+     * This method uses lazy initialization to initialize the logger on
+     * the first call and returns the same instance on subsequent calls,
+     * ensuring a single point of access throughout the application.
+     *
+     * @return std::shared_ptr<spdlog::logger>& A shared pointer to the logger instance.
+     */
+    static std::shared_ptr<spdlog::logger>& getInstance() {
+        static std::shared_ptr<spdlog::logger> instance = createLogger();
+        return instance;
+    }
+
+    /**
+     * @brief Sets the logging level dynamically at runtime.
+     * 
+     * Allows modifying the logging level globally to control verbosity.
+     *
+     * @param level The desired logging level (e.g., spdlog::level::info, spdlog::level::debug).
+     */
+    static void setLevel(spdlog::level::level_enum level) {
+        getInstance()->set_level(level);
+    }
+
+  private:
+    // Private constructor to prevent instantiation
+    FFSLogger() = default;
+
+    /**
+     * @brief Creates and configures the logger instance.
+     * 
+     * Initializes the logger with a rotating file sink and a colored console sink,
+     * enabling asynchronous logging.
+     *
+     * @return std::shared_ptr<spdlog::logger> The configured logger instance.
+     */
+    static std::shared_ptr<spdlog::logger> createLogger() {
+        try {
+            // Queue size for async messages
+            size_t queue_size = 8192;  // Can adjust based on app requirements
+
+            // Initialize spdlog asynchronous mode with a background worker thread
+            spdlog::init_thread_pool(queue_size, 1);
+
+            // Create a rotating file sink (max 5MB per file, 3 rotated files)
+            auto file_sink = std::make_shared<spdlog::sinks::rotating_file_sink_mt>(
+              "logs/ffs_log.txt", 5 * 1024 * 1024, 3);
+
+            // Create a colored console sink
+            auto console_sink = std::make_shared<spdlog::sinks::stdout_color_sink_mt>();
+            console_sink->set_pattern("[%^%l%$] %v");
+
+            // Combine sinks into one asynchronous logger
+            std::vector<spdlog::sink_ptr> sinks{console_sink, file_sink};
+            auto async_logger = std::make_shared<spdlog::async_logger>(
+              "FFSLogger",
+              sinks.begin(),
+              sinks.end(),
+              spdlog::thread_pool(),
+              spdlog::async_overflow_policy::block  // Block if queue is full
+            );
+
+            // Set default log level and pattern
+            async_logger->set_level(spdlog::level::info);
+            async_logger->set_pattern("[%Y-%m-%d %H:%M:%S] [%^%l%$] %v");
+
+            // Register the logger globally
+            spdlog::register_logger(async_logger);
+
+            return async_logger;
+        } catch (const spdlog::spdlog_ex& ex) {
+            throw std::runtime_error(std::string("Logger initialization failed: ")
+                                     + ex.what());
+        }
+    }
+};
+
+#endif  // FFS_LOGGER_HPP

--- a/include/ffs_logger.hpp
+++ b/include/ffs_logger.hpp
@@ -104,7 +104,4 @@ class FFSLogger {
     }
 };
 
-// Global static access to the logger
-static auto& logger = FFSLogger::getInstance();
-
 #endif  // FFS_LOGGER_HPP

--- a/spotfinder/CMakeLists.txt
+++ b/spotfinder/CMakeLists.txt
@@ -5,7 +5,7 @@ find_package(Bitshuffle REQUIRED)
 find_package(CUDAToolkit REQUIRED)
 find_package(Boost REQUIRED COMPONENTS graph)
 find_package(lodepng)
-find_package(spdlog)
+find_package(spdlog REQUIRED)
 
 add_executable(spotfinder
     spotfinder.cc
@@ -29,6 +29,7 @@ target_link_libraries(spotfinder
     Boost::graph
     lodepng
     nlohmann_json::nlohmann_json
+    spdlog::spdlog
     version
 )
 

--- a/spotfinder/CMakeLists.txt
+++ b/spotfinder/CMakeLists.txt
@@ -5,7 +5,6 @@ find_package(Bitshuffle REQUIRED)
 find_package(CUDAToolkit REQUIRED)
 find_package(Boost REQUIRED COMPONENTS graph)
 find_package(lodepng)
-find_package(spdlog REQUIRED)
 
 add_executable(spotfinder
     spotfinder.cc

--- a/spotfinder/spotfinder.cc
+++ b/spotfinder/spotfinder.cc
@@ -267,7 +267,6 @@ class PipeHandler {
 };
 
 int main(int argc, char **argv) {
-    auto logger = FFSLogger::getInstance();
     logger->info("Spotfinder version: {}", FFS_VERSION);
 
 #pragma region Argument Parsing

--- a/spotfinder/spotfinder.cc
+++ b/spotfinder/spotfinder.cc
@@ -27,6 +27,7 @@
 #include "cbfread.hpp"
 #include "common.hpp"
 #include "cuda_common.hpp"
+#include "ffs_logger.hpp"
 #include "h5read.h"
 #include "kernels/masking.cuh"
 #include "shmread.hpp"
@@ -266,6 +267,9 @@ class PipeHandler {
 };
 
 int main(int argc, char **argv) {
+    auto logger = FFSLogger::getInstance();
+    logger->info("Spotfinder version: {}", FFS_VERSION);
+
 #pragma region Argument Parsing
     // Parse arguments and get our H5Reader
     auto parser = CUDAArgumentParser(FFS_VERSION);


### PR DESCRIPTION
This PR adds a centralised logging mechanism to `Spotfinder` utilising 
the `spdlog` library to ensure asynchronous, thread-safe and customised
logging across the application.

- Introduced `FFSLogger` as a singleton to provide a single — global —
  point of access to logging.
- Configured an asynchronous logging system with a coloured console sink
  for visibility.
- Enabled dynamic log level configuration via the `LOG_LEVEL` 
  environment variable.
- Improved logging patterns to include timestamps and thread 
  information.
- Integrated spdlog as a required dependency and linked it to 
  `spotfinder`.