### PR TITLE
Add h5read test to demo h5read failure

### DIFF
--- a/h5read/CMakeLists.txt
+++ b/h5read/CMakeLists.txt
@@ -16,6 +16,8 @@ add_library(h5read STATIC src/h5read.c src/h5read.cc)
 target_include_directories(h5read PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include )
 target_link_libraries(h5read PUBLIC $<TARGET_NAME_IF_EXISTS:hdf5::hdf5> $<TARGET_NAME_IF_EXISTS:compile_options>)
   
+add_subdirectory(tests)
+
 if (TARGET hdf5::hdf5)
   add_compile_definitions(HAVE_HDF5)
   # Problem:
@@ -50,3 +52,5 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR OR H5READ_BUILD_EXE)
         target_link_libraries(read_chunks_cpp PUBLIC h5read LZ4::LZ4 Bitshuffle::bitshuffle)
     endif()
 endif()
+
+

--- a/h5read/src/h5read.c
+++ b/h5read/src/h5read.c
@@ -55,6 +55,10 @@ struct _h5read_handle {
     float oscillation_width;
 };
 
+#ifdef HAVE_HDF5
+static h5read_dtype _detect_hdf5_dtype(hid_t datatype);
+#endif
+
 /// Validate that the HDF5 datatype size matches the expected pixel data size.
 ///
 /// Note that this is only used when trying to extract image data directly,
@@ -91,8 +95,12 @@ h5read_dtype h5read_get_dtype(h5read_handle *obj) {
 void h5read_free(h5read_handle *obj) {
 #ifdef HAVE_HDF5
     for (int i = 0; i < obj->data_file_count; i++) {
-        H5Dclose(obj->data_files[i].dataset);
-        H5Fclose(obj->data_files[i].file);
+        if (obj->data_files[i].dataset != 0) {
+            H5Dclose(obj->data_files[i].dataset);
+        }
+        if (obj->data_files[i].file != 0) {
+            H5Fclose(obj->data_files[i].file);
+        }
     }
     if (obj->master_file) H5Fclose(obj->master_file);
 #endif
@@ -295,28 +303,128 @@ int _find_data_file_for_image(h5read_handle *obj, size_t *index) {
     return data_file;
 }
 
-size_t h5read_get_chunk_size(h5read_handle *obj, size_t index) {
-    if (obj->data_files == 0) {
-        fprintf(stderr, "Error: Cannot do direct chunk read with sample data\n", index);
+/// Get the data file object, opening the data file if possible.
+///
+/// This will always return (barring fatal errors) a valid h5_data_file
+/// object. The .file and .dataset members may not be present, if the
+/// file can not be currently opened.
+h5_data_file *get_data_file(h5read_handle *obj, size_t index) {
+    if (index >= obj->data_file_count) {
+        fprintf(stderr, "Error: Could not find data file for frame %ld\n", index);
         exit(1);
     }
+    h5_data_file *current = &(obj->data_files[index]);
+    if (current->file == 0) {
+        if (access(current->filename, F_OK) == 0) {
+            printf("Opening data file %s\n", current->filename);
+            hid_t file = H5Fopen(
+              current->filename, H5F_ACC_RDONLY | H5F_ACC_SWMR_READ, H5P_DEFAULT);
+            // Failing to open a data file isn't necessarily an error - it could not exist yet
+            if (file > 0) {
+                current->file = file;
+            }
+        }
+    }
+    if (current->file != 0 && current->dataset == 0) {
+        hid_t dataset = H5Dopen(current->file, current->dsetname, H5P_DEFAULT);
+        if (dataset < 0) {
+            fprintf(
+              stderr, "Error: Reading datasets of child file %s\n", current->filename);
+            exit(1);
+        }
+        current->dataset = dataset;
+        // Now we have a dataset, validate that it matches our expected layout
+        hid_t datatype = H5Dget_type(dataset);
+        // For now, with our basic dtype approach, verify this matches
+        if (_detect_hdf5_dtype(datatype) != obj->dtype) {
+            fprintf(stderr,
+                    "Fatal Error: Child data set in %s does not match VDS datatype\n",
+                    current->filename);
+            exit(1);
+        }
+        H5Tclose(datatype);
+        hid_t space = H5Dget_space(dataset);
+        if (H5Sget_simple_extent_ndims(space) != 3) {
+            fprintf(stderr,
+                    "Error: Data file %s data are not three dimensional\n",
+                    current->filename);
+            exit(1);
+        }
+        hsize_t dims[3];
+        H5Sget_simple_extent_dims(space, dims, NULL);
+        H5Sclose(space);
+        // Do a load of validation that this data file matches what we expect
+        if (dims[0] != current->frames) {
+            fprintf(
+              stderr,
+              "Validation Error: Data file %s data has %ld frames, expected %ld\n",
+              current->filename,
+              dims[0],
+              current->frames);
+            exit(1);
+        }
+        if (dims[1] != obj->slow) {
+            fprintf(
+              stderr,
+              "Validation Error: Data file %s slow data has %ld pixels, expected %ld\n",
+              current->filename,
+              dims[1],
+              obj->slow);
+            exit(1);
+        }
+        if (dims[2] != obj->fast) {
+            fprintf(
+              stderr,
+              "Validation Error: Data file %s fast data has %ld pixels, expected %ld\n",
+              current->filename,
+              dims[2],
+              obj->fast);
+            exit(1);
+        }
+    }
+    return current;
+}
+
+size_t h5read_get_chunk_size(h5read_handle *obj, size_t index) {
 #ifdef HAVE_HDF5
     int data_file = _find_data_file_for_image(obj, &index);
     if (data_file == obj->data_file_count) {
         fprintf(stderr, "Error: Could not find data file for frame %ld\n", index);
         exit(1);
     }
-    h5_data_file *current = &(obj->data_files[data_file]);
-
+    h5_data_file *current = get_data_file(obj, data_file);
+    // Count a missing file as "zero" size for the dataset
+    if (current->file == 0) {
+        return 0;
+    }
     hsize_t offset[3] = {index + current->offset, 0, 0};
     hsize_t chunk_size = 0;
-    // H5Drefresh(current->dataset);
+
+    // No way to check without hitting HDF5 error handler if it is missing,
+    // and thus a whole load of error output. Save and clear the error
+    // handler for this call so we don't hit that.
+    H5E_auto2_t old_func;
+    void *old_data;
+    H5Eget_auto(H5E_DEFAULT, &old_func, &old_data);
+    H5Eset_auto(H5E_DEFAULT, NULL, NULL);
+    // Check to see if this chunk is allocated yet
     H5Dget_chunk_storage_size(current->dataset, offset, &chunk_size);
-#endif
+
+    // If this failed, refresh the file then try again
+    if (chunk_size <= 0) {
+        H5Drefresh(current->dataset);
+        H5Dget_chunk_storage_size(current->dataset, offset, &chunk_size);
+    }
+    // Restore error handler
+    H5Eset_auto(H5E_DEFAULT, old_func, old_data);
     if (chunk_size < 0) {
         return 0;
     }
     return (size_t)chunk_size;
+#else
+    fprintf(stderr, "Error: Cannot do direct chunk read with sample data\n", index);
+    exit(1);
+#endif
 }
 
 void h5read_get_raw_chunk(h5read_handle *obj,
@@ -334,8 +442,12 @@ void h5read_get_raw_chunk(h5read_handle *obj,
         fprintf(stderr, "Error: Could not find data file for frame %ld\n", index);
         exit(1);
     }
-    h5_data_file *current = &(obj->data_files[data_file]);
-
+    h5_data_file *current = get_data_file(obj, data_file);
+    // Count a missing file as fatal error here
+    if (current->file == 0) {
+        fprintf(stderr, "Error: Trying to read raw chunk for missing file\n");
+        exit(1);
+    }
     hsize_t offset[3] = {index + current->offset, 0, 0};
     hsize_t chunk_size = 0;
     H5Dget_chunk_storage_size(current->dataset, offset, &chunk_size);
@@ -899,7 +1011,7 @@ int vds_info(char *root, hid_t master, hid_t dataset, h5_data_file **data_files_
             strcpy(vds[j].filename, scr);
         }
 
-        // do I want to open these here? Or when they are needed...
+        // These will be opened when required
         vds[j].file = 0;
         vds[j].dataset = 0;
     }
@@ -975,24 +1087,27 @@ static h5read_dtype _detect_hdf5_dtype(hid_t datatype) {
 }
 
 void setup_data(h5read_handle *obj) {
-    hid_t dataset = obj->data_files[0].dataset;
-    hid_t datatype = H5Dget_type(dataset);
+    hid_t vds_dataset = H5Dopen2(obj->master_file, "/entry/data/data", H5P_DEFAULT);
+
+    hid_t datatype = H5Dget_type(vds_dataset);
     obj->dtype = _detect_hdf5_dtype(datatype);
 
-    hid_t space = H5Dget_space(dataset);
+    hid_t space = H5Dget_space(vds_dataset);
 
     if (H5Sget_simple_extent_ndims(space) != 3) {
-        fprintf(stderr, "raw data not three dimensional\n");
+        fprintf(stderr, "VDS data not three dimensional\n");
         exit(1);
     }
 
     hsize_t dims[3];
     H5Sget_simple_extent_dims(space, dims, NULL);
 
+    obj->frames = dims[0];
     obj->slow = dims[1];
     obj->fast = dims[2];
 
     printf("Total data size: %ldx%ldx%ld\n", obj->frames, obj->slow, obj->fast);
+    H5Dclose(vds_dataset);
     H5Sclose(space);
 }
 
@@ -1016,32 +1131,6 @@ h5read_handle *h5read_open(const char *master_filename) {
         H5Fclose(master_file);
         free(file);
         return NULL;
-    }
-
-    // open up the actual data files, count all the frames
-    file->frames = 0;
-    h5_data_file *data_files = file->data_files;
-    for (int j = 0; j < file->data_file_count; j++) {
-        data_files[j].file = H5Fopen(
-          data_files[j].filename, H5F_ACC_RDONLY | H5F_ACC_SWMR_READ, H5P_DEFAULT);
-        if (data_files[j].file < 0) {
-            fprintf(stderr, "Error: Opening child file %s\n", data_files[j].filename);
-            H5Fclose(master_file);
-            free(file);
-            return NULL;
-        }
-        data_files[j].dataset =
-          H5Dopen(data_files[j].file, data_files[j].dsetname, H5P_DEFAULT);
-        if (data_files[j].dataset < 0) {
-            fprintf(stderr,
-                    "Error: Reading datasets of child file %s\n",
-                    data_files[j].filename);
-            H5Fclose(data_files[j].file);
-            H5Fclose(master_file);
-            free(file);
-            return NULL;
-        }
-        file->frames += data_files[j].frames;
     }
 
     read_trusted_range(file);

--- a/h5read/src/h5read.c
+++ b/h5read/src/h5read.c
@@ -55,10 +55,6 @@ struct _h5read_handle {
     float oscillation_width;
 };
 
-#ifdef HAVE_HDF5
-static h5read_dtype _detect_hdf5_dtype(hid_t datatype);
-#endif
-
 /// Validate that the HDF5 datatype size matches the expected pixel data size.
 ///
 /// Note that this is only used when trying to extract image data directly,
@@ -95,12 +91,8 @@ h5read_dtype h5read_get_dtype(h5read_handle *obj) {
 void h5read_free(h5read_handle *obj) {
 #ifdef HAVE_HDF5
     for (int i = 0; i < obj->data_file_count; i++) {
-        if (obj->data_files[i].dataset != 0) {
-            H5Dclose(obj->data_files[i].dataset);
-        }
-        if (obj->data_files[i].file != 0) {
-            H5Fclose(obj->data_files[i].file);
-        }
+        H5Dclose(obj->data_files[i].dataset);
+        H5Fclose(obj->data_files[i].file);
     }
     if (obj->master_file) H5Fclose(obj->master_file);
 #endif
@@ -303,128 +295,28 @@ int _find_data_file_for_image(h5read_handle *obj, size_t *index) {
     return data_file;
 }
 
-/// Get the data file object, opening the data file if possible.
-///
-/// This will always return (barring fatal errors) a valid h5_data_file
-/// object. The .file and .dataset members may not be present, if the
-/// file can not be currently opened.
-h5_data_file *get_data_file(h5read_handle *obj, size_t index) {
-    if (index >= obj->data_file_count) {
-        fprintf(stderr, "Error: Could not find data file for frame %ld\n", index);
+size_t h5read_get_chunk_size(h5read_handle *obj, size_t index) {
+    if (obj->data_files == 0) {
+        fprintf(stderr, "Error: Cannot do direct chunk read with sample data\n", index);
         exit(1);
     }
-    h5_data_file *current = &(obj->data_files[index]);
-    if (current->file == 0) {
-        if (access(current->filename, F_OK) == 0) {
-            printf("Opening data file %s\n", current->filename);
-            hid_t file = H5Fopen(
-              current->filename, H5F_ACC_RDONLY | H5F_ACC_SWMR_READ, H5P_DEFAULT);
-            // Failing to open a data file isn't necessarily an error - it could not exist yet
-            if (file > 0) {
-                current->file = file;
-            }
-        }
-    }
-    if (current->file != 0 && current->dataset == 0) {
-        hid_t dataset = H5Dopen(current->file, current->dsetname, H5P_DEFAULT);
-        if (dataset < 0) {
-            fprintf(
-              stderr, "Error: Reading datasets of child file %s\n", current->filename);
-            exit(1);
-        }
-        current->dataset = dataset;
-        // Now we have a dataset, validate that it matches our expected layout
-        hid_t datatype = H5Dget_type(dataset);
-        // For now, with our basic dtype approach, verify this matches
-        if (_detect_hdf5_dtype(datatype) != obj->dtype) {
-            fprintf(stderr,
-                    "Fatal Error: Child data set in %s does not match VDS datatype\n",
-                    current->filename);
-            exit(1);
-        }
-        H5Tclose(datatype);
-        hid_t space = H5Dget_space(dataset);
-        if (H5Sget_simple_extent_ndims(space) != 3) {
-            fprintf(stderr,
-                    "Error: Data file %s data are not three dimensional\n",
-                    current->filename);
-            exit(1);
-        }
-        hsize_t dims[3];
-        H5Sget_simple_extent_dims(space, dims, NULL);
-        H5Sclose(space);
-        // Do a load of validation that this data file matches what we expect
-        if (dims[0] != current->frames) {
-            fprintf(
-              stderr,
-              "Validation Error: Data file %s data has %ld frames, expected %ld\n",
-              current->filename,
-              dims[0],
-              current->frames);
-            exit(1);
-        }
-        if (dims[1] != obj->slow) {
-            fprintf(
-              stderr,
-              "Validation Error: Data file %s slow data has %ld pixels, expected %ld\n",
-              current->filename,
-              dims[1],
-              obj->slow);
-            exit(1);
-        }
-        if (dims[2] != obj->fast) {
-            fprintf(
-              stderr,
-              "Validation Error: Data file %s fast data has %ld pixels, expected %ld\n",
-              current->filename,
-              dims[2],
-              obj->fast);
-            exit(1);
-        }
-    }
-    return current;
-}
-
-size_t h5read_get_chunk_size(h5read_handle *obj, size_t index) {
 #ifdef HAVE_HDF5
     int data_file = _find_data_file_for_image(obj, &index);
     if (data_file == obj->data_file_count) {
         fprintf(stderr, "Error: Could not find data file for frame %ld\n", index);
         exit(1);
     }
-    h5_data_file *current = get_data_file(obj, data_file);
-    // Count a missing file as "zero" size for the dataset
-    if (current->file == 0) {
-        return 0;
-    }
+    h5_data_file *current = &(obj->data_files[data_file]);
+
     hsize_t offset[3] = {index + current->offset, 0, 0};
     hsize_t chunk_size = 0;
-
-    // No way to check without hitting HDF5 error handler if it is missing,
-    // and thus a whole load of error output. Save and clear the error
-    // handler for this call so we don't hit that.
-    H5E_auto2_t old_func;
-    void *old_data;
-    H5Eget_auto(H5E_DEFAULT, &old_func, &old_data);
-    H5Eset_auto(H5E_DEFAULT, NULL, NULL);
-    // Check to see if this chunk is allocated yet
+    // H5Drefresh(current->dataset);
     H5Dget_chunk_storage_size(current->dataset, offset, &chunk_size);
-
-    // If this failed, refresh the file then try again
-    if (chunk_size <= 0) {
-        H5Drefresh(current->dataset);
-        H5Dget_chunk_storage_size(current->dataset, offset, &chunk_size);
-    }
-    // Restore error handler
-    H5Eset_auto(H5E_DEFAULT, old_func, old_data);
+#endif
     if (chunk_size < 0) {
         return 0;
     }
     return (size_t)chunk_size;
-#else
-    fprintf(stderr, "Error: Cannot do direct chunk read with sample data\n", index);
-    exit(1);
-#endif
 }
 
 void h5read_get_raw_chunk(h5read_handle *obj,
@@ -442,12 +334,8 @@ void h5read_get_raw_chunk(h5read_handle *obj,
         fprintf(stderr, "Error: Could not find data file for frame %ld\n", index);
         exit(1);
     }
-    h5_data_file *current = get_data_file(obj, data_file);
-    // Count a missing file as fatal error here
-    if (current->file == 0) {
-        fprintf(stderr, "Error: Trying to read raw chunk for missing file\n");
-        exit(1);
-    }
+    h5_data_file *current = &(obj->data_files[data_file]);
+
     hsize_t offset[3] = {index + current->offset, 0, 0};
     hsize_t chunk_size = 0;
     H5Dget_chunk_storage_size(current->dataset, offset, &chunk_size);
@@ -1011,7 +899,7 @@ int vds_info(char *root, hid_t master, hid_t dataset, h5_data_file **data_files_
             strcpy(vds[j].filename, scr);
         }
 
-        // These will be opened when required
+        // do I want to open these here? Or when they are needed...
         vds[j].file = 0;
         vds[j].dataset = 0;
     }
@@ -1087,27 +975,24 @@ static h5read_dtype _detect_hdf5_dtype(hid_t datatype) {
 }
 
 void setup_data(h5read_handle *obj) {
-    hid_t vds_dataset = H5Dopen2(obj->master_file, "/entry/data/data", H5P_DEFAULT);
-
-    hid_t datatype = H5Dget_type(vds_dataset);
+    hid_t dataset = obj->data_files[0].dataset;
+    hid_t datatype = H5Dget_type(dataset);
     obj->dtype = _detect_hdf5_dtype(datatype);
 
-    hid_t space = H5Dget_space(vds_dataset);
+    hid_t space = H5Dget_space(dataset);
 
     if (H5Sget_simple_extent_ndims(space) != 3) {
-        fprintf(stderr, "VDS data not three dimensional\n");
+        fprintf(stderr, "raw data not three dimensional\n");
         exit(1);
     }
 
     hsize_t dims[3];
     H5Sget_simple_extent_dims(space, dims, NULL);
 
-    obj->frames = dims[0];
     obj->slow = dims[1];
     obj->fast = dims[2];
 
     printf("Total data size: %ldx%ldx%ld\n", obj->frames, obj->slow, obj->fast);
-    H5Dclose(vds_dataset);
     H5Sclose(space);
 }
 
@@ -1131,6 +1016,32 @@ h5read_handle *h5read_open(const char *master_filename) {
         H5Fclose(master_file);
         free(file);
         return NULL;
+    }
+
+    // open up the actual data files, count all the frames
+    file->frames = 0;
+    h5_data_file *data_files = file->data_files;
+    for (int j = 0; j < file->data_file_count; j++) {
+        data_files[j].file = H5Fopen(
+          data_files[j].filename, H5F_ACC_RDONLY | H5F_ACC_SWMR_READ, H5P_DEFAULT);
+        if (data_files[j].file < 0) {
+            fprintf(stderr, "Error: Opening child file %s\n", data_files[j].filename);
+            H5Fclose(master_file);
+            free(file);
+            return NULL;
+        }
+        data_files[j].dataset =
+          H5Dopen(data_files[j].file, data_files[j].dsetname, H5P_DEFAULT);
+        if (data_files[j].dataset < 0) {
+            fprintf(stderr,
+                    "Error: Reading datasets of child file %s\n",
+                    data_files[j].filename);
+            H5Fclose(data_files[j].file);
+            H5Fclose(master_file);
+            free(file);
+            return NULL;
+        }
+        file->frames += data_files[j].frames;
     }
 
     read_trusted_range(file);

--- a/h5read/tests/CMakeLists.txt
+++ b/h5read/tests/CMakeLists.txt
@@ -1,0 +1,15 @@
+include(GoogleTest)
+
+execute_process(
+    COMMAND dials.data get -q thaumatin_i03_rotation
+    OUTPUT_VARIABLE THAUMATIN_PATH
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+add_compile_definitions(THAUMATIN_DATA_PATH="${THAUMATIN_PATH}")
+
+add_executable(test_h5read test_h5read.cc)
+target_include_directories(test_h5read PRIVATE "${PROJECT_SOURCE_DIR}")
+target_link_libraries(test_h5read GTest::gtest_main h5read)
+
+gtest_discover_tests(test_h5read PROPERTIES LABELS h5read-tests)

--- a/h5read/tests/test_h5read.cc
+++ b/h5read/tests/test_h5read.cc
@@ -1,0 +1,37 @@
+
+#include <gtest/gtest.h>
+#include "h5read.h"
+
+
+#ifndef THAUMATIN_DATA_PATH
+#error "THAUMATIN_DATA_PATH not set"
+#endif
+
+
+TEST(H5read, test_h5read){
+    std::string filename = std::string(THAUMATIN_DATA_PATH) + "/thau_2_1.nxs";
+    h5read_handle *obj = h5read_open(filename.c_str());
+    size_t n_images = h5read_get_number_of_images(obj);
+    uint16_t image_slow = h5read_get_image_slow(obj);
+    uint16_t image_fast = h5read_get_image_fast(obj);
+
+    std::unordered_map<int, int> total_counts_by_image;
+
+    for (size_t j = 0; j < 5; j++) {
+        image_t *image = h5read_get_image(obj, j);
+        int total = 0;
+        for (int index = 0; index<image_fast*image_slow; index++){
+            if (image->mask[index] != 0){
+                total += image->data[index];
+            }
+        }
+        total_counts_by_image[j] = total;
+    }
+    EXPECT_EQ(total_counts_by_image[0], 504245);
+    EXPECT_EQ(total_counts_by_image[1], 503554);
+    EXPECT_EQ(total_counts_by_image[2], 506110);
+    EXPECT_EQ(total_counts_by_image[3], 505984);
+    EXPECT_EQ(total_counts_by_image[4], 502084);
+}
+
+

--- a/h5read/tests/test_h5read.cc
+++ b/h5read/tests/test_h5read.cc
@@ -10,28 +10,27 @@
 
 TEST(H5read, test_h5read){
     std::string filename = std::string(THAUMATIN_DATA_PATH) + "/thau_2_1.nxs";
-    h5read_handle *obj = h5read_open(filename.c_str());
-    size_t n_images = h5read_get_number_of_images(obj);
-    uint16_t image_slow = h5read_get_image_slow(obj);
-    uint16_t image_fast = h5read_get_image_fast(obj);
+    auto reader = H5Read(filename);
+    auto [image_slow, image_fast] = reader.image_shape();
+    auto mask = reader.get_mask().value();
 
     std::unordered_map<int, int> total_counts_by_image;
 
-    for (size_t j = 0; j < 5; j++) {
-        image_t *image = h5read_get_image(obj, j);
-        int total = 0;
-        for (int index = 0; index<image_fast*image_slow; index++){
-            if (image->mask[index] != 0){
-                total += image->data[index];
+    for (size_t j = 0; j < 3; j++) {
+        if (reader.is_image_available(j)){
+            auto image = reader.get_image(j);
+            int total = 0;
+            for (int index = 0; index<image_fast*image_slow; index++){
+                if (mask[index] != 0){
+                    total += image.data.data()[index];
+                }
             }
+            total_counts_by_image[j] = total;
         }
-        total_counts_by_image[j] = total;
     }
     EXPECT_EQ(total_counts_by_image[0], 504245);
     EXPECT_EQ(total_counts_by_image[1], 503554);
     EXPECT_EQ(total_counts_by_image[2], 506110);
-    EXPECT_EQ(total_counts_by_image[3], 505984);
-    EXPECT_EQ(total_counts_by_image[4], 502084);
 }
 
 

--- a/h5read/tests/test_h5read.cc
+++ b/h5read/tests/test_h5read.cc
@@ -1,14 +1,13 @@
 
 #include <gtest/gtest.h>
-#include "h5read.h"
 
+#include "h5read.h"
 
 #ifndef THAUMATIN_DATA_PATH
 #error "THAUMATIN_DATA_PATH not set"
 #endif
 
-
-TEST(H5read, test_h5read){
+TEST(H5read, test_h5read) {
     std::string filename = std::string(THAUMATIN_DATA_PATH) + "/thau_2_1.nxs";
     auto reader = H5Read(filename);
     auto [image_slow, image_fast] = reader.image_shape();
@@ -17,11 +16,11 @@ TEST(H5read, test_h5read){
     std::unordered_map<int, int> total_counts_by_image;
 
     for (size_t j = 0; j < 3; j++) {
-        if (reader.is_image_available(j)){
+        if (reader.is_image_available(j)) {
             auto image = reader.get_image(j);
             int total = 0;
-            for (int index = 0; index<image_fast*image_slow; index++){
-                if (mask[index] != 0){
+            for (int index = 0; index < image_fast * image_slow; index++) {
+                if (mask[index] != 0) {
                     total += image.data.data()[index];
                 }
             }
@@ -32,5 +31,3 @@ TEST(H5read, test_h5read){
     EXPECT_EQ(total_counts_by_image[1], 503554);
     EXPECT_EQ(total_counts_by_image[2], 506110);
 }
-
-


### PR DESCRIPTION
While trying to develop a baseline integrator, I was having issues reading images with h5read, encountering this error:
```
HDF5-DIAG: Error detected in HDF5 (1.14.6) thread 1:
  #000: H5D.c line 602 in H5Dget_space(): unable to synchronously get dataspace
    major: Dataset
    minor: Can't get value
  #001: H5D.c line 563 in H5D__get_space_api_common(): invalid dataset identifier
    major: Invalid arguments to routine
    minor: Inappropriate type
  #002: H5VLint.c line 1786 in H5VL_vol_object_verify(): identifier is not of specified type
    major: Invalid arguments to routine
    minor: Inappropriate type
HDF5-DIAG: Error detected in HDF5 (1.14.6) thread 1:
  #000: H5D.c line 713 in H5Dget_type(): invalid dataset identifier
    major: Invalid arguments to routine
    minor: Inappropriate type
  #001: H5VLint.c line 1786 in H5VL_vol_object_verify(): identifier is not of specified type
    major: Invalid arguments to routine
    minor: Inappropriate type
HDF5-DIAG: Error detected in HDF5 (1.14.6) thread 1:
  #000: H5T.c line 2440 in H5Tget_size(): not a datatype
    major: Invalid arguments to routine
    minor: Inappropriate type
Error: Expected 16-bit data but got 0 bytes. Use -DPIXEL_DATA_32BIT=ON for 32-bit data.
```
However I notice that if I revert the recent changes to h5read, the function works fine and can read the data without problem. I guess either the metadata in the file is not quite right, or things aren't quite initialized correctly, but it's not clear from the changeset what the issue precisely is.

This PR has two commits, the first adds a test which fails, the second reverts the h5read commit as a demo that commit it is the cause. I'm not planning to merge this PR as is, but would be good to add the test file once the issue is resolved.

To run the test after building: `ctest -L h5read-tests --output-on-failure`