### PR TITLE
Fix illegal-memory access in dispersion extended erosion kernel

### DIFF
--- a/spotfinder/kernels/erosion.cu
+++ b/spotfinder/kernels/erosion.cu
@@ -92,6 +92,13 @@ __global__ void erosion(uint8_t __restrict__ *dispersion_mask_ptr,
             int lx = x + j;                        // Offset x coordinate
             int ly = y + i;                        // Offset y coordinate
 
+            // Boundary guard - don't index outside the image
+            if (lx < 0 || ly < 0 || lx >= static_cast<int>(kernel_constants.width)
+                || ly >= static_cast<int>(kernel_constants.height)) {
+                // Out of bounds - treat as not valid for erosion checks
+                continue;
+            }
+
             // Check if the pixel is masked
             if (mask(lx, ly) == 0) {
                 // If so, skip the pixel

--- a/spotfinder/spotfinder.cu
+++ b/spotfinder/spotfinder.cu
@@ -175,7 +175,7 @@ void call_do_spotfinding_dispersion(dim3 blocks,
       threads, KERNEL_RADIUS);  // Required shared memory
 
     // Synchronize the CUDA stream to ensure the kernel constants are set
-    cudaStreamSynchronize(stream);
+    CUDA_CHECK(cudaStreamSynchronize(stream));
 
     // Launch the dispersion threshold kernel
     dispersion<<<blocks, threads, shared_memory, stream>>>(
@@ -184,8 +184,8 @@ void call_do_spotfinding_dispersion(dim3 blocks,
       result_strong->get()  // Output mask pointer
     );
 
-    cudaStreamSynchronize(
-      stream);  // Synchronize the CUDA stream to ensure the kernel is complete
+    // Synchronize the CUDA stream to ensure the kernel is complete
+    CUDA_CHECK(cudaStreamSynchronize(stream));
 }
 
 /**
@@ -245,7 +245,7 @@ void call_do_spotfinding_extended(dim3 blocks,
     PitchedMalloc<uint8_t> d_erosion_mask(width, height);
 
     // Synchronize the CUDA stream to ensure the kernel constants are set
-    cudaStreamSynchronize(stream);
+    CUDA_CHECK(cudaStreamSynchronize(stream));
 
     /*
      * First pass 🔎
@@ -264,8 +264,8 @@ void call_do_spotfinding_extended(dim3 blocks,
     shared_memory = calculate_shared_memory<uint8_t>(
       threads, KERNEL_RADIUS);  // Required shared memory
 
-    cudaStreamSynchronize(
-      stream);  // Synchronize the CUDA stream to ensure the first pass is complete
+    // Synchronize the CUDA stream to ensure the first pass is complete
+    CUDA_CHECK(cudaStreamSynchronize(stream));
 
     if (do_writeout) {
         printf("First pass complete\n");
@@ -301,8 +301,8 @@ void call_do_spotfinding_extended(dim3 blocks,
     shared_memory = calculate_shared_memory<pixel_t, uint8_t, uint8_t>(
       threads, KERNEL_RADIUS_EXTENDED);  // Required shared memory
 
-    cudaStreamSynchronize(
-      stream);  // Synchronize the CUDA stream to ensure the erosion pass is complete
+    // Synchronize the CUDA stream to ensure the erosion pass is complete
+    CUDA_CHECK(cudaStreamSynchronize(stream));
 
     if (do_writeout) {
         printf("Erosion pass complete\n");
@@ -328,8 +328,9 @@ void call_do_spotfinding_extended(dim3 blocks,
       result_strong->get(),  // Output result mask pointer
       d_erosion_mask.pitch   // Dispersion mask pitch
     );
-    cudaStreamSynchronize(
-      stream);  // Synchronize the CUDA stream to ensure the second pass is complete
+
+    // Synchronize the CUDA stream to ensure the second pass is complete
+    CUDA_CHECK(cudaStreamSynchronize(stream));
 
     if (do_writeout) {
         printf("Second pass complete\n");


### PR DESCRIPTION
When running extended dispersion, some datasets would crash cryptically
with:
```
    terminate called recursively
    terminate called recursively
    terminate called recursively
    terminate called recursively
    terminate called recursively
    Aborted (core dumped)
```
A brief investigation traced the issue to the erosion kernel, which
performs checks on neighbouring pixels. While it validates the central
pixel, no guard was present for its neighbours, causing out-of-bounds
accesses when neighbours fell outside of the image.

This PR adds the missing boundary checks and wraps stream
synchronizations with CUDA_CHECK to attempt to produce clearer error 
messages instead of recursive termination.