### PR TITLE
Enable masking in erosion kernel based on DIALS investigation (fixes #14)

### DIFF
--- a/spotfinder/kernels/erosion.cuh
+++ b/spotfinder/kernels/erosion.cuh
@@ -2,7 +2,8 @@
 
 __global__ void erosion(uint8_t __restrict__ *dispersion_mask_ptr,
                         uint8_t __restrict__ *erosion_mask_ptr,
-                        // uint8_t __restrict__ *mask_ptr,
+                        uint8_t __restrict__ *mask_ptr,
                         size_t dispersion_mask_pitch,
                         size_t erosion_mask_pitch,
+                        size_t mask_pitch,
                         uint8_t radius);

--- a/spotfinder/spotfinder.cu
+++ b/spotfinder/spotfinder.cu
@@ -290,9 +290,10 @@ void call_do_spotfinding_extended(dim3 blocks,
     // Perform erosion
     erosion<<<blocks, threads, shared_memory, stream>>>(d_dispersion_mask.get(),
                                                         d_erosion_mask.get(),
-                                                        // mask.get(),
+                                                        mask.get(),
                                                         d_dispersion_mask.pitch,
                                                         d_erosion_mask.pitch,
+                                                        mask.pitch,
                                                         KERNEL_RADIUS);
 
     // Calculate the shared memory required for the second pass

--- a/tests/dispersion_extended.sh
+++ b/tests/dispersion_extended.sh
@@ -44,7 +44,7 @@ exec 3>&-
 output=$(cat output_file.txt)
 
 # Define the expected output
-expected_output='{"file":"/dls/i03/data/2024/cm37235-2/TestInsulin/ins_14/ins_14_49_45_master.h5","file-number":0,"n_spots_total":102,"num_strong_pixels":729}'
+expected_output='{"file":"/dls/i03/data/2024/cm37235-2/TestInsulin/ins_14/ins_14_49_45_master.h5","file-number":0,"n_spots_total":102,"num_strong_pixels":737}'
 
 # Compare the output with the expected output
 if [ "$output" == "$expected_output" ]; then


### PR DESCRIPTION
This PR enables masking within the erosion CUDA kernel, ensuring that
masked pixels are properly excluded during spotfinding.

- Re-enabled the `mask_ptr` and associated logic in the `erosion`
  kernel.
- Passed the required `mask_pitch` for pitched memory access.
- Updated the kernel call in `spotfinder.cu` accordingly.
- Adjusted test expectations due to the now-active masking behaviour.

Following an investigation in the DIALS repository ([dials/dials#2785](https://github.com/dials/dials/issues/2785)) and
the resolution implemented in [dials/dials#2790](https://github.com/dials/dials/pull/2790), it was confirmed that
masking should be applied during erosion. This prevents masked pixels —
such as panel edges or dead pixels — from eroding actual data as if
they were background, instead of being ignored. This change corrects
that behavior.

Closes [#14](https://github.com/DiamondLightSource/fast-feedback-service/issues/14)