### PR TITLE
Calculate spot variances at the end of 3D spotfinding

### DIFF
--- a/spotfinder/connected_components/connected_components.cc
+++ b/spotfinder/connected_components/connected_components.cc
@@ -156,12 +156,13 @@ bool Reflection3D::is_signal_preferred(const Signal &candidate,
     return candidate.x < current.x;
 }
 
-std::tuple<double, double, int> Reflection3D::variances_in_kabsch_space(const Vector3d& s1,
-                                                          const Vector3d& s0,
-                                                          const Vector3d& m2,
-                                                          const Panel& panel,
-                                                          const Scan& scan,
-                                                          const double phi) const {
+std::tuple<double, double, int> Reflection3D::variances_in_kabsch_space(
+  const Vector3d &s1,
+  const Vector3d &s0,
+  const Vector3d &m2,
+  const Panel &panel,
+  const Scan &scan,
+  const double phi) const {
     Vector3d e1 = s1.cross(s0);
     e1.normalize();
     Vector3d e2 = s1.cross(e1);
@@ -181,12 +182,13 @@ std::tuple<double, double, int> Reflection3D::variances_in_kabsch_space(const Ve
         double x = static_cast<double>(signal.x) + 0.5;
         double y = static_cast<double>(signal.y) + 0.5;
         double z = static_cast<double>(signal.z.value()) + 0.5;
-        auto [xmm, ymm] = panel.px_to_mm(x,y);
+        auto [xmm, ymm] = panel.px_to_mm(x, y);
         Vector3d s1p = panel.get_lab_coord(xmm, ymm);
         Vector3d delta_s1 = s1p - s1;
         double eps1 = e1.dot(delta_s1) / mags1;
         double eps2 = e2.dot(delta_s1) / mags1;
-        double phi_dash = (oscillation_start + (z - image_range_0) * oscillation_width)  * deg_to_rad;
+        double phi_dash =
+          (oscillation_start + (z - image_range_0) * oscillation_width) * deg_to_rad;
         double eps3 = (phi_dash - phi) * zeta;
         varx += signal.intensity * eps1 * eps1;
         vary += signal.intensity * eps2 * eps2;
@@ -197,7 +199,7 @@ std::tuple<double, double, int> Reflection3D::variances_in_kabsch_space(const Ve
     vary = vary / total_intensity;
     varz = varz / total_intensity;
     // Reason for dividing by two below, see https://github.com/dials/dials/issues/2851#issuecomment-2657018707
-    return std::make_tuple((varx + vary) / 2.0, varz, z_max_ - z_min_+1);
+    return std::make_tuple((varx + vary) / 2.0, varz, z_max_ - z_min_ + 1);
 }
 #pragma endregion Reflection3D
 

--- a/spotfinder/connected_components/connected_components.cc
+++ b/spotfinder/connected_components/connected_components.cc
@@ -155,6 +155,48 @@ bool Reflection3D::is_signal_preferred(const Signal &candidate,
     // If both z and y are equal, compare x-coordinates
     return candidate.x < current.x;
 }
+
+std::tuple<double, double, int> Reflection3D::variances_in_kabsch_space(const Vector3d& s1,
+                                                          const Vector3d& s0,
+                                                          const Vector3d& m2,
+                                                          const Panel& panel,
+                                                          const Scan& scan,
+                                                          const double phi) const {
+    Vector3d e1 = s1.cross(s0);
+    e1.normalize();
+    Vector3d e2 = s1.cross(e1);
+    e2.normalize();
+    double mags1 = std::sqrt(s1.dot(s1));
+    double varx = 0;
+    double vary = 0;
+    double varz = 0;
+    double total_intensity = 0;
+    double zeta = m2.dot(e1);
+    int image_range_0 = scan.get_image_range()[0];
+    double oscillation_width = scan.get_oscillation()[1];
+    double oscillation_start = scan.get_oscillation()[0];
+    for (const auto &signal : signals_) {
+        double x = static_cast<double>(signal.x) + 0.5;
+        double y = static_cast<double>(signal.y) + 0.5;
+        double z = static_cast<double>(signal.z.value()) + 0.5;
+        auto [xmm, ymm] = panel.px_to_mm(x,y);
+        Vector3d s1p = panel.get_lab_coord(xmm, ymm);
+        Vector3d delta_s1 = s1p - s1;
+        double eps1 = e1.dot(delta_s1) / mags1;
+        double eps2 = e2.dot(delta_s1) / mags1;
+        double phi_dash = (oscillation_start + (z - image_range_0) * oscillation_width)  * M_PI / 180.0;
+        double eps3 = (phi_dash - phi) * zeta;
+        varx += signal.intensity * eps1 * eps1;
+        vary += signal.intensity * eps2 * eps2;
+        varz += signal.intensity * eps3 * eps3;
+        total_intensity += signal.intensity;
+    }
+    varx = varx / total_intensity;
+    vary = vary / total_intensity;
+    varz = varz / total_intensity;
+    // Reason for dividing by two below, see https://github.com/dials/dials/issues/2851#issuecomment-2657018707
+    return std::make_tuple((varx + vary) / 2.0, varz, z_max_ - z_min_);
+}
 #pragma endregion Reflection3D
 
 #pragma region 2D Connected Components

--- a/spotfinder/connected_components/connected_components.cc
+++ b/spotfinder/connected_components/connected_components.cc
@@ -197,7 +197,7 @@ std::tuple<double, double, int> Reflection3D::variances_in_kabsch_space(const Ve
     vary = vary / total_intensity;
     varz = varz / total_intensity;
     // Reason for dividing by two below, see https://github.com/dials/dials/issues/2851#issuecomment-2657018707
-    return std::make_tuple((varx + vary) / 2.0, varz, z_max_ - z_min_);
+    return std::make_tuple((varx + vary) / 2.0, varz, z_max_ - z_min_+1);
 }
 #pragma endregion Reflection3D
 

--- a/spotfinder/connected_components/connected_components.cc
+++ b/spotfinder/connected_components/connected_components.cc
@@ -175,6 +175,8 @@ std::tuple<double, double, int> Reflection3D::variances_in_kabsch_space(const Ve
     int image_range_0 = scan.get_image_range()[0];
     double oscillation_width = scan.get_oscillation()[1];
     double oscillation_start = scan.get_oscillation()[0];
+    constexpr double deg_to_rad = M_PI / 180.0;
+
     for (const auto &signal : signals_) {
         double x = static_cast<double>(signal.x) + 0.5;
         double y = static_cast<double>(signal.y) + 0.5;
@@ -184,7 +186,7 @@ std::tuple<double, double, int> Reflection3D::variances_in_kabsch_space(const Ve
         Vector3d delta_s1 = s1p - s1;
         double eps1 = e1.dot(delta_s1) / mags1;
         double eps2 = e2.dot(delta_s1) / mags1;
-        double phi_dash = (oscillation_start + (z - image_range_0) * oscillation_width)  * M_PI / 180.0;
+        double phi_dash = (oscillation_start + (z - image_range_0) * oscillation_width)  * deg_to_rad;
         double eps3 = (phi_dash - phi) * zeta;
         varx += signal.intensity * eps1 * eps1;
         vary += signal.intensity * eps2 * eps2;

--- a/spotfinder/connected_components/connected_components.hpp
+++ b/spotfinder/connected_components/connected_components.hpp
@@ -6,11 +6,11 @@
 #include <boost/graph/adjacency_list.hpp>
 #include <boost/graph/connected_components.hpp>
 #include <cstdint>
+#include <dx2/detector.hpp>
+#include <dx2/scan.hpp>
 #include <map>
 #include <tuple>
 #include <vector>
-#include <dx2/detector.hpp>
-#include <dx2/scan.hpp>
 
 #include "cuda_common.hpp"
 #include "ffs_logger.hpp"
@@ -215,11 +215,11 @@ class Reflection3D {
      *
      * @return Tuple containing two variances and the number of frames used.
      */
-    std::tuple<double, double, int> variances_in_kabsch_space(const Vector3d& s1,
-                                                              const Vector3d& s0,
-                                                              const Vector3d& m2,
-                                                              const Panel& panel,
-                                                              const Scan& scan,
+    std::tuple<double, double, int> variances_in_kabsch_space(const Vector3d &s1,
+                                                              const Vector3d &s0,
+                                                              const Vector3d &m2,
+                                                              const Panel &panel,
+                                                              const Scan &scan,
                                                               const double phi) const;
 
     // Getters for bounding box

--- a/spotfinder/connected_components/connected_components.hpp
+++ b/spotfinder/connected_components/connected_components.hpp
@@ -9,6 +9,7 @@
 #include <map>
 #include <tuple>
 #include <vector>
+#include <dx2/detector.hpp>
 
 #include "cuda_common.hpp"
 #include "ffs_logger.hpp"
@@ -59,6 +60,31 @@ class Reflection3D {
         y_max_ = std::max(y_max_, signal.y);
 
         ++num_pixels_;  // Increment the number of pixels in the reflection
+    }
+
+    double kabsch_covariance(Vector3d& s1, Panel& panel, Vector3d& s0) const {
+        Vector3d e1 = s1.cross(s0);
+        e1.normalize();
+        Vector3d e2 = s1.cross(e1);
+        e2.normalize();
+        double mags1 = std::sqrt(s1.dot(s1));
+        double varx = 0;
+        double vary = 0;
+        double total_intensity = 0;
+        for (const auto &signal : signals_) {
+            double x = static_cast<double>(signal.x) + 0.5;
+            double y = static_cast<double>(signal.y) + 0.5;
+            auto [xmm, ymm] = panel.px_to_mm(x,y);
+            Vector3d delta_s1 = panel.get_lab_coord(xmm, ymm) - s1;
+            double eps1 = e1.dot(delta_s1) / mags1;
+            double eps2 = e2.dot(delta_s1) / mags1;
+            varx += signal.intensity * eps1 * eps1;
+            vary += signal.intensity * eps2 * eps2;
+            total_intensity += signal.intensity;
+        }
+        varx = varx / total_intensity;
+        vary = vary / total_intensity;
+        return (varx + vary) / 2.0 ;
     }
 
     /**

--- a/spotfinder/spotfinder.cc
+++ b/spotfinder/spotfinder.cc
@@ -1131,7 +1131,7 @@ int main(int argc, char **argv) {
         double sum_sigma_m = 0.0;
         int min_bbox_width = 4;
         int n_sigma_m = 0;
-        
+
 	      for (const auto &refl : reflections_3d){
           auto [x, y, z] = refl.center_of_mass();
           auto [xmm, ymm] = panel.px_to_mm(x,y);

--- a/spotfinder/spotfinder.cc
+++ b/spotfinder/spotfinder.cc
@@ -1151,15 +1151,17 @@ int main(int argc, char **argv) {
         // Print out the estimated average values. This is only an estimate at this stage,
         // as it will include spots that don't get indexed and which will therefore be
         // excluded when this calculation is repeated in integration.
-        if (reflections_3d.size()){
-          double est_sigma_b = std::sqrt(sum_sigma_b_variance / reflections_3d.size()) * rad_to_deg;
-          logger.info("Estimated sigma_b (degrees): {:.6f}", est_sigma_b);
+        if (reflections_3d.size()) {
+            double est_sigma_b =
+              std::sqrt(sum_sigma_b_variance / reflections_3d.size()) * rad_to_deg;
+            logger.info("Estimated sigma_b (degrees): {:.6f}", est_sigma_b);
         }
-        if (n_sigma_m){
-          double est_sigma_m = std::sqrt(sum_sigma_m_variance / n_sigma_m) * rad_to_deg;
-          logger.info("Estimated sigma_m (degrees): {:.6f}, calculated on {} spots",
-                      est_sigma_m,
-                      n_sigma_m);
+        if (n_sigma_m) {
+            double est_sigma_m =
+              std::sqrt(sum_sigma_m_variance / n_sigma_m) * rad_to_deg;
+            logger.info("Estimated sigma_m (degrees): {:.6f}, calculated on {} spots",
+                        est_sigma_m,
+                        n_sigma_m);
         }
 #pragma endregion Calculate spot variances
 

--- a/spotfinder/spotfinder.cc
+++ b/spotfinder/spotfinder.cc
@@ -14,8 +14,8 @@
 #include <chrono>
 #include <cmath>
 #include <csignal>
-#include <dx2/reflection.hpp>
 #include <dx2/detector.hpp>
+#include <dx2/reflection.hpp>
 #include <dx2/scan.hpp>
 #include <iostream>
 #include <memory>
@@ -1107,15 +1107,17 @@ int main(int argc, char **argv) {
         // integration without needing to reload data.
         // Key new metadata needed
         //  - rotation axis (default +x?)
-        std::array<int, 2> image_size = {static_cast<int>(width), static_cast<int>(height)};
-        Panel panel(
-          detector.distance,
-          {detector.beam_center_x, detector.beam_center_y},
-          {detector.pixel_size_x, detector.pixel_size_y}, image_size);
-        Vector3d s0 = {0.0,0.0,-1.0/wavelength};
-        Scan scan({1,static_cast<int>(num_images)}, {oscillation_start, oscillation_width});
+        std::array<int, 2> image_size = {static_cast<int>(width),
+                                         static_cast<int>(height)};
+        Panel panel(detector.distance,
+                    {detector.beam_center_x, detector.beam_center_y},
+                    {detector.pixel_size_x, detector.pixel_size_y},
+                    image_size);
+        Vector3d s0 = {0.0, 0.0, -1.0 / wavelength};
+        Scan scan({1, static_cast<int>(num_images)},
+                  {oscillation_start, oscillation_width});
         int image_range_0 = scan.get_image_range()[0];
-        Vector3d m2 = {1.0,0.0,0.0}; // The rotation axis, assumed to be +x.
+        Vector3d m2 = {1.0, 0.0, 0.0};  // The rotation axis, assumed to be +x.
         constexpr double deg_to_rad = M_PI / 180.0;
 
         // Data vectors for output.
@@ -1127,33 +1129,38 @@ int main(int argc, char **argv) {
         bbox_depths.reserve(reflections_3d.size());
 
         // Variables for outputting estimated global values.
-	      double sum_sigma_b_variance = 0.0;
+        double sum_sigma_b_variance = 0.0;
         double sum_sigma_m_variance = 0.0;
         int min_bbox_width = 5;
         int n_sigma_m = 0;
 
-	      for (const auto &refl : reflections_3d){
-          auto [x, y, z] = refl.center_of_mass();
-          auto [xmm, ymm] = panel.px_to_mm(x,y);
-          Vector3d s1 = panel.get_lab_coord(xmm, ymm);
-          double phi = (oscillation_start + (z - image_range_0) * oscillation_width) * deg_to_rad;
-          auto [sigma_b_variance, sigma_m_variance, bbox_depth] = refl.variances_in_kabsch_space(s1, s0, m2, panel, scan, phi);
-          sigma_b_variances.push_back(sigma_b_variance);
-          sigma_m_variances.push_back(sigma_m_variance);
-          bbox_depths.push_back(bbox_depth);
-          sum_sigma_b_variance += sigma_b_variance;
-          if (bbox_depth >= min_bbox_width){
-            sum_sigma_m_variance += sigma_m_variance;
-            n_sigma_m++;
-          }
+        for (const auto &refl : reflections_3d) {
+            auto [x, y, z] = refl.center_of_mass();
+            auto [xmm, ymm] = panel.px_to_mm(x, y);
+            Vector3d s1 = panel.get_lab_coord(xmm, ymm);
+            double phi = (oscillation_start + (z - image_range_0) * oscillation_width)
+                         * deg_to_rad;
+            auto [sigma_b_variance, sigma_m_variance, bbox_depth] =
+              refl.variances_in_kabsch_space(s1, s0, m2, panel, scan, phi);
+            sigma_b_variances.push_back(sigma_b_variance);
+            sigma_m_variances.push_back(sigma_m_variance);
+            bbox_depths.push_back(bbox_depth);
+            sum_sigma_b_variance += sigma_b_variance;
+            if (bbox_depth >= min_bbox_width) {
+                sum_sigma_m_variance += sigma_m_variance;
+                n_sigma_m++;
+            }
         }
         // Print out the estimated average values. This is only an estimate at this stage,
         // as it will include spots that don't get indexed and which will therefore be
         // excluded when this calculation is repeated in integration.
-        double est_sigma_b = std::sqrt(sum_sigma_b_variance / reflections_3d.size()) * 180 / M_PI;
+        double est_sigma_b =
+          std::sqrt(sum_sigma_b_variance / reflections_3d.size()) * 180 / M_PI;
         double est_sigma_m = std::sqrt(sum_sigma_m_variance / n_sigma_m) * 180 / M_PI;
         logger.info("Estimated sigma_b (degrees): {:.6f}", est_sigma_b);
-        logger.info("Estimated sigma_m (degrees): {:.6f}, calculated on {} spots", est_sigma_m, n_sigma_m);
+        logger.info("Estimated sigma_m (degrees): {:.6f}, calculated on {} spots",
+                    est_sigma_m,
+                    n_sigma_m);
 
         if (save_to_h5) {
             // Step 4: Write the 3D reflections to a `.h5` file using ReflectionTable
@@ -1178,8 +1185,10 @@ int main(int argc, char **argv) {
                 std::vector<int> id(reflections_3d.size(),
                                     table.get_experiment_ids()[0]);
                 table.add_column("id", reflections_3d.size(), 1, id);
-                table.add_column("sigma_b_variance", sigma_b_variances.size(), 1, sigma_b_variances);
-                table.add_column("sigma_m_variance", sigma_m_variances.size(), 1, sigma_m_variances);
+                table.add_column(
+                  "sigma_b_variance", sigma_b_variances.size(), 1, sigma_b_variances);
+                table.add_column(
+                  "sigma_m_variance", sigma_m_variances.size(), 1, sigma_m_variances);
                 table.add_column("spot_extent_z", bbox_depths.size(), 1, bbox_depths);
 
                 // Write the table to an HDF5 file

--- a/spotfinder/spotfinder.cc
+++ b/spotfinder/spotfinder.cc
@@ -1129,7 +1129,7 @@ int main(int argc, char **argv) {
         // Variables for outputting estimated global values.
 	      double sum_sigma_b_variance = 0.0;
         double sum_sigma_m_variance = 0.0;
-        int min_bbox_width = 4;
+        int min_bbox_width = 5;
         int n_sigma_m = 0;
 
 	      for (const auto &refl : reflections_3d){

--- a/spotfinder/spotfinder.cc
+++ b/spotfinder/spotfinder.cc
@@ -1113,30 +1113,31 @@ int main(int argc, char **argv) {
           {detector.beam_center_x, detector.beam_center_y},
           {detector.pixel_size_x, detector.pixel_size_y}, image_size);
         Vector3d s0 = {0.0,0.0,-1.0/wavelength};
-
-	std::vector<double> sigma_bs;
-	std::vector<double> sigma_ms;
-	std::vector<int> bbox_depths;
-	sigma_bs.reserve(reflections_3d.size());
-	sigma_ms.reserve(reflections_3d.size());
-	bbox_depths.reserve(reflections_3d.size());
-
-	Scan scan({1,static_cast<int>(num_images)}, {oscillation_start, oscillation_width});
+        Scan scan({1,static_cast<int>(num_images)}, {oscillation_start, oscillation_width});
         int image_range_0 = scan.get_image_range()[0];
         Vector3d m2 = {1.0,0.0,0.0}; // The rotation axis, assumed to be +x.
+        constexpr double deg_to_rad = M_PI / 180.0;
 
-	double sum_sigma_b = 0.0;
+        // Data vectors for output.
+        std::vector<double> sigma_bs;
+        std::vector<double> sigma_ms;
+        std::vector<int> bbox_depths;
+        sigma_bs.reserve(reflections_3d.size());
+        sigma_ms.reserve(reflections_3d.size());
+        bbox_depths.reserve(reflections_3d.size());
+
+        // Variables for outputting estimated global values.
+	      double sum_sigma_b = 0.0;
         double sum_sigma_m = 0.0;
         int min_bbox_width = 4;
         int n_sigma_m = 0;
-        constexpr double deg_to_rad = M_PI / 180.0;
-
-	for (const auto &refl : reflections_3d){
+        
+	      for (const auto &refl : reflections_3d){
           auto [x, y, z] = refl.center_of_mass();
           auto [xmm, ymm] = panel.px_to_mm(x,y);
           Vector3d s1 = panel.get_lab_coord(xmm, ymm);
           double phi = (oscillation_start + (z - image_range_0) * oscillation_width) * deg_to_rad;
-          auto [sigma_b, sigma_m, bbox_depth] = refl.kabsch_covariance(s1, panel, s0, m2, scan, phi);
+          auto [sigma_b, sigma_m, bbox_depth] = refl.variances_in_kabsch_space(s1, s0, m2, panel, scan, phi);
           sigma_bs.push_back(sigma_b);
           sigma_ms.push_back(sigma_m);
           bbox_depths.push_back(bbox_depth);

--- a/spotfinder/spotfinder.cc
+++ b/spotfinder/spotfinder.cc
@@ -1105,6 +1105,10 @@ int main(int argc, char **argv) {
 
         // Calculate sigma_b and sigma_m for each spot, so that we have this value for
         // integration without needing to reload data.
+        // Key new metadata needed
+        //  - image size (x,y),
+        //  - oscillation width,
+        //  - rotation axis (default +x?)
         std::array<int, 2> image_size{{4148,4362}};
         Panel panel(
           detector.distance,

--- a/tests/test_spotfinder.py
+++ b/tests/test_spotfinder.py
@@ -110,8 +110,8 @@ def test_dispersion(dials_data, tmp_path):
         assert np.max(spot_extent) == 10.0
         sigma_b_variance = file["/dials/processing/group_0/sigma_b_variance"]
         sigma_m_variance = file["/dials/processing/group_0/sigma_m_variance"]
-        assert np.mean(sigma_b_variance) == pytest.approx(4.105648E-8, rel=1e-4)
-        assert np.mean(sigma_m_variance) == pytest.approx(8.60468E-7, rel=1e-4)
+        assert np.mean(sigma_b_variance) == pytest.approx(4.105648e-8, rel=1e-4)
+        assert np.mean(sigma_m_variance) == pytest.approx(8.60468e-7, rel=1e-4)
 
 
 def test_dispersion_dmin(dials_data, tmp_path):

--- a/tests/test_spotfinder.py
+++ b/tests/test_spotfinder.py
@@ -104,6 +104,14 @@ def test_dispersion(dials_data, tmp_path):
         assert minimum.tolist() == pytest.approx([388.14, 208.50, 0.50], abs=5e-3)
         assert maximum.tolist() == pytest.approx([4071.50, 4297.79, 9.50], abs=5e-3)
         assert mean.tolist() == pytest.approx([2074.33, 2117.60, 4.79], abs=5e-3)
+        ## Test that the spot variance quantities are output.
+        spot_extent = file["/dials/processing/group_0/spot_extent_z"]
+        assert np.min(spot_extent) == 1.0
+        assert np.max(spot_extent) == 10.0
+        sigma_b_variance = file["/dials/processing/group_0/sigma_b_variance"]
+        sigma_m_variance = file["/dials/processing/group_0/sigma_m_variance"]
+        assert np.mean(sigma_b_variance) == pytest.approx(4.105648E-8, rel=1e-4)
+        assert np.mean(sigma_m_variance) == pytest.approx(8.60468E-7, rel=1e-4)
 
 
 def test_dispersion_dmin(dials_data, tmp_path):


### PR DESCRIPTION
Calculate per-spot variances in the Kabsch coordinate frame at the end of 3D spot finding, and save into the output reflection table.
This calculation requires the spot pixel intensity data; performing the calculation here where we already have the data means we can avoid needing to do this at the start of integration, and hence avoid the need for saving "shoebox" data.

Ideally the rotation axis would be available through the readers, assumed to be +x for now.