### PR TITLE
Update README to include gemmi

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,11 @@ In order to create a development environment and compile the service, you need t
 - cmake
 - hdf5
 - hdf5-external-filter-plugins
+- gemmi
 
 For example, you can create a conda/mamba environment with the following command:
 ```bash
-mamba create -c conda-forge -p ENV boost-cpp benchmark gtest cmake hdf5 hdf5-external-filter-plugins compilers bitshuffle spdlog
+mamba create -c conda-forge -p ENV boost-cpp benchmark gtest cmake hdf5 hdf5-external-filter-plugins compilers bitshuffle spdlog gemmi
 ```
 
 ### Initialising submodules


### PR DESCRIPTION
This PR updates the `README.md` file to include `gemmi` among dependencies when instructing how to configure the mamba environment. Additionally, `dx2` installation instructions are provided in `README.md` and `CMakeLists.txt` is modified to not use `dx2` as a git submodule.