### PR TITLE
Correctly link to dx2 in refiner tests

### DIFF
--- a/baseline/refiner/tests/CMakeLists.txt
+++ b/baseline/refiner/tests/CMakeLists.txt
@@ -5,23 +5,23 @@ add_executable(test_gradients_calculator test_gradients_calculator.cc)
 target_include_directories(test_gradients_calculator PRIVATE "${PROJECT_SOURCE_DIR}")
 target_include_directories(test_gradients_calculator PRIVATE "${PROJECT_SOURCE_DIR}/baseline/indexer")
 target_link_libraries(test_gradients_calculator mdspan
-    GTest::gtest_main Eigen3::Eigen nlohmann_json::nlohmann_json gemmi::gemmi_cpp fmt::fmt hdf5::hdf5)
+    GTest::gtest_main Eigen3::Eigen nlohmann_json::nlohmann_json gemmi::gemmi_cpp fmt::fmt hdf5::hdf5 dx2)
 
 add_executable(test_detector_parameterisation test_detector_parameterisation.cc)
 target_include_directories(test_detector_parameterisation PRIVATE "${PROJECT_SOURCE_DIR}")
-target_link_libraries(test_detector_parameterisation GTest::gtest_main Eigen3::Eigen nlohmann_json::nlohmann_json)
+target_link_libraries(test_detector_parameterisation GTest::gtest_main Eigen3::Eigen nlohmann_json::nlohmann_json dx2)
 
 add_executable(test_beam_parameterisation test_beam_parameterisation.cc)
 target_include_directories(test_beam_parameterisation PRIVATE "${PROJECT_SOURCE_DIR}")
-target_link_libraries(test_beam_parameterisation GTest::gtest_main Eigen3::Eigen nlohmann_json::nlohmann_json)
+target_link_libraries(test_beam_parameterisation GTest::gtest_main Eigen3::Eigen nlohmann_json::nlohmann_json dx2)
 
 add_executable(test_orientation_parameterisation test_orientation_parameterisation.cc)
 target_include_directories(test_orientation_parameterisation PRIVATE "${PROJECT_SOURCE_DIR}")
-target_link_libraries(test_orientation_parameterisation GTest::gtest_main Eigen3::Eigen nlohmann_json::nlohmann_json gemmi::gemmi_cpp)
+target_link_libraries(test_orientation_parameterisation GTest::gtest_main Eigen3::Eigen nlohmann_json::nlohmann_json gemmi::gemmi_cpp dx2)
 
 add_executable(test_cell_parameterisation test_cell_parameterisation.cc)
 target_include_directories(test_cell_parameterisation PRIVATE "${PROJECT_SOURCE_DIR}")
-target_link_libraries(test_cell_parameterisation GTest::gtest_main Eigen3::Eigen nlohmann_json::nlohmann_json gemmi::gemmi_cpp)
+target_link_libraries(test_cell_parameterisation GTest::gtest_main Eigen3::Eigen nlohmann_json::nlohmann_json gemmi::gemmi_cpp dx2)
 
 
 gtest_discover_tests(test_gradients_calculator PROPERTIES LABELS baseline-indexer-tests)


### PR DESCRIPTION
Otherwise this code will not correctly link with https://github.com/dials/dx2/pull/23