### PR TITLE
Add option to compile with 32-bit pixel data support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,9 @@ project(fast-feedback-service LANGUAGES CXX VERSION ${FFS_VERSION_CMAKE})
 set(CMAKE_EXPORT_COMPILE_COMMANDS yes)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
+# Option to use 32-bit pixel data instead of 16-bit
+option(PIXEL_DATA_32BIT "Use 32-bit pixel data instead of 16-bit" OFF)
+
 include(SetDefaultBuildRelWithDebInfo)
 include(AlwaysColourCompilation)
 
@@ -66,6 +69,17 @@ project(version CXX)
 configure_file(version.cc.in version.cc @ONLY)
 add_library(version STATIC version.cc)
 
+# Create a header-only interface library for compile definitions
+add_library(compile_options INTERFACE)
+
+# Add compile definitions if enabled
+if(PIXEL_DATA_32BIT)
+    target_compile_definitions(compile_options INTERFACE PIXEL_DATA_32BIT)
+    message(STATUS "Building with 32-bit pixel data support")
+else()
+    message(STATUS "Building with 16-bit pixel data support")
+endif()
+
 # Make a library for a global logger
 add_library(ffs_common STATIC 
     ffs_logger.cc
@@ -73,7 +87,8 @@ add_library(ffs_common STATIC
 target_include_directories(ffs_common PUBLIC
     ${CMAKE_SOURCE_DIR}/include
 )
-target_link_libraries(ffs_common
+target_link_libraries(ffs_common PUBLIC
+    compile_options
     spdlog
     fmt
 )

--- a/README.md
+++ b/README.md
@@ -39,6 +39,25 @@ make                        # Compile the code
 ```
 This will create the executable `spotfinder` in the [`build/bin/`] directory.
 
+### Configuring pixel data precision
+By default, the service is compiled to handle 16-bit pixel data. For detectors that produce 32-bit pixel data, you can enable 32-bit support using the `PIXEL_DATA_32BIT` option.
+
+**Using ccmake (recommended):**
+```bash
+cd build
+ccmake ..                   # Opens an interactive configuration interface
+# Navigate to PIXEL_DATA_32BIT and toggle it to ON
+# Press 'c' to configure, then 'g' to generate
+make                        # Compile with the new settings
+```
+
+**Using cmake command line:**
+```bash
+cd build
+cmake -DPIXEL_DATA_32BIT=ON ..  # Enable 32-bit pixel data support
+make                            # Compile with the new settings
+```
+
 ## Usage
 ### Environment Variables
 The service uses the following environment variables:

--- a/h5read/CMakeLists.txt
+++ b/h5read/CMakeLists.txt
@@ -14,7 +14,7 @@ find_package(HDF5)
 
 add_library(h5read src/h5read.c src/h5read.cc)
 target_include_directories(h5read PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include )
-target_link_libraries(h5read PUBLIC $<TARGET_NAME_IF_EXISTS:hdf5::hdf5>)
+target_link_libraries(h5read PUBLIC $<TARGET_NAME_IF_EXISTS:hdf5::hdf5> $<TARGET_NAME_IF_EXISTS:compile_options>)
 
 if (TARGET hdf5::hdf5)
   add_compile_definitions(HAVE_HDF5)

--- a/h5read/include/h5read.h
+++ b/h5read/include/h5read.h
@@ -13,10 +13,14 @@ extern "C" {
 typedef struct _h5read_handle h5read_handle;
 
 // Define a data type alias so that other users don't have to hardcode
+#ifdef PIXEL_DATA_32BIT
+typedef uint32_t image_t_type;
+#else
 typedef uint16_t image_t_type;
+#endif
 
 typedef struct image_t {
-    uint16_t *data;
+    image_t_type *data;
     uint8_t *mask;
     size_t slow;
     size_t fast;
@@ -24,7 +28,8 @@ typedef struct image_t {
 
 /* data as modules i.e. 3D array */
 typedef struct image_modules_t {
-    uint16_t *data;  ///< Module image data in a 3D array block of [module][slow][fast]
+    image_t_type
+      *data;         ///< Module image data in a 3D array block of [module][slow][fast]
     uint8_t *mask;   ///< Image mask, in the same shape as the module data
     size_t modules;  ///< Total number of modules
     size_t slow;     ///< Number of pixels in slow direction per module
@@ -186,11 +191,11 @@ class H5Read : public Reader {
     H5Read(int argc, char **argv) noexcept;
 
     /// Read image data into an existing buffer
-    void get_image_into(size_t index, uint16_t *data) {
+    void get_image_into(size_t index, image_t_type *data) {
         h5read_get_image_into(_handle.get(), index, data);
     }
     /// Read image data into an existing buffer
-    void get_image_into(size_t index, std::span<uint16_t> data) {
+    void get_image_into(size_t index, std::span<image_t_type> data) {
 #ifndef NDEBUG
         assert(data.size() >= get_image_slow() * get_image_fast());
 #endif

--- a/h5read/src/h5read.c
+++ b/h5read/src/h5read.c
@@ -54,6 +54,30 @@ struct _h5read_handle {
     float oscillation_width;
 };
 
+/// Validate that the HDF5 datatype size matches the expected pixel data size
+///
+/// @param datatype The HDF5 datatype to validate
+static void _validate_data_type_size(hid_t datatype) {
+    size_t datasize = H5Tget_size(datatype);
+#ifdef PIXEL_DATA_32BIT
+    if (datasize != 4) {
+        fprintf(stderr,
+                "Error: Expected 32-bit data but got %zu bytes. Use "
+                "-DPIXEL_DATA_32BIT=OFF for 16-bit data.\n",
+                datasize);
+        exit(1);
+    }
+#else
+    if (datasize != 2) {
+        fprintf(stderr,
+                "Error: Expected 16-bit data but got %zu bytes. Use "
+                "-DPIXEL_DATA_32BIT=ON for 32-bit data.\n",
+                datasize);
+        exit(1);
+    }
+#endif
+}
+
 void h5read_free(h5read_handle *obj) {
 #ifdef HAVE_HDF5
     for (int i = 0; i < obj->data_file_count; i++) {
@@ -114,7 +138,8 @@ void _blit(image_t *image, image_modules_t *modules) {
 
     size_t module_pixels = E2XE_MOD_SLOW * E2XE_MOD_FAST;
 
-    modules->data = (uint16_t *)malloc(sizeof(uint16_t) * slow * fast * module_pixels);
+    modules->data =
+      (image_t_type *)malloc(sizeof(image_t_type) * slow * fast * module_pixels);
 
     for (size_t _slow = 0; _slow < slow; _slow++) {
         size_t row0 = _slow * (E2XE_MOD_SLOW + E2XE_GAP_SLOW) * image->fast;
@@ -126,7 +151,7 @@ void _blit(image_t *image, image_modules_t *modules) {
                   (_slow * fast + _fast) * module_pixels + row * E2XE_MOD_FAST;
                 memcpy((void *)&modules->data[target],
                        (void *)&image->data[offset],
-                       sizeof(uint16_t) * E2XE_MOD_FAST);
+                       sizeof(image_t_type) * E2XE_MOD_FAST);
             }
         }
     }
@@ -174,10 +199,10 @@ void _generate_sample_image(h5read_handle *obj, size_t n, image_t_type *data) {
     assert(n >= 0 && n <= NUM_SAMPLE_IMAGES);
 
     if (n == 0) {
-        memset(data, 0, E2XE_16M_FAST * E2XE_16M_SLOW * sizeof(uint16_t));
+        memset(data, 0, E2XE_16M_FAST * E2XE_16M_SLOW * sizeof(image_t_type));
     } else if (n == 1) {
         // Image 1: I=1 for every unmasked pixel
-        memset(data, 0, E2XE_16M_FAST * E2XE_16M_SLOW * sizeof(uint16_t));
+        memset(data, 0, E2XE_16M_FAST * E2XE_16M_SLOW * sizeof(image_t_type));
         for (int mody = 0; mody < E2XE_16M_NSLOW; ++mody) {
             // row0 is the row of the module top row
             size_t row0 = mody * (E2XE_MOD_SLOW + E2XE_GAP_SLOW);
@@ -193,7 +218,7 @@ void _generate_sample_image(h5read_handle *obj, size_t n, image_t_type *data) {
         }
     } else if (n == 2) {
         // Image 2: High pixel (100) every 42 pixels across the detector
-        memset(data, 0, E2XE_16M_FAST * E2XE_16M_SLOW * sizeof(uint16_t));
+        memset(data, 0, E2XE_16M_FAST * E2XE_16M_SLOW * sizeof(image_t_type));
         for (int y = 0; y < E2XE_16M_SLOW; y += 42) {
             for (int x = 0; x < E2XE_16M_FAST; x += 42) {
                 int k = y * E2XE_16M_FAST + x;
@@ -221,7 +246,7 @@ void _generate_sample_image(h5read_handle *obj, size_t n, image_t_type *data) {
         // Image 3: "Random" background, zero on masks
 
         pcg32_random_t state = {0};
-        memset(data, 0, E2XE_16M_FAST * E2XE_16M_SLOW * sizeof(uint16_t));
+        memset(data, 0, E2XE_16M_FAST * E2XE_16M_SLOW * sizeof(image_t_type));
         for (int mody = 0; mody < E2XE_16M_NSLOW; ++mody) {
             // row0 is the row of the module top row
             size_t row0 = mody * (E2XE_MOD_SLOW + E2XE_GAP_SLOW);
@@ -312,11 +337,7 @@ void h5read_get_raw_chunk(h5read_handle *obj,
     }
 
     hid_t datatype = H5Dget_type(current->dataset);
-    hsize_t datasize = H5Tget_size(datatype);
-    if (datasize != 2) {
-        fprintf(stderr, "Error: Unexpected datasize\n");
-        // exit(1);
-    }
+    _validate_data_type_size(datatype);
 
     uint32_t filter = 0;
     herr_t err = H5Dread_chunk(current->dataset, H5P_DEFAULT, offset, &filter, data);
@@ -584,10 +605,13 @@ herr_t _read_single_value_image_t_type(hid_t origin,
                 datatype_size);
         exit(1);
     }
-    assert(sizeof(image_t_type) == 2);
-    image_t_type value;
+#ifdef PIXEL_DATA_32BIT
+    if (H5Dread(dataset, H5T_NATIVE_UINT32, H5S_ALL, H5S_ALL, H5P_DEFAULT, destination)
+        < 0) {
+#else
     if (H5Dread(dataset, H5T_NATIVE_UINT16, H5S_ALL, H5S_ALL, H5P_DEFAULT, destination)
         < 0) {
+#endif
         char name[256] = "\0";
         H5Iget_name(origin, name, 256);
         fprintf(stderr,
@@ -659,13 +683,27 @@ herr_t _read_single_value_float(hid_t origin, const char *path, float *destinati
 
 void read_trusted_range(h5read_handle *obj) {
     obj->trusted_range_min = 0;
-    obj->trusted_range_max = (image_t_type)(-1);
-    _read_single_value_image_t_type(obj->master_file,
-                                    "/entry/instrument/detector/saturation_value",
-                                    &obj->trusted_range_max);
-    _read_single_value_image_t_type(obj->master_file,
-                                    "/entry/instrument/detector/underload_value",
-                                    &obj->trusted_range_min);
+#ifdef PIXEL_DATA_32BIT
+    obj->trusted_range_max = UINT32_MAX;
+#else
+    obj->trusted_range_max = UINT16_MAX;
+#endif
+
+    // Try to read saturation value, but don't fail if it doesn't exist
+    if (_read_single_value_image_t_type(obj->master_file,
+                                        "/entry/instrument/detector/saturation_value",
+                                        &obj->trusted_range_max)
+        < 0) {
+        fprintf(stderr, "Warning: No saturation_value found, using maximum value\n");
+    }
+
+    // Try to read underload value, but don't fail if it doesn't exist
+    if (_read_single_value_image_t_type(obj->master_file,
+                                        "/entry/instrument/detector/underload_value",
+                                        &obj->trusted_range_min)
+        < 0) {
+        fprintf(stderr, "Warning: No underload_value found, using 0\n");
+    }
 }
 
 void read_wavelength(h5read_handle *obj) {
@@ -712,34 +750,41 @@ void read_detector_metadata(h5read_handle *obj) {
                                  "/entry/instrument/detector/x_pixel_size",
                                  &obj->pixel_size_x)
         < 0) {
+        fprintf(stderr, "Warning: No x_pixel_size found\n");
         obj->pixel_size_x = -1;
     }
     if (_read_single_value_float(obj->master_file,
                                  "/entry/instrument/detector/y_pixel_size",
                                  &obj->pixel_size_y)
         < 0) {
+        fprintf(stderr, "Warning: No y_pixel_size found\n");
         obj->pixel_size_y = -1;
     }
     if (_read_single_value_float(obj->master_file,
                                  "/entry/instrument/detector/beam_center_x",
                                  &obj->beam_center_x)
         < 0) {
+        fprintf(stderr, "Warning: No beam_center_x found\n");
         obj->beam_center_x = -1;
     }
     if (_read_single_value_float(obj->master_file,
                                  "/entry/instrument/detector/beam_center_y",
                                  &obj->beam_center_y)
         < 0) {
+        fprintf(stderr, "Warning: No beam_center_y found\n");
         obj->beam_center_y = -1;
     }
     if (_read_single_value_float(obj->master_file,
                                  "/entry/instrument/detector/distance",
                                  &obj->detector_distance)
         < 0) {
-        obj->detector_distance = 0;
+        fprintf(stderr, "Warning: No detector distance found\n");
+        obj->detector_distance = -1;
     }
 
-    printf("Read pixel size: %f\n", obj->pixel_size_x);
+    if (obj->pixel_size_x > 0) {
+        printf("Read pixel size: %f\n", obj->pixel_size_x);
+    }
 }
 
 /// Get number of VDS and read info about all the sub-files.
@@ -887,10 +932,7 @@ void setup_data(h5read_handle *obj) {
     hid_t dataset = obj->data_files[0].dataset;
     hid_t datatype = H5Dget_type(dataset);
 
-    if (H5Tget_size(datatype) != 2) {
-        fprintf(stderr, "native data size != 2 (%ld)\n", H5Tget_size(datatype));
-        // exit(1);
-    }
+    _validate_data_type_size(datatype);
 
     hid_t space = H5Dget_space(dataset);
 

--- a/h5read/src/h5read.c
+++ b/h5read/src/h5read.c
@@ -315,7 +315,7 @@ void h5read_get_raw_chunk(h5read_handle *obj,
     hsize_t datasize = H5Tget_size(datatype);
     if (datasize != 2) {
         fprintf(stderr, "Error: Unexpected datasize\n");
-        exit(1);
+        // exit(1);
     }
 
     uint32_t filter = 0;
@@ -889,7 +889,7 @@ void setup_data(h5read_handle *obj) {
 
     if (H5Tget_size(datatype) != 2) {
         fprintf(stderr, "native data size != 2 (%ld)\n", H5Tget_size(datatype));
-        exit(1);
+        // exit(1);
     }
 
     hid_t space = H5Dget_space(dataset);

--- a/spotfinder/spotfinder.cc
+++ b/spotfinder/spotfinder.cc
@@ -398,7 +398,6 @@ int main(int argc, char **argv) {
     ushort height = reader.image_shape()[0];
     ushort width = reader.image_shape()[1];
     auto trusted_px_max = reader.get_trusted_range()[1];
-    trusted_px_max = 64000;  // Hardcoded for testing
 
     detector_geometry detector;
 
@@ -721,9 +720,6 @@ int main(int argc, char **argv) {
                 }
                 // Sized buffer for the actual data read from file
                 std::span<uint8_t> buffer;
-                // Buffer to hold decompressed 32-bit data
-                std::vector<uint32_t> decompressed_buffer(
-                  width * height);  // * sizeof(pixel_t));
                 // Fetch the image data from the reader
                 while (true) {
                     {
@@ -750,11 +746,10 @@ int main(int argc, char **argv) {
                 // the decompression
                 switch (reader.get_raw_chunk_compression()) {
                 case Reader::ChunkCompression::BITSHUFFLE_LZ4:
-                    printf("Decompressing with bitshuffle\n");
                     bshuf_decompress_lz4(buffer.data() + 12,
-                                         decompressed_buffer.data(),
+                                         host_image.get(),
                                          width * height,
-                                         4,
+                                         sizeof(pixel_t),
                                          0);
                     break;
                 case Reader::ChunkCompression::BYTE_OFFSET_32:
@@ -769,41 +764,12 @@ int main(int argc, char **argv) {
                     // std::exit(1);
                     break;
                 }
-                // Downcast the decompressed 32-bit data to 16-bit and store it in the host_image buffer
-                uint16_t *host_image_16bit = new uint16_t[width * height];
-                size_t truncation_count = 0;
-
-                for (size_t i = 0; i < width * height; ++i) {
-                    uint32_t original_value = decompressed_buffer[i];
-
-                    // Manually truncate to 16 bits by selecting the lower 16 bits
-                    // uint16_t truncated_value = original_value & 0xFFFF;
-                    uint16_t truncated_value = static_cast<uint16_t>(original_value);
-
-                    // Increment the counter if truncation occurs
-                    if (original_value != truncated_value) {
-                        ++truncation_count;
-                        truncated_value = trusted_px_max + 1;
-                    }
-
-                    // Assign the truncated value to the 16-bit image
-                    host_image_16bit[i] = truncated_value;
-
-                    // Optional: Print the first pixel value after truncation
-                    if (i == 1) {
-                        print("Pixel value after truncation: {}\n",
-                              host_image_16bit[i]);
-                    }
-                }
-
-                // After the loop, you can print the total number of truncated values
-                print("Total truncated values: {}\n", truncation_count);
 
                 start.record(stream);
                 // Copy the image to GPU
                 CUDA_CHECK(cudaMemcpy2DAsync(device_image.get(),
                                              device_image.pitch_bytes(),
-                                             host_image_16bit,
+                                             host_image.get(),
                                              width * sizeof(pixel_t),
                                              width * sizeof(pixel_t),
                                              height,


### PR DESCRIPTION
Add optional 32-bit pixel data support

Early development stages assumed 16-bit pixel data as standard, but as
the software becomes more widely adopted, support for 32-bit data has
become necessary.

Detectors other than an Eiger and even Eiger's at low framerates
output 32-bit data by default. Until now, this data could not be
utilised due to hardcoded assumptions in the codebase.

This change introduces a compile-time option `PIXEL_DATA_32BIT` to
support 32-bit pixel data. By defining a shared `image_t_type` and
using preprocessor conditionals, the program can now compile and run
with either 16-bit or 32-bit input data.

A new `compile_options` interface library was added to manage compile
definitions. This makes it easier to propagate additional flags in the
future, improving configurability and maintainability.

- Introduced `PIXEL_DATA_32BIT` CMake option to switch between 16-bit
  and 32-bit image data
- Created `image_t_type` typedef to abstract pixel type usage
- Updated memory operations, image reads, and HDF5 datatype checks
- Added validation for expected HDF5 datatype size at runtime
- Improved fallback handling for missing metadata fields
- Added `compile_options` interface library to centralize flags