### PR TITLE
Fix 32bit data handling

### DIFF
--- a/h5read/src/read_chunks.cc
+++ b/h5read/src/read_chunks.cc
@@ -12,7 +12,7 @@ int main(int argc, char **argv) {
     size_t n_images = reader.get_number_of_images();
     size_t num_pixels = reader.get_image_slow() * reader.get_image_fast();
 
-    auto buffer = std::vector<uint8_t>(num_pixels * 2);
+    auto buffer = std::vector<uint8_t>(num_pixels * sizeof(image_t_type));
     auto image = std::vector<H5Read::image_type>(num_pixels);
 
     auto start_time = std::chrono::high_resolution_clock::now();
@@ -20,7 +20,8 @@ int main(int argc, char **argv) {
         auto data = reader.get_raw_chunk(j, buffer);
 
         // Decompress this
-        bshuf_decompress_lz4(buffer.data() + 12, image.data(), num_pixels, 2, 0);
+        bshuf_decompress_lz4(
+          buffer.data() + 12, image.data(), num_pixels, sizeof(image_t_type), 0);
 
         printf("Read Image %d chunk of %zu KBytes\n", j, data.size() / 1024);
     }

--- a/spotfinder/shmread.cc
+++ b/spotfinder/shmread.cc
@@ -27,9 +27,16 @@ SHMRead::SHMRead(const std::string &path) : _base_path(path) {
 
     uint8_t bit_depth_image = data["bit_depth_image"].template get<uint8_t>();
 
-    if (bit_depth_image != 16) {
+    // Validate that compile-time type matches runtime data
+#ifdef PIXEL_DATA_32BIT
+    constexpr uint8_t expected_bits = 32;
+#else
+    constexpr uint8_t expected_bits = 16;
+#endif
+
+    if (bit_depth_image != expected_bits) {
         throw std::runtime_error(fmt::format(
-          "Can not read image with bit_depth_image={}, only 16", bit_depth_image));
+          "Data is {}-bit but compiled for {}-bit", bit_depth_image, expected_bits));
     }
     _trusted_range = {
       0, data["countrate_correction_count_cutoff"].template get<image_t_type>()};

--- a/spotfinder/spotfinder.cc
+++ b/spotfinder/spotfinder.cc
@@ -781,15 +781,10 @@ int main(int argc, char **argv) {
                                          0);
                     break;
                 case Reader::ChunkCompression::BYTE_OFFSET_32:
-                    // decompress_byte_offset<pixel_t>(buffer,
-                    //                                 {host_image.get(), width * height});
                     decompress_byte_offset<pixel_t>(
                       buffer,
                       {host_image.get(),
-                       static_cast<std::span<short unsigned int>::size_type>(
-                         width * height)});
-                    // std::copy(buffer.begin(), buffer.end(), host_image.get());
-                    // std::exit(1);
+                       static_cast<std::span<pixel_t>::size_type>(width * height)});
                     break;
                 }
 


### PR DESCRIPTION
This PR updates `shmread` to handle 32-bit data correctly.

It also refactors a couple hard-coded data types to properly handle this
configurable data size.

Closes: #64