### PR TITLE
Update spotfinder to use ReflectionTable from dx2

### DIFF
--- a/spotfinder/spotfinder.cc
+++ b/spotfinder/spotfinder.cc
@@ -319,12 +319,18 @@ int main(int argc, char **argv) {
       .metavar("λ")
       .scan<'f', float>();
     parser.add_argument("--detector").help("Detector geometry JSON").metavar("JSON");
+    parser.add_argument("-h5", "--save-h5")
+      .help("Save the output to an HDF5 file")
+      .metavar("FILE")
+      .default_value(false)
+      .implicit_value(true);
 
     auto args = parser.parse_args(argc, argv);
     bool do_validate = parser.get<bool>("validate");
     bool do_writeout = parser.get<bool>("writeout");
     int pipe_fd = parser.get<int>("pipe_fd");
     float wait_timeout = parser.get<float>("timeout");
+    bool save_to_h5 = parser.get<bool>("save-h5");
 
     float dmin = parser.get<float>("dmin");
     float dmax = parser.get<float>("dmax");

--- a/tests/3d_connected_components.sh
+++ b/tests/3d_connected_components.sh
@@ -30,6 +30,7 @@ exec 3> output_file.txt
   --algorithm "dispersion" \
   --threads 1 \
   --images 5 \
+  --save-h5 \
   --writeout
 
 # Close file descriptor 3


### PR DESCRIPTION
Replace manual HDF5 writing with ReflectionTable interface

We have been relying on manual formatting and writing to export
reflections to HDF5, which was serviceable but limited. With the recent
addition of the `ReflectionTable` API in dx2, we can now move to a
cleaner, more maintainable approach.

This refactor updates spotfinder to use ReflectionTable for writing
output, and adds a `--save-h5` flag to toggle this behaviour. Each
dataset is tagged with a UUID-style identifier, generated on the fly.

See: https://github.com/dials/dx2/pull/10

- Update submodule `dx2` to latest commit
- Add `ersatz_uuid4` to generate UUID-style tags
- Switch to `ReflectionTable` for reflection export
- Add `--save-h5` CLI flag to control output
- Extend test script to cover new functionality