### PR TITLE
Explicitly using fmt:: instead of namespace fmt

### DIFF
--- a/spotfinder/cbfread.cc
+++ b/spotfinder/cbfread.cc
@@ -20,7 +20,7 @@ auto expand_template(const std::string &template_path, size_t index) -> std::str
     std::string suffix = template_path.substr(template_path.rfind("#") + 1);
     int template_length = template_path.length() - prefix.length() - suffix.length();
 
-    return format("{}{:0{}d}{}", prefix, index, template_length, suffix);
+    return fmt::format("{}{:0{}d}{}", prefix, index, template_length, suffix);
 }
 
 // template <>

--- a/spotfinder/cbfread.cc
+++ b/spotfinder/cbfread.cc
@@ -10,7 +10,6 @@
 
 #include "bitshuffle.h"
 #include "common.hpp"
-using namespace fmt;
 
 // const std::string BINARY_MARKER = "--CIF-BINARY-FORMAT-SECTION--";
 const std::string BINARY_MARKER = "\x0c\x1a\x04\xd5";
@@ -38,7 +37,7 @@ auto get_value_contents(const std::string &input) -> std::string {
 CBFRead::CBFRead(const std::string &templatestr, size_t num_images, size_t first_index)
     : _num_images(num_images), _first_index(first_index), _template_path(templatestr) {
     if (first_index > 1) {
-        print("Error: Can only handle CBF start index of 0 or 1\n");
+        fmt::print("Error: Can only handle CBF start index of 0 or 1\n");
         std::exit(1);
     }
     // We must have our first file, as we read this for mask and metadata
@@ -66,9 +65,9 @@ CBFRead::CBFRead(const std::string &templatestr, size_t num_images, size_t first
     auto compressed_data_buffer = std::make_unique<uint8_t[]>(num_pixels * 4);
     get_raw_chunk(0, {compressed_data_buffer.get(), num_pixels * 4});
     for (int i = 0; i < 32; ++i) {
-        print("{:02x} ", compressed_data_buffer[i]);
+        fmt::print("{:02x} ", compressed_data_buffer[i]);
     }
-    print("\n");
+    fmt::print("\n");
     // auto compressed_data =
     //   get_raw_chunk(0, {compressed_data_buffer.get(), 4 * num_pixels});
     auto image_data = std::make_unique<int16_t[]>(num_pixels);

--- a/spotfinder/connected_components/connected_components.cc
+++ b/spotfinder/connected_components/connected_components.cc
@@ -324,7 +324,7 @@ std::vector<Reflection3D> ConnectedComponents::find_3d_components(
      */
     uint initial_spot_count = reflections_3d.size();
     logger->info(
-      fmt::format("Calculated {} spots", styled(initial_spot_count, fmt_cyan)));
+      fmt::format("Calculated {} spots", fmt::styled(initial_spot_count, fmt_cyan)));
 
     if (min_spot_size > 0) {
         logger->debug("Filtering reflections by minimum spot size");
@@ -339,8 +339,8 @@ std::vector<Reflection3D> ConnectedComponents::find_3d_components(
 
     logger->info(
       fmt::format("Filtered {} spots with size < {} pixels",
-                  styled(initial_spot_count - reflections_3d.size(), fmt_cyan),
-                  styled(min_spot_size, fmt_cyan)));
+                  fmt::styled(initial_spot_count - reflections_3d.size(), fmt_cyan),
+                  fmt::styled(min_spot_size, fmt_cyan)));
     uint filtered_spot_count = reflections_3d.size();
 
     if (max_peak_centroid_separation > 0) {
@@ -357,8 +357,8 @@ std::vector<Reflection3D> ConnectedComponents::find_3d_components(
 
     logger->info(
       fmt::format("Filtered {} spots with peak-centroid distance > {}",
-                  styled(filtered_spot_count - reflections_3d.size(), fmt_cyan),
-                  styled(max_peak_centroid_separation, fmt_cyan)));
+                  fmt::styled(filtered_spot_count - reflections_3d.size(), fmt_cyan),
+                  fmt::styled(max_peak_centroid_separation, fmt_cyan)));
 
     return reflections_3d;
 }

--- a/spotfinder/shmread.cc
+++ b/spotfinder/shmread.cc
@@ -11,7 +11,6 @@
 #include "cuda_common.hpp"
 
 using json = nlohmann::json;
-using namespace fmt;
 
 SHMRead::SHMRead(const std::string &path) : _base_path(path) {
     // Read the header

--- a/spotfinder/shmread.cc
+++ b/spotfinder/shmread.cc
@@ -29,7 +29,7 @@ SHMRead::SHMRead(const std::string &path) : _base_path(path) {
     uint8_t bit_depth_image = data["bit_depth_image"].template get<uint8_t>();
 
     if (bit_depth_image != 16) {
-        throw std::runtime_error(format(
+        throw std::runtime_error(fmt::format(
           "Can not read image with bit_depth_image={}, only 16", bit_depth_image));
     }
     _trusted_range = {
@@ -57,7 +57,7 @@ SHMRead::SHMRead(const std::string &path) : _base_path(path) {
     // Read the mask
     std::vector<int32_t> raw_mask;
     raw_mask.resize(_image_shape[0] * _image_shape[1]);
-    auto mask_filename = format("{}/start_5", _base_path);
+    auto mask_filename = fmt::format("{}/start_5", _base_path);
     if (std::filesystem::file_size(mask_filename)
         != raw_mask.size() * sizeof(decltype(raw_mask)::value_type)) {
         throw std::runtime_error("Error: Mask file does not match expected size");
@@ -74,12 +74,12 @@ SHMRead::SHMRead(const std::string &path) : _base_path(path) {
 }
 
 bool SHMRead::is_image_available(size_t index) {
-    return std::filesystem::exists(format("{}/image_{:06d}_2", _base_path, index));
+    return std::filesystem::exists(fmt::format("{}/image_{:06d}_2", _base_path, index));
 }
 
 std::span<uint8_t> SHMRead::get_raw_chunk(size_t index,
                                           std::span<uint8_t> destination) {
-    std::ifstream f(format("{}/image_{:06d}_2", _base_path, index),
+    std::ifstream f(fmt::format("{}/image_{:06d}_2", _base_path, index),
                     std::ios::in | std::ios::binary);
     f.read(reinterpret_cast<char *>(destination.data()), destination.size());
     return {destination.data(), static_cast<size_t>(f.gcount())};
@@ -88,6 +88,6 @@ std::span<uint8_t> SHMRead::get_raw_chunk(size_t index,
 template <>
 bool is_ready_for_read<SHMRead>(const std::string &path) {
     // We need headers.1, and headers.5, to read the metadata
-    return std::filesystem::exists(format("{}/start_1", path))
-           && std::filesystem::exists(format("{}/start_4", path));
+    return std::filesystem::exists(fmt::format("{}/start_1", path))
+           && std::filesystem::exists(fmt::format("{}/start_4", path));
 }

--- a/spotfinder/spotfinder.cc
+++ b/spotfinder/spotfinder.cc
@@ -140,7 +140,7 @@ void wait_for_ready_for_read(const std::string &path,
     if (!checker(path)) {
         auto start_time = std::chrono::high_resolution_clock::now();
         auto message_prefix =
-          format("Waiting for \033[1;35m{}\033[0m to be ready for read", path);
+          fmt::format("Waiting for \033[1;35m{}\033[0m to be ready for read", path);
         std::vector<std::string> ball = {
           "( ●    )",
           "(  ●   )",
@@ -850,7 +850,7 @@ int main(int argc, char **argv) {
                             }
                         }
                     }
-                    lodepng::encode(format("image_{:05d}.png", image_num),
+                    lodepng::encode(fmt::format("image_{:05d}.png", image_num),
                                     reinterpret_cast<uint8_t *>(buffer.data()),
                                     width,
                                     height,

--- a/spotfinder/spotfinder.cc
+++ b/spotfinder/spotfinder.cc
@@ -33,7 +33,6 @@
 #include "standalone.h"
 #include "version.hpp"
 
-using namespace fmt;
 using namespace std::chrono_literals;
 using json = nlohmann::json;
 
@@ -46,7 +45,7 @@ extern "C" void stop_processing(int sig) {
         // We already requested before, but we want it faster. Abort.
         std::quick_exit(1);
     } else {
-        print("Running interrupted by user request\n");
+        fmt::print("Running interrupted by user request\n");
         global_stop.request_stop();
     }
 }
@@ -92,7 +91,7 @@ auto upload_mask(T &reader) -> PitchedMalloc<uint8_t> {
     end.synchronize();
 
     float memcpy_time = end.elapsed_time(start);
-    print("Uploaded mask ({:.2f} Mpx) in {:.2f} ms ({:.1f} GBps)\n",
+    fmt::print("Uploaded mask ({:.2f} Mpx) in {:.2f} ms ({:.1f} GBps)\n",
           static_cast<float>(valid_pixels) / 1e6,
           memcpy_time,
           GBps(memcpy_time, width * height));
@@ -158,17 +157,17 @@ void wait_for_ready_for_read(const std::string &path,
             auto wait_time = std::chrono::duration_cast<std::chrono::duration<double>>(
                                std::chrono::high_resolution_clock::now() - start_time)
                                .count();
-            print("\r{}  {} [{:4.1f} s] ", message_prefix, ball[i], wait_time);
+            fmt::print("\r{}  {} [{:4.1f} s] ", message_prefix, ball[i], wait_time);
             i = (i + 1) % ball.size();
             std::cout << std::flush;
 
             if (wait_time > timeout) {
-                print("\nError: Waited too long for read availability\n");
+                fmt::print("\nError: Waited too long for read availability\n");
                 std::exit(1);
             }
             std::this_thread::sleep_for(80ms);
         }
-        print("\n");
+        fmt::print("\n");
     }
 }
 
@@ -215,7 +214,7 @@ class PipeHandler {
      */
     PipeHandler(int pipe_fd) : pipe_fd(pipe_fd) {
         // Constructor to initialize the pipe handler
-        print("PipeHandler initialized with pipe_fd: {}\n", pipe_fd);
+        fmt::print("PipeHandler initialized with pipe_fd: {}\n", pipe_fd);
     }
 
     /**
@@ -247,7 +246,7 @@ class PipeHandler {
         if (bytes_written == -1) {
             std::cerr << "Error writing to pipe: " << strerror(errno) << std::endl;
         } else {
-            // print("Data sent through the pipe: {}\n", stringified_json);
+            // fmt::print("Data sent through the pipe: {}\n", stringified_json);
         }
     }
 };
@@ -331,11 +330,11 @@ int main(int argc, char **argv) {
     float dmax = parser.get<float>("dmax");
 
     DispersionAlgorithm dispersion_algorithm(parser.get<std::string>("algorithm"));
-    print("Algorithm: {}\n", styled(dispersion_algorithm.algorithm_str, fmt_green));
+    fmt::print("Algorithm: {}\n", styled(dispersion_algorithm.algorithm_str, fmt_green));
 
     uint32_t num_cpu_threads = parser.get<uint32_t>("threads");
     if (num_cpu_threads < 1) {
-        print("Error: Thread count must be >= 1\n");
+        fmt::print("Error: Thread count must be >= 1\n");
         std::exit(1);
     }
     uint32_t min_spot_size = parser.get<uint32_t>("min-spot-size");
@@ -356,7 +355,7 @@ int main(int argc, char **argv) {
         reader_ptr = std::make_unique<SHMRead>(args.file);
     } else if (args.file.ends_with(".cbf")) {
         if (!parser.is_used("images")) {
-            print("Error: CBF reading must specify --images\n");
+            fmt::print("Error: CBF reading must specify --images\n");
             std::exit(1);
         }
         reader_ptr = std::make_unique<CBFRead>(args.file,
@@ -394,7 +393,7 @@ int main(int argc, char **argv) {
                 && (!are_close(detector.beam_center_x, beam_center.value()[1], 0.1)
                     || !are_close(
                       detector.beam_center_y, beam_center.value()[0], 0.1))) {
-                print(
+                fmt::print(
                   "Warning: Beam center mismatched:\n    json:   {} px, {} px (used)\n "
                   "   "
                   "reader: "
@@ -408,7 +407,7 @@ int main(int argc, char **argv) {
                 && (!are_close(detector.pixel_size_x, pixel_size.value()[1], 1e-9)
                     || !are_close(
                       detector.pixel_size_y, pixel_size.value()[0], 1e-9))) {
-                print(
+                fmt::print(
                   "Warning: Pixel size mismatched:\n    json:   {} µm, {} µm (used)\n  "
                   "  "
                   "reader: "
@@ -419,7 +418,7 @@ int main(int argc, char **argv) {
                   pixel_size.value()[0] * 1e6);
             }
             if (distance && !are_close(distance.value(), detector.distance, 0.1e-6)) {
-                print(
+                fmt::print(
                   "Warning: Detector distance mismatched:\n    json:   {} m (used)\n   "
                   " "
                   "reader: "
@@ -434,19 +433,19 @@ int main(int argc, char **argv) {
         auto pixel_size = reader.get_pixel_size();
         auto distance = reader.get_detector_distance();
         if (!beam_center) {
-            print(
+            fmt::print(
               "Error: No beam center available from file. Please pass detector "
               "metadata with --distance.\n");
             std::exit(1);
         }
         if (!pixel_size) {
-            print(
+            fmt::print(
               "Error: No pixel size available from file. Please pass detector metadata "
               "with --distance.\n");
             std::exit(1);
         }
         if (!distance) {
-            print(
+            fmt::print(
               "Error: No detector distance available from file. Please pass metadata "
               "with --distance.\n");
             std::exit(1);
@@ -459,7 +458,7 @@ int main(int argc, char **argv) {
         wavelength = parser.get<float>("wavelength");
         if (do_validate && reader.get_wavelength()
             && reader.get_wavelength().value() != wavelength) {
-            print(
+            fmt::print(
               "Warning: Wavelength mismatch:\n    Argument: {} Å\n    Reader:   {} Å\n",
               wavelength,
               reader.get_wavelength().value());
@@ -467,7 +466,7 @@ int main(int argc, char **argv) {
     } else {
         auto wavelength_opt = reader.get_wavelength();
         if (!wavelength_opt) {
-            print(
+            fmt::print(
               "Error: No wavelength provided. Please pass wavelength using: "
               "--wavelength\n");
             std::exit(1);
@@ -475,7 +474,7 @@ int main(int argc, char **argv) {
         wavelength = wavelength_opt.value();
         printf("Got wavelength from file: %f Å\n", wavelength);
     }
-    print(
+    fmt::print(
       "Detector geometry:\n"
       "    Distance:    {0:.1f} mm\n"
       "    Beam Center: {1:.1f} px {2:.1f} px\n"
@@ -492,7 +491,7 @@ int main(int argc, char **argv) {
      * rotation dataset. Otherwise, it is a still dataset.
     */
     if (oscillation_width > 0) {
-        print("Oscillation:  Start: {:.2f}°  Width: {:.2f}°\n",
+        fmt::print("Oscillation:  Start: {:.2f}°  Width: {:.2f}°\n",
               styled(oscillation_start, fmt_cyan),
               styled(oscillation_width, fmt_cyan));
     }
@@ -508,17 +507,17 @@ int main(int argc, char **argv) {
       static_cast<unsigned int>(ceilf((float)height / gpu_thread_block_size.y))};
     const int num_threads_per_block = gpu_thread_block_size.x * gpu_thread_block_size.y;
     const int num_blocks = blocks_dims.x * blocks_dims.y * blocks_dims.z;
-    print("Image:       {:4d} x {:4d} = {} px\n", width, height, width * height);
-    print("GPU Threads: {:4d} x {:<4d} = {}\n",
+    fmt::print("Image:       {:4d} x {:4d} = {} px\n", width, height, width * height);
+    fmt::print("GPU Threads: {:4d} x {:<4d} = {}\n",
           gpu_thread_block_size.x,
           gpu_thread_block_size.y,
           num_threads_per_block);
-    print("Blocks:      {:4d} x {:<4d} x {:2d} = {}\n",
+    fmt::print("Blocks:      {:4d} x {:<4d} x {:2d} = {}\n",
           blocks_dims.x,
           blocks_dims.y,
           blocks_dims.z,
           num_blocks);
-    print("Running with {} CPU threads\n", num_cpu_threads);
+    fmt::print("Running with {} CPU threads\n", num_cpu_threads);
 
     auto mask = upload_mask(reader);
 
@@ -603,11 +602,11 @@ int main(int argc, char **argv) {
     std::mutex rotation_slices_mutex;  // Mutex to protect the rotation slices map
     if (oscillation_width > 0) {
         // If oscillation information is available then this is a rotation dataset
-        print("Dataset type: {}\n", styled("Rotation set", fmt_magenta));
+        fmt::print("Dataset type: {}\n", styled("Rotation set", fmt_magenta));
         rotation_slices = std::make_unique<
           std::unordered_map<int, std::unique_ptr<ConnectedComponents>>>();
     } else {
-        print("Dataset type: {}\n", styled("Still set", fmt_magenta));
+        fmt::print("Dataset type: {}\n", styled("Still set", fmt_magenta));
     }
 
     // Spawn the reader threads
@@ -665,7 +664,7 @@ int main(int argc, char **argv) {
                             .count();
 
                         if (elapsed_wait_time > wait_timeout) {
-                            print("Timeout waiting for image {}\n", offset_image_num);
+                            fmt::print("Timeout waiting for image {}\n", offset_image_num);
                             global_stop.request_stop();
                             break;
                         }
@@ -698,7 +697,7 @@ int main(int argc, char **argv) {
                     }
                     // /dev/shm we might not have an atomic write
                     if (buffer.size() == 0) {
-                        print(fmt::runtime(
+                        fmt::print(fmt::runtime(
                           "\033[1mRace Condition?!?? Got buffer size 0 for image "
                           "{image_num}. "
                           "Sleeping.\033[0m\n"));
@@ -907,14 +906,14 @@ int main(int argc, char **argv) {
                                                               &mismatch_x,
                                                               &mismatch_y);
                     if (validation_matches) {
-                        print(
+                        fmt::print(
                           "Thread {:2d}, Image {:4d}: Compared: \033[32mMatch {} "
                           "px\033[0m\n",
                           thread_id,
                           image_num,
                           num_strong_pixels);
                     } else {
-                        print(
+                        fmt::print(
                           "Thread {:2d}, Image {:4d}: Compared: "
                           "\033[1;31mMismatch ({} px from kernel)\033[0m\n",
                           thread_id,
@@ -924,7 +923,7 @@ int main(int argc, char **argv) {
 
                 } else {
                     if (num_cpu_threads == 1) {
-                        print(
+                        fmt::print(
                           "Thread {:2d} finished image {:4d}\n"
                           "       Copy: {:5.1f} ms\n"
                           "     Kernel: {:5.1f} ms\n"
@@ -946,7 +945,7 @@ int main(int argc, char **argv) {
                           bold(boxes.size()),
                           bold(num_strong_pixels_filtered));
                     } else {
-                        print(
+                        fmt::print(
                           "Thread {:2d} finished image {:4d} with {:5d} strong pixels, "
                           "{:4d} filtered reflections ({} pixels)\n",
                           thread_id,
@@ -1054,7 +1053,7 @@ int main(int argc, char **argv) {
       std::chrono::duration_cast<std::chrono::duration<double>>(
         std::chrono::high_resolution_clock::now() - all_images_start_time)
         .count();
-    print(
+    fmt::print(
       "\n{} images in {:.2f} s (\033[1;34m{:.2f} GBps\033[0m) (\033[1;34m{:.1f} "
       "fps\033[0m)\n",
       int(completed_images),
@@ -1066,10 +1065,10 @@ int main(int argc, char **argv) {
       width,
       height);
     if (time_waiting_for_images < 10) {
-        print("Total time waiting for images to appear: {:.0f} ms\n",
+        fmt::print("Total time waiting for images to appear: {:.0f} ms\n",
               time_waiting_for_images * 1000);
     } else {
-        print("Total time waiting for images to appear: {:.2f} s\n",
+        fmt::print("Total time waiting for images to appear: {:.2f} s\n",
               time_waiting_for_images);
     }
 }

--- a/spotfinder/spotfinder.cc
+++ b/spotfinder/spotfinder.cc
@@ -331,7 +331,7 @@ int main(int argc, char **argv) {
 
     DispersionAlgorithm dispersion_algorithm(parser.get<std::string>("algorithm"));
     fmt::print("Algorithm: {}\n",
-               styled(dispersion_algorithm.algorithm_str, fmt_green));
+               fmt::styled(dispersion_algorithm.algorithm_str, fmt_green));
 
     uint32_t num_cpu_threads = parser.get<uint32_t>("threads");
     if (num_cpu_threads < 1) {
@@ -480,10 +480,10 @@ int main(int argc, char **argv) {
       "    Distance:    {0:.1f} mm\n"
       "    Beam Center: {1:.1f} px {2:.1f} px\n"
       "Beam Wavelength: {3:.2f} Å\n",
-      styled(detector.distance * 1000, fmt_cyan),
-      styled(detector.beam_center_x, fmt_cyan),
-      styled(detector.beam_center_y, fmt_cyan),
-      styled(wavelength, fmt_cyan));
+      fmt::styled(detector.distance * 1000, fmt_cyan),
+      fmt::styled(detector.beam_center_x, fmt_cyan),
+      fmt::styled(detector.beam_center_y, fmt_cyan),
+      fmt::styled(wavelength, fmt_cyan));
 
     auto [oscillation_start, oscillation_width] = reader.get_oscillation();
 
@@ -493,8 +493,8 @@ int main(int argc, char **argv) {
     */
     if (oscillation_width > 0) {
         fmt::print("Oscillation:  Start: {:.2f}°  Width: {:.2f}°\n",
-                   styled(oscillation_start, fmt_cyan),
-                   styled(oscillation_width, fmt_cyan));
+                   fmt::styled(oscillation_start, fmt_cyan),
+                   fmt::styled(oscillation_width, fmt_cyan));
     }
 
 #pragma endregion Argument Parsing
@@ -603,11 +603,11 @@ int main(int argc, char **argv) {
     std::mutex rotation_slices_mutex;  // Mutex to protect the rotation slices map
     if (oscillation_width > 0) {
         // If oscillation information is available then this is a rotation dataset
-        fmt::print("Dataset type: {}\n", styled("Rotation set", fmt_magenta));
+        fmt::print("Dataset type: {}\n", fmt::styled("Rotation set", fmt_magenta));
         rotation_slices = std::make_unique<
           std::unordered_map<int, std::unique_ptr<ConnectedComponents>>>();
     } else {
-        fmt::print("Dataset type: {}\n", styled("Still set", fmt_magenta));
+        fmt::print("Dataset type: {}\n", fmt::styled("Still set", fmt_magenta));
     }
 
     // Spawn the reader threads
@@ -986,7 +986,7 @@ int main(int argc, char **argv) {
 
         // Step 3: Output the 3D reflections
         logger->info(
-          fmt::format("Found {} spots", styled(reflections_3d.size(), fmt_cyan)));
+          fmt::format("Found {} spots", fmt::styled(reflections_3d.size(), fmt_cyan)));
 
         if (do_writeout) {
             std::ofstream out("3d_reflections.txt");

--- a/spotfinder/spotfinder.cc
+++ b/spotfinder/spotfinder.cc
@@ -92,9 +92,9 @@ auto upload_mask(T &reader) -> PitchedMalloc<uint8_t> {
 
     float memcpy_time = end.elapsed_time(start);
     fmt::print("Uploaded mask ({:.2f} Mpx) in {:.2f} ms ({:.1f} GBps)\n",
-          static_cast<float>(valid_pixels) / 1e6,
-          memcpy_time,
-          GBps(memcpy_time, width * height));
+               static_cast<float>(valid_pixels) / 1e6,
+               memcpy_time,
+               GBps(memcpy_time, width * height));
 
     return PitchedMalloc{
       dev_mask,
@@ -330,7 +330,8 @@ int main(int argc, char **argv) {
     float dmax = parser.get<float>("dmax");
 
     DispersionAlgorithm dispersion_algorithm(parser.get<std::string>("algorithm"));
-    fmt::print("Algorithm: {}\n", styled(dispersion_algorithm.algorithm_str, fmt_green));
+    fmt::print("Algorithm: {}\n",
+               styled(dispersion_algorithm.algorithm_str, fmt_green));
 
     uint32_t num_cpu_threads = parser.get<uint32_t>("threads");
     if (num_cpu_threads < 1) {
@@ -492,8 +493,8 @@ int main(int argc, char **argv) {
     */
     if (oscillation_width > 0) {
         fmt::print("Oscillation:  Start: {:.2f}°  Width: {:.2f}°\n",
-              styled(oscillation_start, fmt_cyan),
-              styled(oscillation_width, fmt_cyan));
+                   styled(oscillation_start, fmt_cyan),
+                   styled(oscillation_width, fmt_cyan));
     }
 
 #pragma endregion Argument Parsing
@@ -509,14 +510,14 @@ int main(int argc, char **argv) {
     const int num_blocks = blocks_dims.x * blocks_dims.y * blocks_dims.z;
     fmt::print("Image:       {:4d} x {:4d} = {} px\n", width, height, width * height);
     fmt::print("GPU Threads: {:4d} x {:<4d} = {}\n",
-          gpu_thread_block_size.x,
-          gpu_thread_block_size.y,
-          num_threads_per_block);
+               gpu_thread_block_size.x,
+               gpu_thread_block_size.y,
+               num_threads_per_block);
     fmt::print("Blocks:      {:4d} x {:<4d} x {:2d} = {}\n",
-          blocks_dims.x,
-          blocks_dims.y,
-          blocks_dims.z,
-          num_blocks);
+               blocks_dims.x,
+               blocks_dims.y,
+               blocks_dims.z,
+               num_blocks);
     fmt::print("Running with {} CPU threads\n", num_cpu_threads);
 
     auto mask = upload_mask(reader);
@@ -664,7 +665,8 @@ int main(int argc, char **argv) {
                             .count();
 
                         if (elapsed_wait_time > wait_timeout) {
-                            fmt::print("Timeout waiting for image {}\n", offset_image_num);
+                            fmt::print("Timeout waiting for image {}\n",
+                                       offset_image_num);
                             global_stop.request_stop();
                             break;
                         }
@@ -1066,9 +1068,9 @@ int main(int argc, char **argv) {
       height);
     if (time_waiting_for_images < 10) {
         fmt::print("Total time waiting for images to appear: {:.0f} ms\n",
-              time_waiting_for_images * 1000);
+                   time_waiting_for_images * 1000);
     } else {
         fmt::print("Total time waiting for images to appear: {:.2f} s\n",
-              time_waiting_for_images);
+                   time_waiting_for_images);
     }
 }


### PR DESCRIPTION
CMake builds were failing when trying to do a fresh install (possibly because of a newer compiler), so I changed all instances of `format()` to `fmt::format()` -- this fixed the associated build errors.