### PR TITLE
Fix non-deterministic results in spotfinding

### DIFF
--- a/include/ffs_logger.hpp
+++ b/include/ffs_logger.hpp
@@ -65,18 +65,18 @@ class FFSLogger {
             spdlog::init_thread_pool(queue_size, 1);
 
             // Create a rotating file sink (max 5MB per file, 3 rotated files)
-            // auto file_sink = std::make_shared<spdlog::sinks::rotating_file_sink_mt>(
-            //   "ffs_log.txt", 5 * 1024 * 1024, 3);
-            // file_sink->set_pattern(
-            //   "[%Y-%m-%d %H:%M:%S] [PID:%P Thread:%t] [%^%l%$] [%s:%#] %v");
+            auto file_sink = std::make_shared<spdlog::sinks::rotating_file_sink_mt>(
+              "ffs_log.txt", 5 * 1024 * 1024, 3);
+            file_sink->set_pattern(
+              "[%Y-%m-%d %H:%M:%S] [PID:%P Thread:%t] [%^%l%$] [%s:%#] %v");
 
             // Create a colored console sink
             auto console_sink = std::make_shared<spdlog::sinks::stdout_color_sink_mt>();
             console_sink->set_pattern("[%Y-%m-%d %H:%M:%S] [thread %t] [%^%l%$] %v");
 
             // Combine sinks into one asynchronous logger
-            // std::vector<spdlog::sink_ptr> sinks{console_sink, file_sink};
-            std::vector<spdlog::sink_ptr> sinks{console_sink};
+            std::vector<spdlog::sink_ptr> sinks{console_sink, file_sink};
+            // std::vector<spdlog::sink_ptr> sinks{console_sink};
             logger_ = std::make_shared<spdlog::async_logger>(
               "FFSLogger",
               sinks.begin(),

--- a/spotfinder/connected_components/connected_components.cc
+++ b/spotfinder/connected_components/connected_components.cc
@@ -273,7 +273,8 @@ std::vector<Reflection3D> ConnectedComponents::find_3d_components(
         // Current slice's vertex id -> linear index map
         const auto &vertex_to_index = slices[i]->get_vertex_to_index();
 
-        logger.trace("Copying edges from slice {}", i);
+        // logger.trace("Copying edges from slice {}", i);
+
         // Iterate over the edges in the slice's graph
         for (const auto &edge : boost::make_iterator_range(boost::edges(graph_2d))) {
             // Get the source and target vertices for the edge

--- a/spotfinder/connected_components/connected_components.cc
+++ b/spotfinder/connected_components/connected_components.cc
@@ -390,10 +390,8 @@ std::vector<Reflection3D> ConnectedComponents::find_3d_components(
             // Get the reflection for this label
             auto &reflection = reflections_3d[label];
 
-            // Calculate DIALS z-index by reversing the slice index
-            auto z_index = slices.size() - z - 1;
             // Add z-index to the signal
-            signal.z = std::make_optional(z_index);
+            signal.z = std::make_optional(z);
 
             // Update the reflection with the signal
             reflection.add_signal(signal);

--- a/spotfinder/connected_components/connected_components.cc
+++ b/spotfinder/connected_components/connected_components.cc
@@ -140,20 +140,20 @@ void ConnectedComponents::generate_boxes(const ushort width,
 #pragma endregion Connected Components
 
 #pragma region Reflection3D
-bool Reflection3D::is_signal_preferred(const Signal &signal1,
-                                       const Signal &signal2) const {
+bool Reflection3D::is_signal_preferred(const Signal &candidate,
+                                       const Signal &current) const {
     // Compare z-coordinates first
-    if (signal1.z.value() != signal2.z.value()) {
-        return signal1.z.value() < signal2.z.value();
+    if (candidate.z.value() != current.z.value()) {
+        return candidate.z.value() < current.z.value();
     }
 
     // If z is equal, compare y-coordinates
-    if (signal1.y != signal2.y) {
-        return signal1.y < signal2.y;
+    if (candidate.y != current.y) {
+        return candidate.y < current.y;
     }
 
     // If both z and y are equal, compare x-coordinates
-    return signal1.x < signal2.x;
+    return candidate.x < current.x;
 }
 #pragma endregion Reflection3D
 

--- a/spotfinder/connected_components/connected_components.cc
+++ b/spotfinder/connected_components/connected_components.cc
@@ -139,6 +139,24 @@ void ConnectedComponents::generate_boxes(const ushort width,
 }
 #pragma endregion Connected Components
 
+#pragma region Reflection3D
+bool Reflection3D::is_signal_preferred(const Signal &signal1,
+                                       const Signal &signal2) const {
+    // Compare z-coordinates first
+    if (signal1.z.value() != signal2.z.value()) {
+        return signal1.z.value() < signal2.z.value();
+    }
+
+    // If z is equal, compare y-coordinates
+    if (signal1.y != signal2.y) {
+        return signal1.y < signal2.y;
+    }
+
+    // If both z and y are equal, compare x-coordinates
+    return signal1.x < signal2.x;
+}
+#pragma endregion Reflection3D
+
 #pragma region 2D Connected Components
 std::tuple<int, int> filter_reflections(std::vector<Reflection3D> &reflections,
                                         const uint min_spot_size,

--- a/spotfinder/connected_components/connected_components.hpp
+++ b/spotfinder/connected_components/connected_components.hpp
@@ -241,11 +241,11 @@ class Reflection3D {
      * @brief Determines if the first signal should be preferred over the second
      *        in case of intensity ties using coordinate-based tie-breaking.
      * 
-     * @param signal1 The signal to compare
-     * @param signal2 The current preferred signal
-     * @return true if signal1 should be preferred over signal2
+     * @param candidate The signal to compare
+     * @param current The current preferred signal
+     * @return true if candidate should be preferred over current
      */
-    bool is_signal_preferred(const Signal &signal1, const Signal &signal2) const;
+    bool is_signal_preferred(const Signal &candidate, const Signal &current) const;
 };
 
 /**

--- a/spotfinder/connected_components/connected_components.hpp
+++ b/spotfinder/connected_components/connected_components.hpp
@@ -117,7 +117,17 @@ class Reflection3D {
         double max_intensity = std::numeric_limits<double>::min();
 
         for (const auto &signal : signals_) {
+            bool should_update = false;
+
             if (signal.intensity > max_intensity) {
+                should_update = true;
+            }
+            // If intensities are equal, prefer signal with smaller linear index
+            else if (signal.intensity == max_intensity && peak_signal != nullptr) {
+                should_update = (signal.linear_index < peak_signal->linear_index);
+            }
+
+            if (should_update) {
                 max_intensity = signal.intensity;
                 peak_signal = &signal;
             }

--- a/spotfinder/connected_components/connected_components.hpp
+++ b/spotfinder/connected_components/connected_components.hpp
@@ -112,8 +112,8 @@ class Reflection3D {
             throw std::runtime_error("No pixels in 3D reflection");
         }
 
-        logger.debug("Finding peak signal for reflection with {} pixels",
-                     signals_.size());
+        // logger.debug("Finding peak signal for reflection with {} pixels",
+        //              signals_.size());
 
         // Find the signal with the highest intensity
         const Signal *peak_signal = nullptr;
@@ -131,13 +131,13 @@ class Reflection3D {
                 max_intensity = signal.intensity;
                 peak_signal = &signal;
                 candidates_with_max_intensity = 1;
-                logger.trace(
-                  "New max intensity found: {} at ({}, {}, {}) linear_index: {}",
-                  signal.intensity,
-                  signal.x,
-                  signal.y,
-                  signal.z.has_value() ? signal.z.value() : -1,
-                  signal.linear_index);
+                // logger.trace(
+                //   "New max intensity found: {} at ({}, {}, {}) linear_index: {}",
+                //   signal.intensity,
+                //   signal.x,
+                //   signal.y,
+                //   signal.z.has_value() ? signal.z.value() : -1,
+                //   signal.linear_index);
                 continue;
             }
 
@@ -152,17 +152,17 @@ class Reflection3D {
             // Deterministic tie-breaking using coordinate comparison
             bool should_update_tie = is_signal_preferred(signal, *peak_signal);
 
-            logger.trace(
-              "Tie at intensity {}: current ({}, {}, {}) vs peak ({}, {}, {}), "
-              "should_update: {}",
-              signal.intensity,
-              signal.x,
-              signal.y,
-              signal.z.value(),
-              peak_signal->x,
-              peak_signal->y,
-              peak_signal->z.value(),
-              should_update_tie);
+            // logger.trace(
+            //   "Tie at intensity {}: current ({}, {}, {}) vs peak ({}, {}, {}), "
+            //   "should_update: {}",
+            //   signal.intensity,
+            //   signal.x,
+            //   signal.y,
+            //   signal.z.value(),
+            //   peak_signal->x,
+            //   peak_signal->y,
+            //   peak_signal->z.value(),
+            //   should_update_tie);
 
             if (should_update_tie) {
                 peak_signal = &signal;
@@ -174,19 +174,19 @@ class Reflection3D {
             throw std::runtime_error("Failed to find peak intensity signal");
         }
 
-        logger.debug(
-          "Selected peak signal: intensity={}, position=({}, {}, {}), linear_index={}, "
-          "candidates_with_max_intensity={}",
-          peak_signal->intensity,
-          peak_signal->x,
-          peak_signal->y,
-          peak_signal->z.has_value() ? peak_signal->z.value() : -1,
-          peak_signal->linear_index,
-          candidates_with_max_intensity);
+        // logger.debug(
+        //   "Selected peak signal: intensity={}, position=({}, {}, {}), linear_index={}, "
+        //   "candidates_with_max_intensity={}",
+        //   peak_signal->intensity,
+        //   peak_signal->x,
+        //   peak_signal->y,
+        //   peak_signal->z.has_value() ? peak_signal->z.value() : -1,
+        //   peak_signal->linear_index,
+        //   candidates_with_max_intensity);
 
         // Get the cached or computed center of mass
         auto [com_x, com_y, com_z] = center_of_mass();
-        logger.debug("Center of mass: ({:.3f}, {:.3f}, {:.3f})", com_x, com_y, com_z);
+        // logger.debug("Center of mass: ({:.3f}, {:.3f}, {:.3f})", com_x, com_y, com_z);
 
         // Calculate the Euclidean distance
         float dx = (peak_signal->x + 0.5f) - com_x;
@@ -194,11 +194,11 @@ class Reflection3D {
         float dz = (peak_signal->z.value() + 0.5f) - com_z;
 
         float distance = std::sqrt(dx * dx + dy * dy + dz * dz);
-        logger.debug("Peak-centroid distance: {:.3f} (dx={:.3f}, dy={:.3f}, dz={:.3f})",
-                     distance,
-                     dx,
-                     dy,
-                     dz);
+        // logger.debug("Peak-centroid distance: {:.3f} (dx={:.3f}, dy={:.3f}, dz={:.3f})",
+        //              distance,
+        //              dx,
+        //              dy,
+        //              dz);
 
         return distance;
     }

--- a/spotfinder/connected_components/connected_components.hpp
+++ b/spotfinder/connected_components/connected_components.hpp
@@ -6,6 +6,7 @@
 #include <boost/graph/adjacency_list.hpp>
 #include <boost/graph/connected_components.hpp>
 #include <cstdint>
+#include <map>
 #include <tuple>
 #include <vector>
 
@@ -228,7 +229,7 @@ class ConnectedComponents {
         return boxes;
     }
 
-    std::unordered_map<size_t, Signal> &get_signals() {
+    std::map<size_t, Signal> &get_signals() {
         return signals;
     }
 
@@ -274,11 +275,11 @@ class ConnectedComponents {
     uint num_strong_pixels_filtered;  // Number of strong pixels after filtering
     std::vector<Reflection> boxes;    // Bounding boxes
     // Maps pixel linear index -> Signal (used to store signal pixels)
-    std::unordered_map<size_t, Signal> signals;
+    std::map<size_t, Signal> signals;
     // Maps graph linear index -> vertex ID
-    std::unordered_map<size_t, size_t> index_to_vertex;
+    std::map<size_t, size_t> index_to_vertex;
     // Maps graph vertex ID -> linear index
-    std::unordered_map<size_t, size_t> vertex_to_index;
+    std::map<size_t, size_t> vertex_to_index;
     // 2D graph representing the connected components
     boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS> graph;
 

--- a/spotfinder/connected_components/connected_components.hpp
+++ b/spotfinder/connected_components/connected_components.hpp
@@ -112,19 +112,39 @@ class Reflection3D {
             throw std::runtime_error("No pixels in 3D reflection");
         }
 
+        logger.debug("Finding peak signal for reflection with {} pixels",
+                     signals_.size());
+
         // Find the signal with the highest intensity
         const Signal *peak_signal = nullptr;
         double max_intensity = std::numeric_limits<double>::min();
+        int candidates_with_max_intensity = 0;
 
         for (const auto &signal : signals_) {
             bool should_update = false;
 
             if (signal.intensity > max_intensity) {
                 should_update = true;
+                candidates_with_max_intensity = 1;
+                logger.trace(
+                  "New max intensity found: {} at ({}, {}, {}) linear_index: {}",
+                  signal.intensity,
+                  signal.x,
+                  signal.y,
+                  signal.z.has_value() ? signal.z.value() : -1,
+                  signal.linear_index);
             }
             // If intensities are equal, prefer signal with smaller linear index
             else if (signal.intensity == max_intensity && peak_signal != nullptr) {
+                candidates_with_max_intensity++;
                 should_update = (signal.linear_index < peak_signal->linear_index);
+                logger.trace(
+                  "Tie at intensity {}: current linear_index {} vs peak linear_index "
+                  "{}, should_update: {}",
+                  signal.intensity,
+                  signal.linear_index,
+                  peak_signal->linear_index,
+                  should_update);
             }
 
             if (should_update) {
@@ -138,15 +158,33 @@ class Reflection3D {
             throw std::runtime_error("Failed to find peak intensity signal");
         }
 
+        logger.debug(
+          "Selected peak signal: intensity={}, position=({}, {}, {}), linear_index={}, "
+          "candidates_with_max_intensity={}",
+          peak_signal->intensity,
+          peak_signal->x,
+          peak_signal->y,
+          peak_signal->z.has_value() ? peak_signal->z.value() : -1,
+          peak_signal->linear_index,
+          candidates_with_max_intensity);
+
         // Get the cached or computed center of mass
         auto [com_x, com_y, com_z] = center_of_mass();
+        logger.debug("Center of mass: ({:.3f}, {:.3f}, {:.3f})", com_x, com_y, com_z);
 
         // Calculate the Euclidean distance
         float dx = (peak_signal->x + 0.5f) - com_x;
         float dy = (peak_signal->y + 0.5f) - com_y;
         float dz = (peak_signal->z.value() + 0.5f) - com_z;
 
-        return std::sqrt(dx * dx + dy * dy + dz * dz);
+        float distance = std::sqrt(dx * dx + dy * dy + dz * dz);
+        logger.debug("Peak-centroid distance: {:.3f} (dx={:.3f}, dy={:.3f}, dz={:.3f})",
+                     distance,
+                     dx,
+                     dy,
+                     dz);
+
+        return distance;
     }
 
     // Getters for bounding box

--- a/spotfinder/spotfinder.cc
+++ b/spotfinder/spotfinder.cc
@@ -646,26 +646,25 @@ int main(int argc, char **argv) {
     }
 
     // Create a unique pointer to store the image slices if this is a rotation dataset
-    std::unique_ptr<std::unordered_map<int, std::unique_ptr<ConnectedComponents>>>
+    std::unique_ptr<std::map<int, std::unique_ptr<ConnectedComponents>>>
       rotation_slices = nullptr;
     std::mutex rotation_slices_mutex;  // Mutex to protect the rotation slices map
     // Create a unique pointer to store the reflection centres if we want to save 2D spot data.
-    std::unique_ptr<std::unordered_map<int, std::vector<float>>> reflection_centers_2d =
-      nullptr;
+    std::unique_ptr<std::map<int, std::vector<float>>> reflection_centers_2d = nullptr;
     std::mutex
       reflection_centers_2d_mutex;  // Mutex to protect the reflection centers 2d map
 
     if (oscillation_width > 0) {
         // If oscillation information is available then this is a rotation dataset
-        rotation_slices = std::make_unique<
-          std::unordered_map<int, std::unique_ptr<ConnectedComponents>>>();
+        rotation_slices =
+          std::make_unique<std::map<int, std::unique_ptr<ConnectedComponents>>>();
         fmt::print("Dataset type: {}\n", fmt::styled("Rotation set", fmt_magenta));
     } else {
         fmt::print("Dataset type: {}\n", fmt::styled("Still set", fmt_magenta));
         if (save_to_h5) {
             // A map we will use to save results as we go.
             reflection_centers_2d =
-              std::make_unique<std::unordered_map<int, std::vector<float>>>();
+              std::make_unique<std::map<int, std::vector<float>>>();
         }
     }
 


### PR DESCRIPTION
The spotfinder was producing different results on consecutive runs when using multiple threads (--threads > 1), caused by a race condition in image processing order. While threads acquired image numbers sequentially, they completed processing at different speeds and stored results in std::unordered_map containers with no guaranteed iteration order. This caused 3D connected components analysis to process image slices out of rotation sequence and indexing output (--output-for-index) to send spot data with incorrect temporal ordering. The fix replaces std::unordered_map with std::map to ensure deterministic iteration by image number, making results reproducible across multiple runs.

Some differences may still occur when resolution filtering (--dmin specifically) is not applied and is being looked into, but the major non-deterministic behaviour from multithreading is resolved.

Performance impact is negligible since maps are only accessed during initialization and final processing, not during tighter processing loops.