### PR TITLE
Complete the baseline summation integrator

### DIFF
--- a/baseline/integrator/CMakeLists.txt
+++ b/baseline/integrator/CMakeLists.txt
@@ -13,6 +13,7 @@ target_link_libraries(baseline_integrator
     PRIVATE
     fmt
     dx2
+    h5read
     Eigen3::Eigen
     argparse
     nlohmann_json::nlohmann_json

--- a/baseline/integrator/background.cc
+++ b/baseline/integrator/background.cc
@@ -1,47 +1,47 @@
-#include <vector>
-#include <unordered_map>
 #include <algorithm>
 #include <cstddef>
+#include <unordered_map>
+#include <vector>
 
 constexpr std::size_t VECTOR_LIMIT = 64;
 
 class BackgroundAggregator {
-    public:
-        BackgroundAggregator(){}
-        void add(int x){
-            if (x >= 0 && x < VECTOR_LIMIT) {
-                ++_small_hist[x];
-            } else {
-                ++_large_hist[x];
-            }
-            ++n_pixels;
+  public:
+    BackgroundAggregator() {}
+    void add(int x) {
+        if (x >= 0 && x < VECTOR_LIMIT) {
+            ++_small_hist[x];
+        } else {
+            ++_large_hist[x];
         }
-        int num_pixels() const {
-            return n_pixels;
-        }
-        std::vector<std::size_t> small_hist() const {
-            return _small_hist;
-        }
-        std::unordered_map<int, std::size_t> large_hist() const {
-            return _large_hist;
-        }
-    private:
-        std::vector<std::size_t> _small_hist = std::vector<std::size_t>(VECTOR_LIMIT, 0);
-        std::unordered_map<int, std::size_t> _large_hist;
-        int n_pixels = 0;
-};
+        ++n_pixels;
+    }
+    int num_pixels() const {
+        return n_pixels;
+    }
+    std::vector<std::size_t> small_hist() const {
+        return _small_hist;
+    }
+    std::unordered_map<int, std::size_t> large_hist() const {
+        return _large_hist;
+    }
 
+  private:
+    std::vector<std::size_t> _small_hist = std::vector<std::size_t>(VECTOR_LIMIT, 0);
+    std::unordered_map<int, std::size_t> _large_hist;
+    int n_pixels = 0;
+};
 
 // Compute constant 3d glm background model
 // int min_pixels=10
 
 // Actually do simple with tukey outlier
 
-std::tuple<double, double> compute_background_constant_3d(BackgroundAggregator data){
+std::tuple<double, double> compute_background_constant_3d(BackgroundAggregator data) {
     // first do tukey outlier rejection based on 1.5 IQR multiplier.
     double iqr_multiplier = 1.5;
     int N = data.num_pixels();
-    
+
     std::size_t p25 = (N + 3) / 4;
     std::size_t p50 = (N + 1) / 2;
     std::size_t p75 = (3 * N + 1) / 4;
@@ -59,15 +59,14 @@ std::tuple<double, double> compute_background_constant_3d(BackgroundAggregator d
         if (median < 0 && cumulative >= p50) median = value;
         if (q3 < 0 && cumulative >= p75) {
             q3 = value;
-            break; // may be able to stop early
+            break;  // may be able to stop early
         }
     }
     // iterate the hist if not all found.
     if (q3 < 0) {
         std::vector<int> keys;
         keys.reserve(large_hist.size());
-        for (auto& [k, _] : large_hist)
-            keys.push_back(k);
+        for (auto &[k, _] : large_hist) keys.push_back(k);
 
         std::sort(keys.begin(), keys.end());
 
@@ -91,8 +90,7 @@ std::tuple<double, double> compute_background_constant_3d(BackgroundAggregator d
 
     // ---- Small values (vector) ----
     for (std::size_t value = 0; value < small_hist.size(); ++value) {
-        if (value < lower_bound || value > upper_bound)
-            continue;
+        if (value < lower_bound || value > upper_bound) continue;
 
         std::size_t count = small_hist[value];
         included_count += count;
@@ -100,16 +98,17 @@ std::tuple<double, double> compute_background_constant_3d(BackgroundAggregator d
     }
 
     // ---- Large outliers (unordered_map) ----
-    for (const auto& [value, count] : large_hist) {
-        if (value < lower_bound || value > upper_bound)
-            continue;
+    for (const auto &[value, count] : large_hist) {
+        if (value < lower_bound || value > upper_bound) continue;
 
         included_count += count;
         weighted_sum += value * static_cast<double>(count);
     }
 
     // Avoid division by zero if everything was excluded
-    if (included_count == 0) throw std::runtime_error("No counts included in background calculation");
+    if (included_count == 0)
+        throw std::runtime_error("No counts included in background calculation");
 
-    return std::make_tuple(weighted_sum / static_cast<double>(included_count), weighted_sum);
+    return std::make_tuple(weighted_sum / static_cast<double>(included_count),
+                           weighted_sum);
 }

--- a/baseline/integrator/background.cc
+++ b/baseline/integrator/background.cc
@@ -1,0 +1,115 @@
+#include <vector>
+#include <unordered_map>
+#include <algorithm>
+#include <cstddef>
+
+constexpr std::size_t VECTOR_LIMIT = 64;
+
+class BackgroundAggregator {
+    public:
+        BackgroundAggregator(){}
+        void add(int x){
+            if (x >= 0 && x < VECTOR_LIMIT) {
+                ++_small_hist[x];
+            } else {
+                ++_large_hist[x];
+            }
+            ++n_pixels;
+        }
+        int num_pixels() const {
+            return n_pixels;
+        }
+        std::vector<std::size_t> small_hist() const {
+            return _small_hist;
+        }
+        std::unordered_map<int, std::size_t> large_hist() const {
+            return _large_hist;
+        }
+    private:
+        std::vector<std::size_t> _small_hist = std::vector<std::size_t>(VECTOR_LIMIT, 0);
+        std::unordered_map<int, std::size_t> _large_hist;
+        int n_pixels = 0;
+};
+
+
+// Compute constant 3d glm background model
+// int min_pixels=10
+
+// Actually do simple with tukey outlier
+
+std::tuple<double, double> compute_background_constant_3d(BackgroundAggregator data){
+    // first do tukey outlier rejection based on 1.5 IQR multiplier.
+    double iqr_multiplier = 1.5;
+    int N = data.num_pixels();
+    
+    std::size_t p25 = (N + 3) / 4;
+    std::size_t p50 = (N + 1) / 2;
+    std::size_t p75 = (3 * N + 1) / 4;
+
+    std::vector<std::size_t> small_hist = data.small_hist();
+    std::unordered_map<int, std::size_t> large_hist = data.large_hist();
+
+    // iterate the vector.
+    std::size_t cumulative = 0;
+    int q1 = -1, median = -1, q3 = -1;
+    for (int value = 0; value < small_hist.size(); ++value) {
+        cumulative += small_hist[value];
+
+        if (q1 < 0 && cumulative >= p25) q1 = value;
+        if (median < 0 && cumulative >= p50) median = value;
+        if (q3 < 0 && cumulative >= p75) {
+            q3 = value;
+            break; // may be able to stop early
+        }
+    }
+    // iterate the hist if not all found.
+    if (q3 < 0) {
+        std::vector<int> keys;
+        keys.reserve(large_hist.size());
+        for (auto& [k, _] : large_hist)
+            keys.push_back(k);
+
+        std::sort(keys.begin(), keys.end());
+
+        for (int value : keys) {
+            cumulative += large_hist[value];
+
+            if (q1 < 0 && cumulative >= p25) q1 = value;
+            if (median < 0 && cumulative >= p50) median = value;
+            if (q3 < 0 && cumulative >= p75) {
+                q3 = value;
+                break;
+            }
+        }
+    }
+    int iqr = q3 - q1;
+    double upper_bound = q3 + (iqr * iqr_multiplier);
+    double lower_bound = q1 - (iqr * iqr_multiplier);
+
+    std::size_t included_count = 0;
+    double weighted_sum = 0.0;
+
+    // ---- Small values (vector) ----
+    for (std::size_t value = 0; value < small_hist.size(); ++value) {
+        if (value < lower_bound || value > upper_bound)
+            continue;
+
+        std::size_t count = small_hist[value];
+        included_count += count;
+        weighted_sum += value * static_cast<double>(count);
+    }
+
+    // ---- Large outliers (unordered_map) ----
+    for (const auto& [value, count] : large_hist) {
+        if (value < lower_bound || value > upper_bound)
+            continue;
+
+        included_count += count;
+        weighted_sum += value * static_cast<double>(count);
+    }
+
+    // Avoid division by zero if everything was excluded
+    if (included_count == 0) throw std::runtime_error("No counts included in background calculation");
+
+    return std::make_tuple(weighted_sum / static_cast<double>(included_count), weighted_sum);
+}

--- a/baseline/integrator/background.cc
+++ b/baseline/integrator/background.cc
@@ -27,6 +27,9 @@ class BackgroundAggregator {
     }
 
   private:
+    // Use two data structures for the histogram
+    // - a small vector for small counts (< VECTOR_LIMIT) (vast majority of pixels, efficient for adding a large number of low-value pixels)
+    // - an unordered map for large counts (sparse, infrequent, efficient for adding a low number of high-value pixels (perhaps outliers))
     std::vector<std::size_t> _small_hist = std::vector<std::size_t>(VECTOR_LIMIT, 0);
     std::unordered_map<int, std::size_t> _large_hist;
     int n_pixels = 0;

--- a/baseline/integrator/integration_calculations.cc
+++ b/baseline/integrator/integration_calculations.cc
@@ -1,0 +1,70 @@
+#include <Eigen/Dense>
+
+using Eigen::Vector3d;
+
+double lorentz_correction(Vector3d const &s0, Vector3d const &m2, Vector3d const &s1) {
+  double s1_length = s1.norm();
+  double s0_length = s0.norm();
+  return std::abs(s1.dot(m2.cross(s0))) / (s0_length * s1_length);
+}
+double polarization_correction(Vector3d const &s0,
+                                 Vector3d const &pn,
+                                 double pf,
+                                 Vector3d const &s1) {
+  double s1_length = s1.norm();
+  double s0_length = s0.norm();
+  double P1 = ((pn.dot(s1)) / s1_length);
+  double P2 = (1.0 - 2.0 * pf) * (1.0 - P1 * P1);
+  double P3 = (s1.dot(s0) / (s1_length * s0_length));
+  double P4 = pf * (1.0 + P3 * P3);
+  double P = P2 + P4;
+  return P;
+}
+
+class LPCorrection {
+  public:
+    LPCorrection(Vector3d s0, Vector3d pn, double pf, Vector3d m2): s0_(s0), pn_(pn), pf_(pf), m2_(m2) {}
+    double calculate(Vector3d const s1){
+      double L = lorentz_correction(s0_, m2_, s1);
+      double P = polarization_correction(s0_, pn_, pf_, s1);
+      return L / P;
+    }
+  private:
+    Vector3d s0_;
+    Vector3d pn_;
+    double pf_;
+    Vector3d m2_;
+    double s0_length;
+};
+
+
+class CoordinateSystem {
+  public:
+    CoordinateSystem(Vector3d m2, Vector3d s0, Vector3d s1, double phi) : s1_(s1), phi_(phi) {
+      Vector3d m2_(m2);
+      m2_.normalize();
+      Vector3d e1_ = s1.cross(s0);
+      e1_.normalize();
+      Vector3d e2_ = s1.cross(e1_);
+      e2_.normalize();
+      double s1_length = s1.norm();
+      scaled_e1_ = e1_ /  s1_length;
+      scaled_e2_ = e2_ /  s1_length;
+      zeta_ = m2_.dot(e1_);
+    }
+    Vector3d coords_from_s1vector(const Vector3d s_dash, double phi_dash){
+      Vector3d coord = {scaled_e1_.dot(s_dash - s1_),
+          scaled_e2_.dot(s_dash - s1_),
+          zeta_ * (phi_dash - phi_)};
+      return coord;
+    }
+    double zeta() const {
+      return zeta_;
+    }
+  private:
+    Vector3d s1_;
+    double phi_;
+    double zeta_;
+    Vector3d scaled_e1_;
+    Vector3d scaled_e2_;
+};

--- a/baseline/integrator/integration_calculations.cc
+++ b/baseline/integrator/integration_calculations.cc
@@ -3,32 +3,34 @@
 using Eigen::Vector3d;
 
 double lorentz_correction(Vector3d const &s0, Vector3d const &m2, Vector3d const &s1) {
-  double s1_length = s1.norm();
-  double s0_length = s0.norm();
-  return std::abs(s1.dot(m2.cross(s0))) / (s0_length * s1_length);
+    double s1_length = s1.norm();
+    double s0_length = s0.norm();
+    return std::abs(s1.dot(m2.cross(s0))) / (s0_length * s1_length);
 }
 double polarization_correction(Vector3d const &s0,
-                                 Vector3d const &pn,
-                                 double pf,
-                                 Vector3d const &s1) {
-  double s1_length = s1.norm();
-  double s0_length = s0.norm();
-  double P1 = ((pn.dot(s1)) / s1_length);
-  double P2 = (1.0 - 2.0 * pf) * (1.0 - P1 * P1);
-  double P3 = (s1.dot(s0) / (s1_length * s0_length));
-  double P4 = pf * (1.0 + P3 * P3);
-  double P = P2 + P4;
-  return P;
+                               Vector3d const &pn,
+                               double pf,
+                               Vector3d const &s1) {
+    double s1_length = s1.norm();
+    double s0_length = s0.norm();
+    double P1 = ((pn.dot(s1)) / s1_length);
+    double P2 = (1.0 - 2.0 * pf) * (1.0 - P1 * P1);
+    double P3 = (s1.dot(s0) / (s1_length * s0_length));
+    double P4 = pf * (1.0 + P3 * P3);
+    double P = P2 + P4;
+    return P;
 }
 
 class LPCorrection {
   public:
-    LPCorrection(Vector3d s0, Vector3d pn, double pf, Vector3d m2): s0_(s0), pn_(pn), pf_(pf), m2_(m2) {}
-    double calculate(Vector3d const s1){
-      double L = lorentz_correction(s0_, m2_, s1);
-      double P = polarization_correction(s0_, pn_, pf_, s1);
-      return L / P;
+    LPCorrection(Vector3d s0, Vector3d pn, double pf, Vector3d m2)
+        : s0_(s0), pn_(pn), pf_(pf), m2_(m2) {}
+    double calculate(Vector3d const s1) {
+        double L = lorentz_correction(s0_, m2_, s1);
+        double P = polarization_correction(s0_, pn_, pf_, s1);
+        return L / P;
     }
+
   private:
     Vector3d s0_;
     Vector3d pn_;
@@ -37,30 +39,31 @@ class LPCorrection {
     double s0_length;
 };
 
-
 class CoordinateSystem {
   public:
-    CoordinateSystem(Vector3d m2, Vector3d s0, Vector3d s1, double phi) : s1_(s1), phi_(phi) {
-      Vector3d m2_(m2);
-      m2_.normalize();
-      Vector3d e1_ = s1.cross(s0);
-      e1_.normalize();
-      Vector3d e2_ = s1.cross(e1_);
-      e2_.normalize();
-      double s1_length = s1.norm();
-      scaled_e1_ = e1_ /  s1_length;
-      scaled_e2_ = e2_ /  s1_length;
-      zeta_ = m2_.dot(e1_);
+    CoordinateSystem(Vector3d m2, Vector3d s0, Vector3d s1, double phi)
+        : s1_(s1), phi_(phi) {
+        Vector3d m2_(m2);
+        m2_.normalize();
+        Vector3d e1_ = s1.cross(s0);
+        e1_.normalize();
+        Vector3d e2_ = s1.cross(e1_);
+        e2_.normalize();
+        double s1_length = s1.norm();
+        scaled_e1_ = e1_ / s1_length;
+        scaled_e2_ = e2_ / s1_length;
+        zeta_ = m2_.dot(e1_);
     }
-    Vector3d coords_from_s1vector(const Vector3d s_dash, double phi_dash){
-      Vector3d coord = {scaled_e1_.dot(s_dash - s1_),
-          scaled_e2_.dot(s_dash - s1_),
-          zeta_ * (phi_dash - phi_)};
-      return coord;
+    Vector3d coords_from_s1vector(const Vector3d s_dash, double phi_dash) {
+        Vector3d coord = {scaled_e1_.dot(s_dash - s1_),
+                          scaled_e2_.dot(s_dash - s1_),
+                          zeta_ * (phi_dash - phi_)};
+        return coord;
     }
     double zeta() const {
-      return zeta_;
+        return zeta_;
     }
+
   private:
     Vector3d s1_;
     double phi_;

--- a/baseline/integrator/integrator.cc
+++ b/baseline/integrator/integrator.cc
@@ -99,9 +99,8 @@ class BaselineIntegratorArgumentParser : public FFSArgumentParser {
           .default_value<int>(6)
           .scan<'i', int>();
 
-        add_argument("-a","--algorithm")
-          .help(
-            "Foreground algorithm choice - dials or ellipsoid.")
+        add_argument("-a", "--algorithm")
+          .help("Foreground algorithm choice - dials or ellipsoid.")
           .default_value<std::string>("ellipsoid");
 
         add_argument("output")
@@ -125,8 +124,9 @@ int main(int argc, char **argv) {
     float timeout = parser.get<float>("timeout");
     std::string output_file = parser.get<std::string>("output");
     std::string fg_algorithm = parser.get<std::string>("algorithm");
-    if ((fg_algorithm != "dials") && (fg_algorithm != "ellipsoid")){
-        throw std::invalid_argument("Invalid algorithm specified (must be 'dials' or 'ellipsoid')");
+    if ((fg_algorithm != "dials") && (fg_algorithm != "ellipsoid")) {
+        throw std::invalid_argument(
+          "Invalid algorithm specified (must be 'dials' or 'ellipsoid')");
     }
 
     // Guard against missing files
@@ -454,12 +454,13 @@ int main(int argc, char **argv) {
         for (size_t k = 0; k < reflections_by_image[j].size(); k++) {
             size_t refl_id = reflections_by_image[j][k];
             const auto &bbox = computed_bounding_boxes[refl_id];
-            if (fg_algorithm == "ellipsoid"){
+            if (fg_algorithm == "ellipsoid") {
                 // calculate dxy array (arrays of distances in kabsch space from pixel corners to xyzcal)
                 int n_x = bbox.x_max - bbox.x_min + 1;
                 int n_y = bbox.y_max - bbox.y_min + 1;
-                std::vector<double> dxy_start(n_x * n_y);  // start of image (in rotation)
-                std::vector<double> dxy_end(n_x * n_y);    // end of image (in rotation)
+                std::vector<double> dxy_start(n_x
+                                              * n_y);    // start of image (in rotation)
+                std::vector<double> dxy_end(n_x * n_y);  // end of image (in rotation)
                 double phidash_start = (phi0 + (j * dphi)) * DEG2RAD;
                 double phidash_end = (phi0 + ((j + 1) * dphi)) * DEG2RAD;
                 double phi_c = phi_column(refl_id, 2);
@@ -469,30 +470,31 @@ int main(int argc, char **argv) {
                     for (int y = 0; y < n_y; y++) {
                         int index = x + (y * (n_x));
                         std::array<double, 2> px_mm =
-                        panel.px_to_mm(x + bbox.x_min, y + bbox.y_min);
+                          panel.px_to_mm(x + bbox.x_min, y + bbox.y_min);
                         Vector3d s1_ = panel.get_lab_coord(px_mm[0], px_mm[1]);
                         s1_.normalize();
                         Vector3d s1dash = s1_ * s0_length;
                         Vector3d epsilon_coords_start =
-                        cs.coords_from_s1vector(s1dash, phidash_start);
+                          cs.coords_from_s1vector(s1dash, phidash_start);
                         Vector3d epsilon_coords_end =
-                        cs.coords_from_s1vector(s1dash, phidash_end);
+                          cs.coords_from_s1vector(s1dash, phidash_end);
                         if ((phidash_start > phi_c) && (phi_c < phidash_end)) {
                             epsilon_coords_start[2] = 0.0;
                             epsilon_coords_end[2] = 0.0;
                         }
 
                         dxy_start[index] =
-                        ((epsilon_coords_start[0] * epsilon_coords_start[0]
+                          ((epsilon_coords_start[0] * epsilon_coords_start[0]
                             + epsilon_coords_start[1] * epsilon_coords_start[1])
-                        * delta_b_r2)
-                        + ((epsilon_coords_start[2] * epsilon_coords_start[2])
-                            * delta_m_r2);
+                           * delta_b_r2)
+                          + ((epsilon_coords_start[2] * epsilon_coords_start[2])
+                             * delta_m_r2);
                         dxy_end[index] =
-                        ((epsilon_coords_end[0] * epsilon_coords_end[0]
+                          ((epsilon_coords_end[0] * epsilon_coords_end[0]
                             + epsilon_coords_end[1] * epsilon_coords_end[1])
-                        * delta_b_r2)
-                        + ((epsilon_coords_end[2] * epsilon_coords_end[2]) * delta_m_r2);
+                           * delta_b_r2)
+                          + ((epsilon_coords_end[2] * epsilon_coords_end[2])
+                             * delta_m_r2);
                     }
                 }
                 // Now loop through pixels in bbox, adding to foreground or background if unmasked and in image.
@@ -511,11 +513,12 @@ int main(int argc, char **argv) {
                         double d6 = dxy_end[dxyindex + 1];
                         double d7 = dxy_end[dxyindex + n_x];
                         double d8 = dxy_end[dxyindex + n_x + 1];
-                        double d = std::min(std::min(std::min(d1, d2), std::min(d3, d4)),
-                                            std::min(std::min(d5, d6), std::min(d7, d8)));
+                        double d =
+                          std::min(std::min(std::min(d1, d2), std::min(d3, d4)),
+                                   std::min(std::min(d5, d6), std::min(d7, d8)));
                         int index = x + (y * image_fast);
                         bool in_image =
-                        x >= 0 && x < image_fast && y >= 0 && y < image_slow;
+                          x >= 0 && x < image_fast && y >= 0 && y < image_slow;
                         if (d <= 1.0) {
                             // Foreground
                             if (in_image) {
@@ -525,12 +528,13 @@ int main(int argc, char **argv) {
                                     auto data = image.data.data()[index];
                                     intensity_accumulators[refl_id] += data;
                                     nfg_accumulators[refl_id] += 1;
-                                    Vector3d I_times_c = {
-                                    data * (x + 0.5), data * (y + 0.5), data * (j + 0.5)};
+                                    Vector3d I_times_c = {data * (x + 0.5),
+                                                          data * (y + 0.5),
+                                                          data * (j + 0.5)};
                                     intensity_times_coord_accumulators[refl_id] +=
-                                    I_times_c;
+                                      I_times_c;
                                 }
-                            } else { // NB dials doesn't seem to do this check.
+                            } else {  // NB dials doesn't seem to do this check.
                                 success[refl_id] = false;
                             }
                         } else {  // d>1.0
@@ -551,24 +555,25 @@ int main(int argc, char **argv) {
                 int n_x = bbox.x_max - bbox.x_min + 1;
                 int n_y = bbox.y_max - bbox.y_min + 1;
                 std::vector<double> dxy(n_x * n_y);
-                double phi = phi0 + (j * dphi) * DEG2RAD; // Required for calls but not actually used as don't use e3.
+                double phi =
+                  phi0
+                  + (j * dphi)
+                      * DEG2RAD;  // Required for calls but not actually used as don't use e3.
                 CoordinateSystem cs = coord_system_vector[refl_id];
                 Vector3d s1_this = Eigen::Map<Vector3d>(&s1_vectors(refl_id, 0));
                 for (int x = 0; x < n_x; x++) {
                     for (int y = 0; y < n_y; y++) {
                         int index = x + (y * (n_x));
                         std::array<double, 2> px_mm =
-                        panel.px_to_mm(x + bbox.x_min, y + bbox.y_min);
+                          panel.px_to_mm(x + bbox.x_min, y + bbox.y_min);
                         Vector3d s1_ = panel.get_lab_coord(px_mm[0], px_mm[1]);
                         s1_.normalize();
                         Vector3d s1dash = s1_ * s0_length;
-                        Vector3d epsilon_coords =
-                        cs.coords_from_s1vector(s1dash, phi);
+                        Vector3d epsilon_coords = cs.coords_from_s1vector(s1dash, phi);
 
-                        dxy[index] =
-                        ((epsilon_coords[0] * epsilon_coords[0]
-                            + epsilon_coords[1] * epsilon_coords[1])
-                        * delta_b_r2);
+                        dxy[index] = ((epsilon_coords[0] * epsilon_coords[0]
+                                       + epsilon_coords[1] * epsilon_coords[1])
+                                      * delta_b_r2);
                     }
                 }
                 // Now loop through pixels in bbox, adding to foreground or background if unmasked and in image.
@@ -586,7 +591,7 @@ int main(int argc, char **argv) {
                         double d = std::min(std::min(d1, d2), std::min(d3, d4));
                         int index = x + (y * image_fast);
                         bool in_image =
-                        x >= 0 && x < image_fast && y >= 0 && y < image_slow;
+                          x >= 0 && x < image_fast && y >= 0 && y < image_slow;
 
                         if (d <= 1.0) {
                             // Foreground
@@ -597,12 +602,13 @@ int main(int argc, char **argv) {
                                     auto data = image.data.data()[index];
                                     intensity_accumulators[refl_id] += data;
                                     nfg_accumulators[refl_id] += 1;
-                                    Vector3d I_times_c = {
-                                    data * (x + 0.5), data * (y + 0.5), data * (j + 0.5)};
+                                    Vector3d I_times_c = {data * (x + 0.5),
+                                                          data * (y + 0.5),
+                                                          data * (j + 0.5)};
                                     intensity_times_coord_accumulators[refl_id] +=
-                                    I_times_c;
+                                      I_times_c;
                                 }
-                            }// else { // NB dials doesn't seem to do this check?
+                            }  // else { // NB dials doesn't seem to do this check?
                             //    success[refl_id] = false;
                             //}
                         } else {  // d>1.0
@@ -718,9 +724,12 @@ int main(int argc, char **argv) {
     integrated_data.add_column("xyzobs.px.value", num_reflections, 3, xyzobs_px);
     integrated_data.add_column("s1", num_reflections, 3, s1);
     integrated_data.add_column("id", num_reflections, 1, id);
-    integrated_data.add_column("num_pixels.background", num_reflections, 1, nbg_accumulators);
-    integrated_data.add_column("num_pixels.foreground", num_reflections, 1, nfg_accumulators);
-    integrated_data.add_column("background.sum.value", num_reflections, 1, bg_accumulators);
+    integrated_data.add_column(
+      "num_pixels.background", num_reflections, 1, nbg_accumulators);
+    integrated_data.add_column(
+      "num_pixels.foreground", num_reflections, 1, nfg_accumulators);
+    integrated_data.add_column(
+      "background.sum.value", num_reflections, 1, bg_accumulators);
     integrated_data.add_column("background.mean", num_reflections, 1, mean_bg);
     std::vector<std::size_t> final_flags(num_reflections, IntegratedSum);
     integrated_data.add_column(std::string("flags"), num_reflections, 1, final_flags);

--- a/baseline/integrator/integrator.cc
+++ b/baseline/integrator/integrator.cc
@@ -6,6 +6,7 @@
 #include <Eigen/Dense>
 #include <dx2/beam.hpp>
 #include <dx2/experiment.hpp>
+#include <dx2/detector.hpp>
 #include <dx2/goniometer.hpp>
 #include <dx2/h5/h5read_processed.hpp>
 #include <dx2/reflection.hpp>
@@ -26,6 +27,7 @@
 #include "predict.cc"
 #include "sigma_estimation.cc"
 #include "version.hpp"
+#include "h5read.h"
 
 using json = nlohmann::json;
 
@@ -101,6 +103,35 @@ class BaselineIntegratorArgumentParser : public FFSArgumentParser {
     }
 };
 #pragma endregion Argument Parsing
+constexpr double DEG2RAD = M_PI / 180.0;
+class CoordinateSystem {
+  public:
+    CoordinateSystem(Vector3d m2, Vector3d s0, Vector3d s1, double phi) : s1_(s1), phi_(phi) {
+      Vector3d m2_(m2);
+      m2_.normalize();
+      Vector3d e1_ = s1.cross(s0);
+      e1_.normalize();
+      Vector3d e2_ = s1.cross(e1_);
+      e2_.normalize();
+      double s1_length = s1.norm();
+      scaled_e1_ = e1_ /  s1_length;
+      scaled_e2_ = e2_ /  s1_length;
+      zeta_ = m2_.dot(e1_);
+    }
+    Vector3d coords_from_s1vector(const Vector3d s_dash, double phi_dash){
+      Vector3d coord = {scaled_e1_.dot(s_dash - s1_),
+          scaled_e2_.dot(s_dash - s1_),
+          zeta_ * (phi_dash - phi_)};
+      return coord;
+    }
+  private:
+    Vector3d s1_;
+    double phi_;
+    double zeta_;
+    Vector3d scaled_e1_;
+    Vector3d scaled_e2_;
+};
+
 
 #pragma region Application Entry
 int main(int argc, char **argv) {
@@ -262,6 +293,7 @@ int main(int argc, char **argv) {
 
     mdspan_type<double> phi_column;
     mdspan_type<double> s1_vectors;
+    std::vector<int> hkl_vectors;
     size_t num_reflections;
     predicted_data_rotation output_data;  // Define here so that members stay in scope
     if (!all_predicted) {
@@ -293,6 +325,7 @@ int main(int argc, char **argv) {
         phi_column = mdspan_type<double>(
           output_data.xyz_mm.data(), output_data.xyz_mm.size() / 3, 3);
         num_reflections = output_data.enter.size();
+        hkl_vectors = output_data.hkl;
     } else {
         // is already predicted, so just extract required data.
         auto s1_vectors_opt = reflections.column<double>("s1");
@@ -306,8 +339,16 @@ int main(int argc, char **argv) {
             logger.error("Column 'xyzcal.mm' not found for phi positions.");
             return 1;
         }
+        auto hkl_vectors_opt = reflections.column<int>("miller_index");
+        if (!hkl_vectors_opt) {
+            logger.error("Column 'miller_index' not found in reflection data.");
+            return 1;
+        }
         phi_column = *phi_column_opt;
         num_reflections = s1_vectors.extent(0);
+        hkl_vectors = std::vector<int>(
+          hkl_vectors_opt.value().data_handle(), 
+          hkl_vectors_opt.value().data_handle() + hkl_vectors_opt.value().size());
     }
 
 #pragma endregion Predict or extract predictions
@@ -334,6 +375,145 @@ int main(int argc, char **argv) {
     logger.info("Successfully computed {} bounding boxes",
                 computed_bounding_boxes.size());
 
+    // Map reflections by z layer (image number)
+    logger.info("Mapping reflections by image number (z layer)");
+    std::unordered_map<int, std::vector<size_t>> reflections_by_image;
+    std::vector<int> intensity_accumulators(num_reflections);
+    std::vector<int> bg_accumulators(num_reflections);
+    std::vector<int> nbg_accumulators(num_reflections);
+    std::vector<int> nfg_accumulators(num_reflections);
+
+    for (size_t refl_id = 0; refl_id < num_reflections; ++refl_id) {
+        const auto &bbox = computed_bounding_boxes[refl_id];
+
+        // Add this reflection to all images it spans
+        for (int z = bbox.z_min; z < bbox.z_max; ++z) {
+            reflections_by_image[z].push_back(refl_id);
+        }
+    }
+    logger.info("Reflections mapped across {} unique images",
+                reflections_by_image.size());
+
+    // Now load some image data:
+    std::string filename = expt.imagesequence().filename();
+    h5read_handle *obj = h5read_open(filename.c_str());
+    size_t n_images = h5read_get_number_of_images(obj);
+    uint16_t image_slow = h5read_get_image_slow(obj);
+    uint16_t image_fast = h5read_get_image_fast(obj);
+    double s0_length = beam.get_s0().norm();
+    double phi0 = scan.get_oscillation()[0];
+    double dphi = scan.get_oscillation()[1];
+    std::cout << "Phi0 " << phi0 << " dphi " << dphi << std::endl;
+    // make a vector of coordinate systems for each reflection.
+    std::cout << "Making CS vector" << std::endl;
+    std::vector<CoordinateSystem> coord_system_vector = {};
+    coord_system_vector.reserve(num_reflections);
+    const Vector3d m2 = gonio.get_rotation_axis();
+    for (int i=0;i<num_reflections;i++){
+      Vector3d s1_this = Eigen::Map<Vector3d>(&s1_vectors(i,0));
+      coord_system_vector.push_back(CoordinateSystem(
+        m2, s0, s1_this, phi_column(i,2)));
+    }
+    std::cout << "Made CS vector" << std::endl;
+    double delta_b = sigma_b * 3.0;
+    double delta_b_r2 = 1.0 / (delta_b * delta_b);
+    double delta_m = sigma_m * 3.0;
+    double delta_m_r2 = 1.0 / (delta_m * delta_m);
+    std::cout << "delta_b_r2 " << delta_b_r2 << " delta_m_r2 " << delta_m_r2 << std::endl;
+
+    for (size_t j = 0; j < n_images; j++) {
+      image_t *image = h5read_get_image(obj, j);
+      std::cout << "Processing image " << j +1 << std::endl;
+      size_t zero = 0;
+      size_t masked = 0;
+      size_t total = 0;
+      size_t signal = 0;
+      //for (size_t k=0;k<1;k++){
+      for (size_t k=0;k<reflections_by_image[j].size();k++){
+        size_t refl_id = reflections_by_image[j][k];
+        //std::cout << "Image " << j << " refl_id " << refl_id << std::endl;
+        //std::cout << "Image fast " << image_fast << std::endl;
+        //std::cout << "Image slow " << image_slow << std::endl;
+        const auto &bbox = computed_bounding_boxes[refl_id];
+        
+        // calculate dxy array
+        int n_x = bbox.x_max - bbox.x_min + 1;
+        int n_y = bbox.y_max - bbox.y_min + 1;
+        std::vector<double> dxy_start(n_x * n_y); // start of image (in rotation)
+        std::vector<double> dxy_end(n_x * n_y); // end of image (in rotation)
+        double phidash_start = (phi0 + (j * dphi)) * DEG2RAD;
+        double phidash_end = (phi0 + ((j + 1) * dphi)) * DEG2RAD;
+        double phi_c = phi_column(refl_id,2);
+        //std::cout << "Phis s e c: "<< phidash_start << ' ' << phidash_end << " " << phi_c << std::endl;
+        CoordinateSystem cs = coord_system_vector[refl_id];
+        Vector3d s1_this = Eigen::Map<Vector3d>(&s1_vectors(refl_id,0));
+        for (int x = 0; x<n_x; x++){
+          for (int y = 0; y<n_y; y++){
+            int index = x + (y * (n_x));
+            std::array<double, 2> px_mm = panel.px_to_mm(x+bbox.x_min,y+bbox.y_min);
+            Vector3d s1_ = panel.get_lab_coord(px_mm[0], px_mm[1]);
+            s1_.normalize();
+            Vector3d s1dash = s1_ * s0_length;
+            //std::cout << "s1dash " << s1dash[0] << " " << s1dash[1] << " " << s1dash[2] << std::endl;
+            //std::cout << "s1c " << s1_this[0] << " " << s1_this[1] << " " << s1_this[2] << std::endl;
+            Vector3d epsilon_coords_start = cs.coords_from_s1vector(s1dash, phidash_start);
+            Vector3d epsilon_coords_end = cs.coords_from_s1vector(s1dash, phidash_end);
+            if ((phidash_start > phi_c) && (phi_c < phidash_end)) {
+              epsilon_coords_start[2] = 0.0;
+              epsilon_coords_end[2] = 0.0;
+            }
+            
+            dxy_start[index] = ((epsilon_coords_start[0] * epsilon_coords_start[0]
+                  + epsilon_coords_start[1] * epsilon_coords_start[1])
+                 * delta_b_r2) + ((epsilon_coords_start[2] * epsilon_coords_start[2]) * delta_m_r2);
+            dxy_end[index] = ((epsilon_coords_end[0] * epsilon_coords_end[0]
+                  + epsilon_coords_end[1] * epsilon_coords_end[1])
+                 * delta_b_r2) + ((epsilon_coords_end[2] * epsilon_coords_end[2]) * delta_m_r2);
+          }
+        }
+        //std::cout << "Made dxy array" << std::endl;
+        for (int x = bbox.x_min; x<bbox.x_max-1; x++){
+          for (int y = bbox.y_min; y<bbox.y_max-1; y++){
+            if (x >=0 && x < image_fast && y >=0 && y < image_slow){
+              int index = x + (y * image_fast);
+              //std::cout << x << " " << y << " " << index << std::endl;
+              if (image->mask[index] != 0){
+                int data = image->data[index];
+                // Need to work out if foreground or background.
+                int x_index = x - bbox.x_min;
+                int y_index = y - bbox.y_min;
+                int dxyindex = x_index + (y_index * n_x);
+                double d1 = dxy_start[dxyindex];
+                double d2 = dxy_start[dxyindex+1];
+                double d3 = dxy_start[dxyindex+n_x];
+                double d4 = dxy_start[dxyindex+n_x+1];
+                double d5 = dxy_end[dxyindex];
+                double d6 = dxy_end[dxyindex+1];
+                double d7 = dxy_end[dxyindex+n_x];
+                double d8 = dxy_end[dxyindex+n_x+1];
+                double d = std::min(std::min(std::min(d1, d2), std::min(d3, d4)),
+                                    std::min(std::min(d5, d6), std::min(d7, d8)));
+                //std::cout << "Pixel x y d: " << x << " " << y  << " " << d << std::endl;
+                if (d > 1.0){
+                  bg_accumulators[refl_id] += data;
+                  nbg_accumulators[refl_id] += 1;
+                }
+                else {
+                  intensity_accumulators[refl_id] += data;
+                  nfg_accumulators[refl_id] += 1;
+                }
+              }
+            }
+              
+          }
+        }
+        
+        //std::cout << "Done fg/bg calc" << std::endl;
+      }
+      h5read_free_image(image);
+    }
+    h5read_free(obj);
+
     // Convert to reflection table format
     std::vector<double> computed_bbox_data;
     computed_bbox_data.reserve(num_reflections * 6);
@@ -348,7 +528,7 @@ int main(int argc, char **argv) {
     }
 
     // Display some sample results
-    logger.info("Sample bounding box results (first 5 reflections):");
+    /*logger.info("Sample bounding box results (first 5 reflections):");
     for (size_t i = 0; i < std::min<size_t>(5, num_reflections); ++i) {
         const auto &bbox = computed_bounding_boxes[i];
         logger.info("  bbox[{}]: x=[{:.1f},{:.1f}] y=[{:.1f},{:.1f}] z=[{},{}]",
@@ -432,16 +612,29 @@ int main(int argc, char **argv) {
 
     size_t actual_voxels = voxel_reflection_ids.size();
     logger.info("Processed {} voxel centers total", actual_voxels);
-
+    */
     // Create results and save to HDF5
     logger.info("Saving results to: {}", output_file);
 
     // Add computed bounding boxes to reflection table
+    //integrated_data.add_column(
+    //  "baseline_bbox", std::vector<size_t>{num_reflections, 6}, computed_bbox_data);
+    std::vector<double> intensities(num_reflections);
+    for (int i=0;i<num_reflections;i++){
+      if (nbg_accumulators[i]){
+        intensities[i] = intensity_accumulators[i] - (nfg_accumulators[i] * bg_accumulators[i] / nbg_accumulators[i]);
+      }
+      
+    }
     integrated_data.add_column(
-      "baseline_bbox", std::vector<size_t>{num_reflections, 6}, computed_bbox_data);
+      "intensity", num_reflections,1,intensities
+    );
+    integrated_data.add_column(
+      "miller_index", num_reflections,3, hkl_vectors
+    );
 
     // Create voxel data table
-    ReflectionTable voxel_table;
+    /*ReflectionTable voxel_table;
     if (actual_voxels > 0) {
         voxel_table.add_column("kabsch_coordinates",
                                std::vector<size_t>{actual_voxels, 3},
@@ -454,23 +647,23 @@ int main(int argc, char **argv) {
           "pixel_coordinates", std::vector<size_t>{actual_voxels, 3}, voxel_positions);
         voxel_table.add_column(
           "voxel_s1_length", std::vector<size_t>{actual_voxels, 1}, voxel_s1_lengths);
-    }
+    }*/
 
     // Write output files
     integrated_data.write(output_file);
-    if (actual_voxels > 0) {
+    /*if (actual_voxels > 0) {
         std::string voxel_output =
           output_file.substr(0, output_file.find_last_of('.')) + "_voxels.h5";
         voxel_table.write(voxel_output);
         logger.info("Voxel data saved to: {}", voxel_output);
     }
-
+    */
     logger.info("Baseline integration complete!");
     logger.info("Summary:");
     logger.info("  {} reflections processed", num_reflections);
     logger.info("  {} bounding boxes computed", computed_bounding_boxes.size());
-    logger.info("  {} voxel centers processed", actual_voxels);
-    logger.info("Results saved to: {}", output_file);
+    //logger.info("  {} voxel centers processed", actual_voxels);
+    //logger.info("Results saved to: {}", output_file);
 
     return 0;
 }

--- a/baseline/integrator/integrator.cc
+++ b/baseline/integrator/integrator.cc
@@ -99,8 +99,9 @@ class BaselineIntegratorArgumentParser : public FFSArgumentParser {
           .default_value<int>(6)
           .scan<'i', int>();
 
-        add_argument("-a", "--algorithm")
-          .help("Foreground algorithm choice - dials or ellipsoid.")
+        add_argument("-a","--algorithm")
+          .help(
+            "Foreground algorithm choice - dials or ellipsoid.")
           .default_value<std::string>("ellipsoid");
 
         add_argument("output")
@@ -124,9 +125,8 @@ int main(int argc, char **argv) {
     float timeout = parser.get<float>("timeout");
     std::string output_file = parser.get<std::string>("output");
     std::string fg_algorithm = parser.get<std::string>("algorithm");
-    if ((fg_algorithm != "dials") && (fg_algorithm != "ellipsoid")) {
-        throw std::invalid_argument(
-          "Invalid algorithm specified (must be 'dials' or 'ellipsoid')");
+    if ((fg_algorithm != "dials") && (fg_algorithm != "ellipsoid")){
+        throw std::invalid_argument("Invalid algorithm specified (must be 'dials' or 'ellipsoid')");
     }
 
     // Guard against missing files
@@ -454,13 +454,12 @@ int main(int argc, char **argv) {
         for (size_t k = 0; k < reflections_by_image[j].size(); k++) {
             size_t refl_id = reflections_by_image[j][k];
             const auto &bbox = computed_bounding_boxes[refl_id];
-            if (fg_algorithm == "ellipsoid") {
+            if (fg_algorithm == "ellipsoid"){
                 // calculate dxy array (arrays of distances in kabsch space from pixel corners to xyzcal)
                 int n_x = bbox.x_max - bbox.x_min + 1;
                 int n_y = bbox.y_max - bbox.y_min + 1;
-                std::vector<double> dxy_start(n_x
-                                              * n_y);    // start of image (in rotation)
-                std::vector<double> dxy_end(n_x * n_y);  // end of image (in rotation)
+                std::vector<double> dxy_start(n_x * n_y);  // start of image (in rotation)
+                std::vector<double> dxy_end(n_x * n_y);    // end of image (in rotation)
                 double phidash_start = (phi0 + (j * dphi)) * DEG2RAD;
                 double phidash_end = (phi0 + ((j + 1) * dphi)) * DEG2RAD;
                 double phi_c = phi_column(refl_id, 2);
@@ -470,31 +469,30 @@ int main(int argc, char **argv) {
                     for (int y = 0; y < n_y; y++) {
                         int index = x + (y * (n_x));
                         std::array<double, 2> px_mm =
-                          panel.px_to_mm(x + bbox.x_min, y + bbox.y_min);
+                        panel.px_to_mm(x + bbox.x_min, y + bbox.y_min);
                         Vector3d s1_ = panel.get_lab_coord(px_mm[0], px_mm[1]);
                         s1_.normalize();
                         Vector3d s1dash = s1_ * s0_length;
                         Vector3d epsilon_coords_start =
-                          cs.coords_from_s1vector(s1dash, phidash_start);
+                        cs.coords_from_s1vector(s1dash, phidash_start);
                         Vector3d epsilon_coords_end =
-                          cs.coords_from_s1vector(s1dash, phidash_end);
+                        cs.coords_from_s1vector(s1dash, phidash_end);
                         if ((phidash_start > phi_c) && (phi_c < phidash_end)) {
                             epsilon_coords_start[2] = 0.0;
                             epsilon_coords_end[2] = 0.0;
                         }
 
                         dxy_start[index] =
-                          ((epsilon_coords_start[0] * epsilon_coords_start[0]
+                        ((epsilon_coords_start[0] * epsilon_coords_start[0]
                             + epsilon_coords_start[1] * epsilon_coords_start[1])
-                           * delta_b_r2)
-                          + ((epsilon_coords_start[2] * epsilon_coords_start[2])
-                             * delta_m_r2);
+                        * delta_b_r2)
+                        + ((epsilon_coords_start[2] * epsilon_coords_start[2])
+                            * delta_m_r2);
                         dxy_end[index] =
-                          ((epsilon_coords_end[0] * epsilon_coords_end[0]
+                        ((epsilon_coords_end[0] * epsilon_coords_end[0]
                             + epsilon_coords_end[1] * epsilon_coords_end[1])
-                           * delta_b_r2)
-                          + ((epsilon_coords_end[2] * epsilon_coords_end[2])
-                             * delta_m_r2);
+                        * delta_b_r2)
+                        + ((epsilon_coords_end[2] * epsilon_coords_end[2]) * delta_m_r2);
                     }
                 }
                 // Now loop through pixels in bbox, adding to foreground or background if unmasked and in image.
@@ -513,12 +511,11 @@ int main(int argc, char **argv) {
                         double d6 = dxy_end[dxyindex + 1];
                         double d7 = dxy_end[dxyindex + n_x];
                         double d8 = dxy_end[dxyindex + n_x + 1];
-                        double d =
-                          std::min(std::min(std::min(d1, d2), std::min(d3, d4)),
-                                   std::min(std::min(d5, d6), std::min(d7, d8)));
+                        double d = std::min(std::min(std::min(d1, d2), std::min(d3, d4)),
+                                            std::min(std::min(d5, d6), std::min(d7, d8)));
                         int index = x + (y * image_fast);
                         bool in_image =
-                          x >= 0 && x < image_fast && y >= 0 && y < image_slow;
+                        x >= 0 && x < image_fast && y >= 0 && y < image_slow;
                         if (d <= 1.0) {
                             // Foreground
                             if (in_image) {
@@ -528,13 +525,12 @@ int main(int argc, char **argv) {
                                     auto data = image.data.data()[index];
                                     intensity_accumulators[refl_id] += data;
                                     nfg_accumulators[refl_id] += 1;
-                                    Vector3d I_times_c = {data * (x + 0.5),
-                                                          data * (y + 0.5),
-                                                          data * (j + 0.5)};
+                                    Vector3d I_times_c = {
+                                    data * (x + 0.5), data * (y + 0.5), data * (j + 0.5)};
                                     intensity_times_coord_accumulators[refl_id] +=
-                                      I_times_c;
+                                    I_times_c;
                                 }
-                            } else {  // NB dials doesn't seem to do this check.
+                            } else { // NB dials doesn't seem to do this check.
                                 success[refl_id] = false;
                             }
                         } else {  // d>1.0
@@ -555,25 +551,24 @@ int main(int argc, char **argv) {
                 int n_x = bbox.x_max - bbox.x_min + 1;
                 int n_y = bbox.y_max - bbox.y_min + 1;
                 std::vector<double> dxy(n_x * n_y);
-                double phi =
-                  phi0
-                  + (j * dphi)
-                      * DEG2RAD;  // Required for calls but not actually used as don't use e3.
+                double phi = phi0 + (j * dphi) * DEG2RAD; // Required for calls but not actually used as don't use e3.
                 CoordinateSystem cs = coord_system_vector[refl_id];
                 Vector3d s1_this = Eigen::Map<Vector3d>(&s1_vectors(refl_id, 0));
                 for (int x = 0; x < n_x; x++) {
                     for (int y = 0; y < n_y; y++) {
                         int index = x + (y * (n_x));
                         std::array<double, 2> px_mm =
-                          panel.px_to_mm(x + bbox.x_min, y + bbox.y_min);
+                        panel.px_to_mm(x + bbox.x_min, y + bbox.y_min);
                         Vector3d s1_ = panel.get_lab_coord(px_mm[0], px_mm[1]);
                         s1_.normalize();
                         Vector3d s1dash = s1_ * s0_length;
-                        Vector3d epsilon_coords = cs.coords_from_s1vector(s1dash, phi);
+                        Vector3d epsilon_coords =
+                        cs.coords_from_s1vector(s1dash, phi);
 
-                        dxy[index] = ((epsilon_coords[0] * epsilon_coords[0]
-                                       + epsilon_coords[1] * epsilon_coords[1])
-                                      * delta_b_r2);
+                        dxy[index] =
+                        ((epsilon_coords[0] * epsilon_coords[0]
+                            + epsilon_coords[1] * epsilon_coords[1])
+                        * delta_b_r2);
                     }
                 }
                 // Now loop through pixels in bbox, adding to foreground or background if unmasked and in image.
@@ -591,7 +586,7 @@ int main(int argc, char **argv) {
                         double d = std::min(std::min(d1, d2), std::min(d3, d4));
                         int index = x + (y * image_fast);
                         bool in_image =
-                          x >= 0 && x < image_fast && y >= 0 && y < image_slow;
+                        x >= 0 && x < image_fast && y >= 0 && y < image_slow;
 
                         if (d <= 1.0) {
                             // Foreground
@@ -602,13 +597,12 @@ int main(int argc, char **argv) {
                                     auto data = image.data.data()[index];
                                     intensity_accumulators[refl_id] += data;
                                     nfg_accumulators[refl_id] += 1;
-                                    Vector3d I_times_c = {data * (x + 0.5),
-                                                          data * (y + 0.5),
-                                                          data * (j + 0.5)};
+                                    Vector3d I_times_c = {
+                                    data * (x + 0.5), data * (y + 0.5), data * (j + 0.5)};
                                     intensity_times_coord_accumulators[refl_id] +=
-                                      I_times_c;
+                                    I_times_c;
                                 }
-                            }  // else { // NB dials doesn't seem to do this check?
+                            }// else { // NB dials doesn't seem to do this check?
                             //    success[refl_id] = false;
                             //}
                         } else {  // d>1.0
@@ -724,13 +718,10 @@ int main(int argc, char **argv) {
     integrated_data.add_column("xyzobs.px.value", num_reflections, 3, xyzobs_px);
     integrated_data.add_column("s1", num_reflections, 3, s1);
     integrated_data.add_column("id", num_reflections, 1, id);
-    integrated_data.add_column(
-      "num_pixels.background", num_reflections, 1, nbg_accumulators);
-    integrated_data.add_column(
-      "num_pixels.foreground", num_reflections, 1, nfg_accumulators);
-    integrated_data.add_column(
-      "background.sum.value", num_reflections, 1, bg_accumulators);
-    integrated_data.add_column("background.mean", num_reflections, 1, mean_bg);
+    integrated_data.add_column("num_pixels.background", num_reflections, 1, nbg_accumulators); // Useful for debug but not required for downstream
+    integrated_data.add_column("num_pixels.foreground", num_reflections, 1, nfg_accumulators); // Useful for debug but not required for downstream
+    integrated_data.add_column("background.sum.value", num_reflections, 1, bg_accumulators); // Useful for debug but not required for downstream
+    integrated_data.add_column("background.mean", num_reflections, 1, mean_bg); // Useful for debug but not required for downstream
     std::vector<std::size_t> final_flags(num_reflections, IntegratedSum);
     integrated_data.add_column(std::string("flags"), num_reflections, 1, final_flags);
 

--- a/baseline/integrator/integrator.cc
+++ b/baseline/integrator/integrator.cc
@@ -10,6 +10,7 @@
 #include <dx2/goniometer.hpp>
 #include <dx2/h5/h5read_processed.hpp>
 #include <dx2/reflection.hpp>
+#include <gemmi/unitcell.hpp>
 #include <experimental/mdspan>
 #include <filesystem>
 #include <fstream>
@@ -26,11 +27,16 @@
 #include "math/math_utils.cuh"
 #include "predict.cc"
 #include "sigma_estimation.cc"
+#include "integration_calculations.cc"
 #include "version.hpp"
 #include "h5read.h"
 
 using json = nlohmann::json;
+using Eigen::Vector3i;
 
+constexpr size_t IntegratedSum = (1 << 8);
+constexpr double DEG2RAD = M_PI / 180.0;
+constexpr double RAD2DEG = 180.0 / M_PI;
 
 #pragma region Argument Parsing
 class BaselineIntegratorArgumentParser : public FFSArgumentParser {
@@ -100,38 +106,6 @@ class BaselineIntegratorArgumentParser : public FFSArgumentParser {
     }
 };
 #pragma endregion Argument Parsing
-constexpr double DEG2RAD = M_PI / 180.0;
-constexpr double RAD2DEG = 180.0 / M_PI;
-class CoordinateSystem {
-  public:
-    CoordinateSystem(Vector3d m2, Vector3d s0, Vector3d s1, double phi) : s1_(s1), phi_(phi) {
-      Vector3d m2_(m2);
-      m2_.normalize();
-      Vector3d e1_ = s1.cross(s0);
-      e1_.normalize();
-      Vector3d e2_ = s1.cross(e1_);
-      e2_.normalize();
-      double s1_length = s1.norm();
-      scaled_e1_ = e1_ /  s1_length;
-      scaled_e2_ = e2_ /  s1_length;
-      zeta_ = m2_.dot(e1_);
-    }
-    Vector3d coords_from_s1vector(const Vector3d s_dash, double phi_dash){
-      Vector3d coord = {scaled_e1_.dot(s_dash - s1_),
-          scaled_e2_.dot(s_dash - s1_),
-          zeta_ * (phi_dash - phi_)};
-      return coord;
-    }
-    double zeta() const {
-      return zeta_;
-    }
-  private:
-    Vector3d s1_;
-    double phi_;
-    double zeta_;
-    Vector3d scaled_e1_;
-    Vector3d scaled_e2_;
-};
 
 
 #pragma region Application Entry
@@ -202,6 +176,7 @@ int main(int argc, char **argv) {
     Goniometer gonio = expt.goniometer();
     const Panel &panel = expt.detector().panels()[0];  // Assuming single panel detector
     const Scan &scan = expt.scan();
+    const Crystal &crystal = expt.crystal();
 
     // Extract vectors and parameters
     Eigen::Vector3d s0 = beam.get_s0();
@@ -210,6 +185,7 @@ int main(int argc, char **argv) {
     int image_range_start = scan.get_image_range()[0];
     int image_range_end = scan.get_image_range()[1];
     double wl = beam.get_wavelength();
+    gemmi::UnitCell cell = crystal.get_unit_cell();
 
     logger.info("Experimental parameters:");
     logger.info("  Beam s0: ({:.6f}, {:.6f}, {:.6f})", s0.x(), s0.y(), s0.z());
@@ -353,6 +329,8 @@ int main(int argc, char **argv) {
     }
 
 #pragma endregion Predict or extract predictions
+
+#pragma region Calculate or extract bounding boxes
     // Create a new reflection table for the output.
     std::vector<std::string> identifiers = reflections.get_identifiers();
     std::vector<uint64_t> ids = reflections.get_experiment_ids();
@@ -396,20 +374,15 @@ int main(int argc, char **argv) {
         logger.info("Successfully loaded {} bounding boxes from input reflections",
                     computed_bounding_boxes.size());
     }
-    
+
+#pragma endregion Calculate or extract bounding boxes
+
+#pragma region Map reflections to images
     // Map reflections by z layer (image number)
     logger.info("Mapping reflections by image number (z layer)");
     std::unordered_map<int, std::vector<size_t>> reflections_by_image;
-    std::vector<int> intensity_accumulators(num_reflections);
-    std::vector<int> bg_accumulators(num_reflections);
-    std::vector<int> nbg_accumulators(num_reflections);
-    std::vector<int> nfg_accumulators(num_reflections);
-    std::vector<int> nbgbad_accumulators(num_reflections);
-    std::vector<bool> success(num_reflections, true);
-
     for (size_t refl_id = 0; refl_id < num_reflections; ++refl_id) {
         const auto &bbox = computed_bounding_boxes[refl_id];
-
         // Add this reflection to all images it spans
         for (int z = bbox.z_min; z < bbox.z_max; ++z) {
             reflections_by_image[z].push_back(refl_id);
@@ -418,32 +391,33 @@ int main(int argc, char **argv) {
     logger.info("Reflections mapped across {} unique images",
                 reflections_by_image.size());
     
-
     std::vector<int> keys;
     keys.reserve(reflections_by_image.size());
     for (const auto& kv : reflections_by_image) {
         keys.push_back(kv.first);
     }
     std::sort(keys.begin(), keys.end());
-
     
     for (int image : keys) {
         const auto& refl_list = reflections_by_image.at(image);
         logger.info("Image {} has {} reflections", image+1, refl_list.size());
     }
+#pragma endregion Map reflections to images
 
-
-    // Now load some image data:
-    std::string filename = expt.imagesequence().filename();
-    auto reader = H5Read(filename);
-    size_t n_images = reader.get_number_of_images();
-    auto [image_slow, image_fast] = reader.image_shape();
+#pragma region Loop over images and perform summation
+    // Set up data arrays to fill during accumulation
+    std::vector<int> intensity_accumulators(num_reflections);
+    std::vector<Vector3d> intensity_times_coord_accumulators(num_reflections);
+    std::vector<int> bg_accumulators(num_reflections);
+    std::vector<int> nbg_accumulators(num_reflections);
+    std::vector<int> nfg_accumulators(num_reflections);
+    std::vector<bool> success(num_reflections, true);
+    std::vector<CoordinateSystem> coord_system_vector = {}; // a vector of coordinate systems for each reflection.
+    coord_system_vector.reserve(num_reflections);
+    // Precalculate a few things
     double s0_length = beam.get_s0().norm();
     double phi0 = scan.get_oscillation()[0];
     double dphi = scan.get_oscillation()[1];
-    // make a vector of coordinate systems for each reflection.
-    std::vector<CoordinateSystem> coord_system_vector = {};
-    coord_system_vector.reserve(num_reflections);
     const Vector3d m2 = gonio.get_rotation_axis();
     for (int i=0;i<num_reflections;i++){
       Vector3d s1_this = Eigen::Map<Vector3d>(&s1_vectors(i,0));
@@ -454,22 +428,25 @@ int main(int argc, char **argv) {
     double delta_b_r2 = 1.0 / (delta_b * delta_b);
     double delta_m = sigma_m * 3.0;
     double delta_m_r2 = 1.0 / (delta_m * delta_m);
+
+    // Now load some image data and loop through:
+    std::string filename = expt.imagesequence().filename();
+    auto reader = H5Read(filename);
+    size_t n_images = reader.get_number_of_images();
+    auto [image_slow, image_fast] = reader.image_shape();
     auto mask = reader.get_mask().value();
+
     for (size_t j = 0; j < n_images; j++) {
       if (!reader.is_image_available(j)) {
         continue;
       }
       auto image = reader.get_image(j);
-      std::cout << "Processing image " << j +1 << std::endl;
-      size_t zero = 0;
-      size_t masked = 0;
-      size_t total = 0;
-      size_t signal = 0;
+      logger.info("Processing image {}", j +1);
       for (size_t k=0;k<reflections_by_image[j].size();k++){
         size_t refl_id = reflections_by_image[j][k];
         const auto &bbox = computed_bounding_boxes[refl_id];
         
-        // calculate dxy array
+        // calculate dxy array (arrays of distances in kabsch space from pixel corners to xyzcal)
         int n_x = bbox.x_max - bbox.x_min + 1;
         int n_y = bbox.y_max - bbox.y_min + 1;
         std::vector<double> dxy_start(n_x * n_y); // start of image (in rotation)
@@ -501,58 +478,60 @@ int main(int argc, char **argv) {
                  * delta_b_r2) + ((epsilon_coords_end[2] * epsilon_coords_end[2]) * delta_m_r2);
           }
         }
+        // Now loop through pixels in bbox, adding to foreground or background if unmasked and in image.
         for (int x = bbox.x_min; x<bbox.x_max; x++){
           for (int y = bbox.y_min; y<bbox.y_max; y++){
-            if (x >=0 && x < image_fast && y >=0 && y < image_slow){
-              int index = x + (y * image_fast);
-              //std::cout << index << std::endl;
-              int x_index = x - bbox.x_min;
-              int y_index = y - bbox.y_min;
-              int dxyindex = x_index + (y_index * n_x);
-              double d1 = dxy_start[dxyindex];
-              double d2 = dxy_start[dxyindex+1];
-              double d3 = dxy_start[dxyindex+n_x];
-              double d4 = dxy_start[dxyindex+n_x+1];
-              double d5 = dxy_end[dxyindex];
-              double d6 = dxy_end[dxyindex+1];
-              double d7 = dxy_end[dxyindex+n_x];
-              double d8 = dxy_end[dxyindex+n_x+1];
-              double d = std::min(std::min(std::min(d1, d2), std::min(d3, d4)),
-                                  std::min(std::min(d5, d6), std::min(d7, d8)));
-              if (mask[index] == 0){
-                // masked, might be ok if bg
-                if (d > 1.0){
-                  nbgbad_accumulators[refl_id] += 1;
-                }
-                else {
+            // The bounding box may extend beyond the image - if so, this is ok if it is only background
+            // but not if it is foreground.
+            int x_index = x - bbox.x_min;
+            int y_index = y - bbox.y_min;
+            int dxyindex = x_index + (y_index * n_x);
+            double d1 = dxy_start[dxyindex];
+            double d2 = dxy_start[dxyindex+1];
+            double d3 = dxy_start[dxyindex+n_x];
+            double d4 = dxy_start[dxyindex+n_x+1];
+            double d5 = dxy_end[dxyindex];
+            double d6 = dxy_end[dxyindex+1];
+            double d7 = dxy_end[dxyindex+n_x];
+            double d8 = dxy_end[dxyindex+n_x+1];
+            double d = std::min(std::min(std::min(d1, d2), std::min(d3, d4)),
+                                std::min(std::min(d5, d6), std::min(d7, d8)));
+            int index = x + (y * image_fast);
+            bool in_image = x >=0 && x < image_fast && y >=0 && y < image_slow;
+            if (d <= 1.0){
+              // Foreground
+              if (in_image){
+                if (mask[index] == 0){ // masked
                   success[refl_id] = false;
-                }
-              } else {
-                // Not masked
-                uint16_t data = image.data.data()[index];
-                //std::cout << "Read data" << std::endl;
-                // Need to work out if foreground or background.
-                
-                //std::cout << "Calculated d" << std::endl;
-                if (d > 1.0){
-                  bg_accumulators[refl_id] += data;
-                  nbg_accumulators[refl_id] += 1;
-                }
-                else {
+                } else {
+                  uint16_t data = image.data.data()[index];
                   intensity_accumulators[refl_id] += data;
                   nfg_accumulators[refl_id] += 1;
+                  Vector3d I_times_c = {data *(x + 0.5), data * (y+0.5), data * (j+0.5)};
+                  intensity_times_coord_accumulators[refl_id] += I_times_c;
+                }
+              } else {
+                success[refl_id] = false;
+              }
+            } else { // d>1.0
+              // Background
+              if (in_image){
+                if (mask[index] != 0){
+                  // In image, not masked
+                  uint16_t data = image.data.data()[index];
+                  bg_accumulators[refl_id] += data;
+                  nbg_accumulators[refl_id] += 1;
                 }
               }
             }
           }
         }
       }
-      //h5read_free_image(image);
-      //std::cout << "Processed image " << j +1 << std::endl;
     }
-    //h5read_free(obj);
+#pragma endregion Loop over images and perform summation
 
-    // Convert to reflection table format
+#pragma region Finalize calculations
+    // Convert bbox data to reflection table format
     std::vector<double> computed_bbox_data;
     computed_bbox_data.reserve(num_reflections * 6);
     for (const auto &bbox : computed_bounding_boxes) {
@@ -564,16 +543,18 @@ int main(int argc, char **argv) {
                                    static_cast<double>(bbox.z_min),
                                    static_cast<double>(bbox.z_max)});
     }
-
-    // Create results and save to HDF5
-    logger.info("Saving results to: {}", output_file);
-
+    // FIXME - these are not yet output as seems to cause an issue with dials?
     // Add computed bounding boxes to reflection table
     //integrated_data.add_column(
     //  "baseline_bbox", std::vector<size_t>{num_reflections, 6}, computed_bbox_data);
+
+    // Do the calculations to determine the background-subtracted intensities as well as other quantities of interest.
     std::vector<double> intensities(num_reflections);
     std::vector<double> variances(num_reflections);
     std::vector<double> partialities(num_reflections);
+    std::vector<double> lp_corrections(num_reflections);
+    std::vector<double> xyzobs_px(num_reflections*3);
+    std::vector<double> d_values(num_reflections);
     for (int i=0;i<num_reflections;i++){
       if (nbg_accumulators[i]){
         double bg = nfg_accumulators[i] * bg_accumulators[i] / static_cast<double>(nbg_accumulators[i]); // average bg * num fg pixels
@@ -581,27 +562,44 @@ int main(int argc, char **argv) {
         intensities[i] = I;
         double m_n = nfg_accumulators[i] / nbg_accumulators[i];
         variances[i] = std::abs(I) + (std::abs(bg) * (1.0 + m_n));
+        if ((nfg_accumulators[i] > 0) && (intensity_accumulators[i] > 0)){
+          Vector3d com = intensity_times_coord_accumulators[i] / intensity_accumulators[i];
+          xyzobs_px[i*3] = com[0];
+          xyzobs_px[i*3+1] = com[1];
+          xyzobs_px[i*3+2] = com[2];
+        } else {
+          success[i] = false;
+        }
       }
       else {
         success[i] = false;
       }
     }
-    // Calculate the partiality of all reflections
+    // Calculate the partiality, LP, d of all reflections
+    Vector3d pn = beam.get_polarization_normal();
+    double pf = beam.get_polarization_fraction();
+    LPCorrection lpcalculator(s0, pn, pf, rotation_axis);
     for (int i=0;i<num_reflections;i++){
       double xyzcal_px_z = phi_column(i,2) * RAD2DEG / osc_width;
-      // then convert to phi
-      // convert bbox start and end to phi.
-
       double phi = osc_start + ((xyzcal_px_z + 1 - image_range_start)*osc_width);
       double phia = osc_start + ((computed_bounding_boxes[i].z_min + 1 - image_range_start)*osc_width);
       double phib = osc_start + ((computed_bounding_boxes[i].z_max + 1 - image_range_start)*osc_width);
-
       double zeta = coord_system_vector[i].zeta();
+      // Partiality calculation
       double c = std::abs(zeta) / (std::sqrt(2.0) * sigma_m);
       double p = 0.5 * (std::erf(c * (phib - phi)) - std::erf(c * (phia - phi)));
       partialities[i] = p;
+      // LP calculation
+      Vector3d s1_this = Eigen::Map<Vector3d>(&s1_vectors(i,0));
+      lp_corrections[i] = lpcalculator.calculate(s1_this);
+      // resolution calculation
+      std::array<int, 3> hkl_this = {hkl_vectors[i*3],hkl_vectors[i*3+1],hkl_vectors[i*3+2]};
+      d_values[i] = cell.calculate_d(hkl_this);
     }
+#pragma endregion Finalize calculations
 
+#pragma region Make output table and save
+    // Add data to reflection table.
     integrated_data.add_column(
       "intensity.sum.value", num_reflections,1,intensities
     );
@@ -614,6 +612,12 @@ int main(int argc, char **argv) {
     integrated_data.add_column(
       "miller_index", num_reflections,3, hkl_vectors
     );
+    integrated_data.add_column(
+      "lp", num_reflections,1, lp_corrections
+    );
+    integrated_data.add_column(
+      "d", num_reflections,1, d_values
+    );
     std::vector<double> xyzcal_mm = std::vector<double>(
       phi_column.data_handle(), phi_column.data_handle() + phi_column.size()
     );
@@ -622,16 +626,18 @@ int main(int argc, char **argv) {
     );
     std::vector<int> id = std::vector<int>(num_reflections, 0);
     integrated_data.add_column("xyzcal.mm", num_reflections, 3, xyzcal_mm);
+    integrated_data.add_column("xyzobs.px.value", num_reflections, 3, xyzobs_px);
     integrated_data.add_column("s1", num_reflections, 3, s1);
     integrated_data.add_column("id", num_reflections, 1, id);
+    std::vector<std::size_t> final_flags(num_reflections, IntegratedSum);
+    integrated_data.add_column(std::string("flags"), num_reflections, 1, final_flags);
+
+    // Only output successfully integrated reflections.
     ReflectionTable success_data = integrated_data.select(success);
     int n_integrated = success_data.column<double>("intensity.sum.value").value().extent(0);
+    // Other things to potentially output xyzcal.px, xyzobs.mm.value, xyzobs.mm.variance, xyzobs.px.variance?
 
-
-    // Other things to output
-    // d, flags, id, intensity.sum.variance, lp, partiality, xyzcal.px?,
-    // xyzobs.mm.value, xyzobs.mm.variance, xyzobs.px.value, xyzobs.px.variance
-
+    logger.info("Saving results to: {}", output_file);
     success_data.write(output_file);
     logger.info("Baseline integration complete!");
     logger.info("Summary:");
@@ -639,6 +645,8 @@ int main(int argc, char **argv) {
     logger.info("  {} bounding boxes computed", computed_bounding_boxes.size());
     logger.info("  {} reflections successfully integrated", n_integrated);
     logger.info("Results saved to: {}", output_file);
+
+#pragma endregion Make output table and save
 
     return 0;
 }

--- a/baseline/integrator/integrator.cc
+++ b/baseline/integrator/integrator.cc
@@ -5,15 +5,15 @@
 
 #include <Eigen/Dense>
 #include <dx2/beam.hpp>
-#include <dx2/experiment.hpp>
 #include <dx2/detector.hpp>
+#include <dx2/experiment.hpp>
 #include <dx2/goniometer.hpp>
 #include <dx2/h5/h5read_processed.hpp>
 #include <dx2/reflection.hpp>
-#include <gemmi/unitcell.hpp>
 #include <experimental/mdspan>
 #include <filesystem>
 #include <fstream>
+#include <gemmi/unitcell.hpp>
 #include <iostream>
 #include <nlohmann/json.hpp>
 #include <string>
@@ -23,13 +23,13 @@
 #include "common.hpp"
 #include "extent.cc"
 #include "ffs_logger.hpp"
+#include "h5read.h"
+#include "integration_calculations.cc"
 #include "kabsch.cc"
 #include "math/math_utils.cuh"
 #include "predict.cc"
 #include "sigma_estimation.cc"
-#include "integration_calculations.cc"
 #include "version.hpp"
-#include "h5read.h"
 
 using json = nlohmann::json;
 using Eigen::Vector3i;
@@ -106,7 +106,6 @@ class BaselineIntegratorArgumentParser : public FFSArgumentParser {
     }
 };
 #pragma endregion Argument Parsing
-
 
 #pragma region Application Entry
 int main(int argc, char **argv) {
@@ -324,7 +323,7 @@ int main(int argc, char **argv) {
         phi_column = *phi_column_opt;
         num_reflections = s1_vectors.extent(0);
         hkl_vectors = std::vector<int>(
-          hkl_vectors_opt.value().data_handle(), 
+          hkl_vectors_opt.value().data_handle(),
           hkl_vectors_opt.value().data_handle() + hkl_vectors_opt.value().size());
     }
 
@@ -344,32 +343,32 @@ int main(int argc, char **argv) {
     if (!computed_bounding_boxes_opt.has_value()) {
         logger.info("Computing Kabsch bounding boxes using baseline CPU algorithms...");
         computed_bounding_boxes = compute_kabsch_bounding_boxes(s0,
-                                                                    rotation_axis,
-                                                                    s1_vectors,
-                                                                    phi_column,
-                                                                    num_reflections,
-                                                                    sigma_b,
-                                                                    sigma_m,
-                                                                    panel,
-                                                                    scan,
-                                                                    beam);
+                                                                rotation_axis,
+                                                                s1_vectors,
+                                                                phi_column,
+                                                                num_reflections,
+                                                                sigma_b,
+                                                                sigma_m,
+                                                                panel,
+                                                                scan,
+                                                                beam);
 
         logger.info("Successfully computed {} bounding boxes",
                     computed_bounding_boxes.size());
-        }
-    else {
-        std::vector<int> bbox_data = std::vector<int>(
-          computed_bounding_boxes_opt.value().data_handle(), 
-          computed_bounding_boxes_opt.value().data_handle() + computed_bounding_boxes_opt.value().size());
-        for (int i=0;i<bbox_data.size();i+=6){
-          BoundingBoxExtents bbox;
-          bbox.x_min = bbox_data[i];
-          bbox.x_max = bbox_data[i+1];
-          bbox.y_min = bbox_data[i+2];
-          bbox.y_max = bbox_data[i+3];
-          bbox.z_min = bbox_data[i+4];
-          bbox.z_max = bbox_data[i+5];
-          computed_bounding_boxes.push_back(bbox);
+    } else {
+        std::vector<int> bbox_data =
+          std::vector<int>(computed_bounding_boxes_opt.value().data_handle(),
+                           computed_bounding_boxes_opt.value().data_handle()
+                             + computed_bounding_boxes_opt.value().size());
+        for (int i = 0; i < bbox_data.size(); i += 6) {
+            BoundingBoxExtents bbox;
+            bbox.x_min = bbox_data[i];
+            bbox.x_max = bbox_data[i + 1];
+            bbox.y_min = bbox_data[i + 2];
+            bbox.y_max = bbox_data[i + 3];
+            bbox.z_min = bbox_data[i + 4];
+            bbox.z_max = bbox_data[i + 5];
+            computed_bounding_boxes.push_back(bbox);
         }
         logger.info("Successfully loaded {} bounding boxes from input reflections",
                     computed_bounding_boxes.size());
@@ -390,17 +389,17 @@ int main(int argc, char **argv) {
     }
     logger.info("Reflections mapped across {} unique images",
                 reflections_by_image.size());
-    
+
     std::vector<int> keys;
     keys.reserve(reflections_by_image.size());
-    for (const auto& kv : reflections_by_image) {
+    for (const auto &kv : reflections_by_image) {
         keys.push_back(kv.first);
     }
     std::sort(keys.begin(), keys.end());
-    
+
     for (int image : keys) {
-        const auto& refl_list = reflections_by_image.at(image);
-        logger.info("Image {} has {} reflections", image+1, refl_list.size());
+        const auto &refl_list = reflections_by_image.at(image);
+        logger.info("Image {} has {} reflections", image + 1, refl_list.size());
     }
 #pragma endregion Map reflections to images
 
@@ -412,17 +411,18 @@ int main(int argc, char **argv) {
     std::vector<int> nbg_accumulators(num_reflections);
     std::vector<int> nfg_accumulators(num_reflections);
     std::vector<bool> success(num_reflections, true);
-    std::vector<CoordinateSystem> coord_system_vector = {}; // a vector of coordinate systems for each reflection.
+    std::vector<CoordinateSystem> coord_system_vector =
+      {};  // a vector of coordinate systems for each reflection.
     coord_system_vector.reserve(num_reflections);
     // Precalculate a few things
     double s0_length = beam.get_s0().norm();
     double phi0 = scan.get_oscillation()[0];
     double dphi = scan.get_oscillation()[1];
     const Vector3d m2 = gonio.get_rotation_axis();
-    for (int i=0;i<num_reflections;i++){
-      Vector3d s1_this = Eigen::Map<Vector3d>(&s1_vectors(i,0));
-      coord_system_vector.push_back(CoordinateSystem(
-        m2, s0, s1_this, phi_column(i,2)));
+    for (int i = 0; i < num_reflections; i++) {
+        Vector3d s1_this = Eigen::Map<Vector3d>(&s1_vectors(i, 0));
+        coord_system_vector.push_back(
+          CoordinateSystem(m2, s0, s1_this, phi_column(i, 2)));
     }
     double delta_b = sigma_b * 3.0;
     double delta_b_r2 = 1.0 / (delta_b * delta_b);
@@ -437,96 +437,107 @@ int main(int argc, char **argv) {
     auto mask = reader.get_mask().value();
 
     for (size_t j = 0; j < n_images; j++) {
-      if (!reader.is_image_available(j)) {
-        continue;
-      }
-      auto image = reader.get_image(j);
-      logger.info("Processing image {}", j +1);
-      for (size_t k=0;k<reflections_by_image[j].size();k++){
-        size_t refl_id = reflections_by_image[j][k];
-        const auto &bbox = computed_bounding_boxes[refl_id];
-        
-        // calculate dxy array (arrays of distances in kabsch space from pixel corners to xyzcal)
-        int n_x = bbox.x_max - bbox.x_min + 1;
-        int n_y = bbox.y_max - bbox.y_min + 1;
-        std::vector<double> dxy_start(n_x * n_y); // start of image (in rotation)
-        std::vector<double> dxy_end(n_x * n_y); // end of image (in rotation)
-        double phidash_start = (phi0 + (j * dphi)) * DEG2RAD;
-        double phidash_end = (phi0 + ((j + 1) * dphi)) * DEG2RAD;
-        double phi_c = phi_column(refl_id,2);
-        CoordinateSystem cs = coord_system_vector[refl_id];
-        Vector3d s1_this = Eigen::Map<Vector3d>(&s1_vectors(refl_id,0));
-        for (int x = 0; x<n_x; x++){
-          for (int y = 0; y<n_y; y++){
-            int index = x + (y * (n_x));
-            std::array<double, 2> px_mm = panel.px_to_mm(x+bbox.x_min,y+bbox.y_min);
-            Vector3d s1_ = panel.get_lab_coord(px_mm[0], px_mm[1]);
-            s1_.normalize();
-            Vector3d s1dash = s1_ * s0_length;
-            Vector3d epsilon_coords_start = cs.coords_from_s1vector(s1dash, phidash_start);
-            Vector3d epsilon_coords_end = cs.coords_from_s1vector(s1dash, phidash_end);
-            if ((phidash_start > phi_c) && (phi_c < phidash_end)) {
-              epsilon_coords_start[2] = 0.0;
-              epsilon_coords_end[2] = 0.0;
-            }
-            
-            dxy_start[index] = ((epsilon_coords_start[0] * epsilon_coords_start[0]
-                  + epsilon_coords_start[1] * epsilon_coords_start[1])
-                 * delta_b_r2) + ((epsilon_coords_start[2] * epsilon_coords_start[2]) * delta_m_r2);
-            dxy_end[index] = ((epsilon_coords_end[0] * epsilon_coords_end[0]
-                  + epsilon_coords_end[1] * epsilon_coords_end[1])
-                 * delta_b_r2) + ((epsilon_coords_end[2] * epsilon_coords_end[2]) * delta_m_r2);
-          }
+        if (!reader.is_image_available(j)) {
+            continue;
         }
-        // Now loop through pixels in bbox, adding to foreground or background if unmasked and in image.
-        for (int x = bbox.x_min; x<bbox.x_max; x++){
-          for (int y = bbox.y_min; y<bbox.y_max; y++){
-            // The bounding box may extend beyond the image - if so, this is ok if it is only background
-            // but not if it is foreground.
-            int x_index = x - bbox.x_min;
-            int y_index = y - bbox.y_min;
-            int dxyindex = x_index + (y_index * n_x);
-            double d1 = dxy_start[dxyindex];
-            double d2 = dxy_start[dxyindex+1];
-            double d3 = dxy_start[dxyindex+n_x];
-            double d4 = dxy_start[dxyindex+n_x+1];
-            double d5 = dxy_end[dxyindex];
-            double d6 = dxy_end[dxyindex+1];
-            double d7 = dxy_end[dxyindex+n_x];
-            double d8 = dxy_end[dxyindex+n_x+1];
-            double d = std::min(std::min(std::min(d1, d2), std::min(d3, d4)),
-                                std::min(std::min(d5, d6), std::min(d7, d8)));
-            int index = x + (y * image_fast);
-            bool in_image = x >=0 && x < image_fast && y >=0 && y < image_slow;
-            if (d <= 1.0){
-              // Foreground
-              if (in_image){
-                if (mask[index] == 0){ // masked
-                  success[refl_id] = false;
-                } else {
-                  uint16_t data = image.data.data()[index];
-                  intensity_accumulators[refl_id] += data;
-                  nfg_accumulators[refl_id] += 1;
-                  Vector3d I_times_c = {data *(x + 0.5), data * (y+0.5), data * (j+0.5)};
-                  intensity_times_coord_accumulators[refl_id] += I_times_c;
+        auto image = reader.get_image(j);
+        logger.info("Processing image {}", j + 1);
+        for (size_t k = 0; k < reflections_by_image[j].size(); k++) {
+            size_t refl_id = reflections_by_image[j][k];
+            const auto &bbox = computed_bounding_boxes[refl_id];
+
+            // calculate dxy array (arrays of distances in kabsch space from pixel corners to xyzcal)
+            int n_x = bbox.x_max - bbox.x_min + 1;
+            int n_y = bbox.y_max - bbox.y_min + 1;
+            std::vector<double> dxy_start(n_x * n_y);  // start of image (in rotation)
+            std::vector<double> dxy_end(n_x * n_y);    // end of image (in rotation)
+            double phidash_start = (phi0 + (j * dphi)) * DEG2RAD;
+            double phidash_end = (phi0 + ((j + 1) * dphi)) * DEG2RAD;
+            double phi_c = phi_column(refl_id, 2);
+            CoordinateSystem cs = coord_system_vector[refl_id];
+            Vector3d s1_this = Eigen::Map<Vector3d>(&s1_vectors(refl_id, 0));
+            for (int x = 0; x < n_x; x++) {
+                for (int y = 0; y < n_y; y++) {
+                    int index = x + (y * (n_x));
+                    std::array<double, 2> px_mm =
+                      panel.px_to_mm(x + bbox.x_min, y + bbox.y_min);
+                    Vector3d s1_ = panel.get_lab_coord(px_mm[0], px_mm[1]);
+                    s1_.normalize();
+                    Vector3d s1dash = s1_ * s0_length;
+                    Vector3d epsilon_coords_start =
+                      cs.coords_from_s1vector(s1dash, phidash_start);
+                    Vector3d epsilon_coords_end =
+                      cs.coords_from_s1vector(s1dash, phidash_end);
+                    if ((phidash_start > phi_c) && (phi_c < phidash_end)) {
+                        epsilon_coords_start[2] = 0.0;
+                        epsilon_coords_end[2] = 0.0;
+                    }
+
+                    dxy_start[index] =
+                      ((epsilon_coords_start[0] * epsilon_coords_start[0]
+                        + epsilon_coords_start[1] * epsilon_coords_start[1])
+                       * delta_b_r2)
+                      + ((epsilon_coords_start[2] * epsilon_coords_start[2])
+                         * delta_m_r2);
+                    dxy_end[index] =
+                      ((epsilon_coords_end[0] * epsilon_coords_end[0]
+                        + epsilon_coords_end[1] * epsilon_coords_end[1])
+                       * delta_b_r2)
+                      + ((epsilon_coords_end[2] * epsilon_coords_end[2]) * delta_m_r2);
                 }
-              } else {
-                success[refl_id] = false;
-              }
-            } else { // d>1.0
-              // Background
-              if (in_image){
-                if (mask[index] != 0){
-                  // In image, not masked
-                  uint16_t data = image.data.data()[index];
-                  bg_accumulators[refl_id] += data;
-                  nbg_accumulators[refl_id] += 1;
-                }
-              }
             }
-          }
+            // Now loop through pixels in bbox, adding to foreground or background if unmasked and in image.
+            for (int x = bbox.x_min; x < bbox.x_max; x++) {
+                for (int y = bbox.y_min; y < bbox.y_max; y++) {
+                    // The bounding box may extend beyond the image - if so, this is ok if it is only background
+                    // but not if it is foreground.
+                    int x_index = x - bbox.x_min;
+                    int y_index = y - bbox.y_min;
+                    int dxyindex = x_index + (y_index * n_x);
+                    double d1 = dxy_start[dxyindex];
+                    double d2 = dxy_start[dxyindex + 1];
+                    double d3 = dxy_start[dxyindex + n_x];
+                    double d4 = dxy_start[dxyindex + n_x + 1];
+                    double d5 = dxy_end[dxyindex];
+                    double d6 = dxy_end[dxyindex + 1];
+                    double d7 = dxy_end[dxyindex + n_x];
+                    double d8 = dxy_end[dxyindex + n_x + 1];
+                    double d = std::min(std::min(std::min(d1, d2), std::min(d3, d4)),
+                                        std::min(std::min(d5, d6), std::min(d7, d8)));
+                    int index = x + (y * image_fast);
+                    bool in_image =
+                      x >= 0 && x < image_fast && y >= 0 && y < image_slow;
+                    if (d <= 1.0) {
+                        // Foreground
+                        if (in_image) {
+                            if (mask[index] == 0) {  // masked
+                                success[refl_id] = false;
+                            } else {
+                                uint16_t data = image.data.data()[index];
+                                intensity_accumulators[refl_id] += data;
+                                nfg_accumulators[refl_id] += 1;
+                                Vector3d I_times_c = {
+                                  data * (x + 0.5), data * (y + 0.5), data * (j + 0.5)};
+                                intensity_times_coord_accumulators[refl_id] +=
+                                  I_times_c;
+                            }
+                        } else {
+                            success[refl_id] = false;
+                        }
+                    } else {  // d>1.0
+                        // Background
+                        if (in_image) {
+                            if (mask[index] != 0) {
+                                // In image, not masked
+                                uint16_t data = image.data.data()[index];
+                                bg_accumulators[refl_id] += data;
+                                nbg_accumulators[refl_id] += 1;
+                            }
+                        }
+                    }
+                }
+            }
         }
-      }
     }
 #pragma endregion Loop over images and perform summation
 
@@ -553,77 +564,70 @@ int main(int argc, char **argv) {
     std::vector<double> variances(num_reflections);
     std::vector<double> partialities(num_reflections);
     std::vector<double> lp_corrections(num_reflections);
-    std::vector<double> xyzobs_px(num_reflections*3);
+    std::vector<double> xyzobs_px(num_reflections * 3);
     std::vector<double> d_values(num_reflections);
-    for (int i=0;i<num_reflections;i++){
-      if (nbg_accumulators[i]){
-        double bg = nfg_accumulators[i] * bg_accumulators[i] / static_cast<double>(nbg_accumulators[i]); // average bg * num fg pixels
-        double I = intensity_accumulators[i] - bg;
-        intensities[i] = I;
-        double m_n = nfg_accumulators[i] / nbg_accumulators[i];
-        variances[i] = std::abs(I) + (std::abs(bg) * (1.0 + m_n));
-        if ((nfg_accumulators[i] > 0) && (intensity_accumulators[i] > 0)){
-          Vector3d com = intensity_times_coord_accumulators[i] / intensity_accumulators[i];
-          xyzobs_px[i*3] = com[0];
-          xyzobs_px[i*3+1] = com[1];
-          xyzobs_px[i*3+2] = com[2];
+    for (int i = 0; i < num_reflections; i++) {
+        if (nbg_accumulators[i]) {
+            double bg =
+              nfg_accumulators[i] * bg_accumulators[i]
+              / static_cast<double>(nbg_accumulators[i]);  // average bg * num fg pixels
+            double I = intensity_accumulators[i] - bg;
+            intensities[i] = I;
+            double m_n = nfg_accumulators[i] / nbg_accumulators[i];
+            variances[i] = std::abs(I) + (std::abs(bg) * (1.0 + m_n));
+            if ((nfg_accumulators[i] > 0) && (intensity_accumulators[i] > 0)) {
+                Vector3d com =
+                  intensity_times_coord_accumulators[i] / intensity_accumulators[i];
+                xyzobs_px[i * 3] = com[0];
+                xyzobs_px[i * 3 + 1] = com[1];
+                xyzobs_px[i * 3 + 2] = com[2];
+            } else {
+                success[i] = false;
+            }
         } else {
-          success[i] = false;
+            success[i] = false;
         }
-      }
-      else {
-        success[i] = false;
-      }
     }
     // Calculate the partiality, LP, d of all reflections
     Vector3d pn = beam.get_polarization_normal();
     double pf = beam.get_polarization_fraction();
     LPCorrection lpcalculator(s0, pn, pf, rotation_axis);
-    for (int i=0;i<num_reflections;i++){
-      double xyzcal_px_z = phi_column(i,2) * RAD2DEG / osc_width;
-      double phi = osc_start + ((xyzcal_px_z + 1 - image_range_start)*osc_width);
-      double phia = osc_start + ((computed_bounding_boxes[i].z_min + 1 - image_range_start)*osc_width);
-      double phib = osc_start + ((computed_bounding_boxes[i].z_max + 1 - image_range_start)*osc_width);
-      double zeta = coord_system_vector[i].zeta();
-      // Partiality calculation
-      double c = std::abs(zeta) / (std::sqrt(2.0) * sigma_m);
-      double p = 0.5 * (std::erf(c * (phib - phi)) - std::erf(c * (phia - phi)));
-      partialities[i] = p;
-      // LP calculation
-      Vector3d s1_this = Eigen::Map<Vector3d>(&s1_vectors(i,0));
-      lp_corrections[i] = lpcalculator.calculate(s1_this);
-      // resolution calculation
-      std::array<int, 3> hkl_this = {hkl_vectors[i*3],hkl_vectors[i*3+1],hkl_vectors[i*3+2]};
-      d_values[i] = cell.calculate_d(hkl_this);
+    for (int i = 0; i < num_reflections; i++) {
+        double xyzcal_px_z = phi_column(i, 2) * RAD2DEG / osc_width;
+        double phi = osc_start + ((xyzcal_px_z + 1 - image_range_start) * osc_width);
+        double phia =
+          osc_start
+          + ((computed_bounding_boxes[i].z_min + 1 - image_range_start) * osc_width);
+        double phib =
+          osc_start
+          + ((computed_bounding_boxes[i].z_max + 1 - image_range_start) * osc_width);
+        double zeta = coord_system_vector[i].zeta();
+        // Partiality calculation
+        double c = std::abs(zeta) / (std::sqrt(2.0) * sigma_m);
+        double p = 0.5 * (std::erf(c * (phib - phi)) - std::erf(c * (phia - phi)));
+        partialities[i] = p;
+        // LP calculation
+        Vector3d s1_this = Eigen::Map<Vector3d>(&s1_vectors(i, 0));
+        lp_corrections[i] = lpcalculator.calculate(s1_this);
+        // resolution calculation
+        std::array<int, 3> hkl_this = {
+          hkl_vectors[i * 3], hkl_vectors[i * 3 + 1], hkl_vectors[i * 3 + 2]};
+        d_values[i] = cell.calculate_d(hkl_this);
     }
 #pragma endregion Finalize calculations
 
 #pragma region Make output table and save
     // Add data to reflection table.
-    integrated_data.add_column(
-      "intensity.sum.value", num_reflections,1,intensities
-    );
-    integrated_data.add_column(
-      "intensity.sum.variance", num_reflections,1,variances
-    );
-    integrated_data.add_column(
-      "partiality", num_reflections, 1, partialities
-    );
-    integrated_data.add_column(
-      "miller_index", num_reflections,3, hkl_vectors
-    );
-    integrated_data.add_column(
-      "lp", num_reflections,1, lp_corrections
-    );
-    integrated_data.add_column(
-      "d", num_reflections,1, d_values
-    );
+    integrated_data.add_column("intensity.sum.value", num_reflections, 1, intensities);
+    integrated_data.add_column("intensity.sum.variance", num_reflections, 1, variances);
+    integrated_data.add_column("partiality", num_reflections, 1, partialities);
+    integrated_data.add_column("miller_index", num_reflections, 3, hkl_vectors);
+    integrated_data.add_column("lp", num_reflections, 1, lp_corrections);
+    integrated_data.add_column("d", num_reflections, 1, d_values);
     std::vector<double> xyzcal_mm = std::vector<double>(
-      phi_column.data_handle(), phi_column.data_handle() + phi_column.size()
-    );
+      phi_column.data_handle(), phi_column.data_handle() + phi_column.size());
     std::vector<double> s1 = std::vector<double>(
-      s1_vectors.data_handle(), s1_vectors.data_handle() + s1_vectors.size()
-    );
+      s1_vectors.data_handle(), s1_vectors.data_handle() + s1_vectors.size());
     std::vector<int> id = std::vector<int>(num_reflections, 0);
     integrated_data.add_column("xyzcal.mm", num_reflections, 3, xyzcal_mm);
     integrated_data.add_column("xyzobs.px.value", num_reflections, 3, xyzobs_px);
@@ -634,7 +638,8 @@ int main(int argc, char **argv) {
 
     // Only output successfully integrated reflections.
     ReflectionTable success_data = integrated_data.select(success);
-    int n_integrated = success_data.column<double>("intensity.sum.value").value().extent(0);
+    int n_integrated =
+      success_data.column<double>("intensity.sum.value").value().extent(0);
     // Other things to potentially output xyzcal.px, xyzobs.mm.value, xyzobs.mm.variance, xyzobs.px.variance?
 
     logger.info("Saving results to: {}", output_file);

--- a/baseline/integrator/integrator.cc
+++ b/baseline/integrator/integrator.cc
@@ -99,6 +99,11 @@ class BaselineIntegratorArgumentParser : public FFSArgumentParser {
           .default_value<int>(6)
           .scan<'i', int>();
 
+        add_argument("-a","--algorithm")
+          .help(
+            "Foreground algorithm choice - dials or ellipsoid.")
+          .default_value<std::string>("ellipsoid");
+
         add_argument("output")
           .help("Output file path")
           .metavar("integrated.refl")
@@ -119,6 +124,10 @@ int main(int argc, char **argv) {
 
     float timeout = parser.get<float>("timeout");
     std::string output_file = parser.get<std::string>("output");
+    std::string fg_algorithm = parser.get<std::string>("algorithm");
+    if ((fg_algorithm != "dials") && (fg_algorithm != "ellipsoid")){
+        throw std::invalid_argument("Invalid algorithm specified (must be 'dials' or 'ellipsoid')");
+    }
 
     // Guard against missing files
     if (!std::filesystem::exists(reflection_file)) {
@@ -445,93 +454,166 @@ int main(int argc, char **argv) {
         for (size_t k = 0; k < reflections_by_image[j].size(); k++) {
             size_t refl_id = reflections_by_image[j][k];
             const auto &bbox = computed_bounding_boxes[refl_id];
-
-            // calculate dxy array (arrays of distances in kabsch space from pixel corners to xyzcal)
-            int n_x = bbox.x_max - bbox.x_min + 1;
-            int n_y = bbox.y_max - bbox.y_min + 1;
-            std::vector<double> dxy_start(n_x * n_y);  // start of image (in rotation)
-            std::vector<double> dxy_end(n_x * n_y);    // end of image (in rotation)
-            double phidash_start = (phi0 + (j * dphi)) * DEG2RAD;
-            double phidash_end = (phi0 + ((j + 1) * dphi)) * DEG2RAD;
-            double phi_c = phi_column(refl_id, 2);
-            CoordinateSystem cs = coord_system_vector[refl_id];
-            Vector3d s1_this = Eigen::Map<Vector3d>(&s1_vectors(refl_id, 0));
-            for (int x = 0; x < n_x; x++) {
-                for (int y = 0; y < n_y; y++) {
-                    int index = x + (y * (n_x));
-                    std::array<double, 2> px_mm =
-                      panel.px_to_mm(x + bbox.x_min, y + bbox.y_min);
-                    Vector3d s1_ = panel.get_lab_coord(px_mm[0], px_mm[1]);
-                    s1_.normalize();
-                    Vector3d s1dash = s1_ * s0_length;
-                    Vector3d epsilon_coords_start =
-                      cs.coords_from_s1vector(s1dash, phidash_start);
-                    Vector3d epsilon_coords_end =
-                      cs.coords_from_s1vector(s1dash, phidash_end);
-                    if ((phidash_start > phi_c) && (phi_c < phidash_end)) {
-                        epsilon_coords_start[2] = 0.0;
-                        epsilon_coords_end[2] = 0.0;
-                    }
-
-                    dxy_start[index] =
-                      ((epsilon_coords_start[0] * epsilon_coords_start[0]
-                        + epsilon_coords_start[1] * epsilon_coords_start[1])
-                       * delta_b_r2)
-                      + ((epsilon_coords_start[2] * epsilon_coords_start[2])
-                         * delta_m_r2);
-                    dxy_end[index] =
-                      ((epsilon_coords_end[0] * epsilon_coords_end[0]
-                        + epsilon_coords_end[1] * epsilon_coords_end[1])
-                       * delta_b_r2)
-                      + ((epsilon_coords_end[2] * epsilon_coords_end[2]) * delta_m_r2);
-                }
-            }
-            // Now loop through pixels in bbox, adding to foreground or background if unmasked and in image.
-            for (int x = bbox.x_min; x < bbox.x_max; x++) {
-                for (int y = bbox.y_min; y < bbox.y_max; y++) {
-                    // The bounding box may extend beyond the image - if so, this is ok if it is only background
-                    // but not if it is foreground.
-                    int x_index = x - bbox.x_min;
-                    int y_index = y - bbox.y_min;
-                    int dxyindex = x_index + (y_index * n_x);
-                    double d1 = dxy_start[dxyindex];
-                    double d2 = dxy_start[dxyindex + 1];
-                    double d3 = dxy_start[dxyindex + n_x];
-                    double d4 = dxy_start[dxyindex + n_x + 1];
-                    double d5 = dxy_end[dxyindex];
-                    double d6 = dxy_end[dxyindex + 1];
-                    double d7 = dxy_end[dxyindex + n_x];
-                    double d8 = dxy_end[dxyindex + n_x + 1];
-                    double d = std::min(std::min(std::min(d1, d2), std::min(d3, d4)),
-                                        std::min(std::min(d5, d6), std::min(d7, d8)));
-                    int index = x + (y * image_fast);
-                    bool in_image =
-                      x >= 0 && x < image_fast && y >= 0 && y < image_slow;
-                    if (d <= 1.0) {
-                        // Foreground
-                        if (in_image) {
-                            if (mask[index] == 0) {  // masked
-                                success[refl_id] = false;
-                            } else {
-                                uint16_t data = image.data.data()[index];
-                                intensity_accumulators[refl_id] += data;
-                                nfg_accumulators[refl_id] += 1;
-                                Vector3d I_times_c = {
-                                  data * (x + 0.5), data * (y + 0.5), data * (j + 0.5)};
-                                intensity_times_coord_accumulators[refl_id] +=
-                                  I_times_c;
-                            }
-                        } else {
-                            success[refl_id] = false;
+            if (fg_algorithm == "ellipsoid"){
+                // calculate dxy array (arrays of distances in kabsch space from pixel corners to xyzcal)
+                int n_x = bbox.x_max - bbox.x_min + 1;
+                int n_y = bbox.y_max - bbox.y_min + 1;
+                std::vector<double> dxy_start(n_x * n_y);  // start of image (in rotation)
+                std::vector<double> dxy_end(n_x * n_y);    // end of image (in rotation)
+                double phidash_start = (phi0 + (j * dphi)) * DEG2RAD;
+                double phidash_end = (phi0 + ((j + 1) * dphi)) * DEG2RAD;
+                double phi_c = phi_column(refl_id, 2);
+                CoordinateSystem cs = coord_system_vector[refl_id];
+                Vector3d s1_this = Eigen::Map<Vector3d>(&s1_vectors(refl_id, 0));
+                for (int x = 0; x < n_x; x++) {
+                    for (int y = 0; y < n_y; y++) {
+                        int index = x + (y * (n_x));
+                        std::array<double, 2> px_mm =
+                        panel.px_to_mm(x + bbox.x_min, y + bbox.y_min);
+                        Vector3d s1_ = panel.get_lab_coord(px_mm[0], px_mm[1]);
+                        s1_.normalize();
+                        Vector3d s1dash = s1_ * s0_length;
+                        Vector3d epsilon_coords_start =
+                        cs.coords_from_s1vector(s1dash, phidash_start);
+                        Vector3d epsilon_coords_end =
+                        cs.coords_from_s1vector(s1dash, phidash_end);
+                        if ((phidash_start > phi_c) && (phi_c < phidash_end)) {
+                            epsilon_coords_start[2] = 0.0;
+                            epsilon_coords_end[2] = 0.0;
                         }
-                    } else {  // d>1.0
-                        // Background
-                        if (in_image) {
-                            if (mask[index] != 0) {
-                                // In image, not masked
-                                uint16_t data = image.data.data()[index];
-                                bg_accumulators[refl_id] += data;
-                                nbg_accumulators[refl_id] += 1;
+
+                        dxy_start[index] =
+                        ((epsilon_coords_start[0] * epsilon_coords_start[0]
+                            + epsilon_coords_start[1] * epsilon_coords_start[1])
+                        * delta_b_r2)
+                        + ((epsilon_coords_start[2] * epsilon_coords_start[2])
+                            * delta_m_r2);
+                        dxy_end[index] =
+                        ((epsilon_coords_end[0] * epsilon_coords_end[0]
+                            + epsilon_coords_end[1] * epsilon_coords_end[1])
+                        * delta_b_r2)
+                        + ((epsilon_coords_end[2] * epsilon_coords_end[2]) * delta_m_r2);
+                    }
+                }
+                // Now loop through pixels in bbox, adding to foreground or background if unmasked and in image.
+                for (int x = bbox.x_min; x < bbox.x_max; x++) {
+                    for (int y = bbox.y_min; y < bbox.y_max; y++) {
+                        // The bounding box may extend beyond the image - if so, this is ok if it is only background
+                        // but not if it is foreground.
+                        int x_index = x - bbox.x_min;
+                        int y_index = y - bbox.y_min;
+                        int dxyindex = x_index + (y_index * n_x);
+                        double d1 = dxy_start[dxyindex];
+                        double d2 = dxy_start[dxyindex + 1];
+                        double d3 = dxy_start[dxyindex + n_x];
+                        double d4 = dxy_start[dxyindex + n_x + 1];
+                        double d5 = dxy_end[dxyindex];
+                        double d6 = dxy_end[dxyindex + 1];
+                        double d7 = dxy_end[dxyindex + n_x];
+                        double d8 = dxy_end[dxyindex + n_x + 1];
+                        double d = std::min(std::min(std::min(d1, d2), std::min(d3, d4)),
+                                            std::min(std::min(d5, d6), std::min(d7, d8)));
+                        int index = x + (y * image_fast);
+                        bool in_image =
+                        x >= 0 && x < image_fast && y >= 0 && y < image_slow;
+                        if (d <= 1.0) {
+                            // Foreground
+                            if (in_image) {
+                                if (mask[index] == 0) {  // masked
+                                    success[refl_id] = false;
+                                } else {
+                                    auto data = image.data.data()[index];
+                                    intensity_accumulators[refl_id] += data;
+                                    nfg_accumulators[refl_id] += 1;
+                                    Vector3d I_times_c = {
+                                    data * (x + 0.5), data * (y + 0.5), data * (j + 0.5)};
+                                    intensity_times_coord_accumulators[refl_id] +=
+                                    I_times_c;
+                                }
+                            } else { // NB dials doesn't seem to do this check.
+                                success[refl_id] = false;
+                            }
+                        } else {  // d>1.0
+                            // Background
+                            if (in_image) {
+                                if (mask[index] != 0) {
+                                    // In image, not masked=
+                                    uint16_t data = image.data.data()[index];
+                                    bg_accumulators[refl_id] += data;
+                                    nbg_accumulators[refl_id] += 1;
+                                }
+                            }
+                        }
+                    }
+                }
+            } else {
+                // dials algorithm - a fixed ellipse (2D) across all images in the bbox
+                int n_x = bbox.x_max - bbox.x_min + 1;
+                int n_y = bbox.y_max - bbox.y_min + 1;
+                std::vector<double> dxy(n_x * n_y);
+                double phi = phi0 + (j * dphi) * DEG2RAD; // Required for calls but not actually used as don't use e3.
+                CoordinateSystem cs = coord_system_vector[refl_id];
+                Vector3d s1_this = Eigen::Map<Vector3d>(&s1_vectors(refl_id, 0));
+                for (int x = 0; x < n_x; x++) {
+                    for (int y = 0; y < n_y; y++) {
+                        int index = x + (y * (n_x));
+                        std::array<double, 2> px_mm =
+                        panel.px_to_mm(x + bbox.x_min, y + bbox.y_min);
+                        Vector3d s1_ = panel.get_lab_coord(px_mm[0], px_mm[1]);
+                        s1_.normalize();
+                        Vector3d s1dash = s1_ * s0_length;
+                        Vector3d epsilon_coords =
+                        cs.coords_from_s1vector(s1dash, phi);
+
+                        dxy[index] =
+                        ((epsilon_coords[0] * epsilon_coords[0]
+                            + epsilon_coords[1] * epsilon_coords[1])
+                        * delta_b_r2);
+                    }
+                }
+                // Now loop through pixels in bbox, adding to foreground or background if unmasked and in image.
+                for (int x = bbox.x_min; x < bbox.x_max; x++) {
+                    for (int y = bbox.y_min; y < bbox.y_max; y++) {
+                        // The bounding box may extend beyond the image - if so, this is ok if it iis only background
+                        // but not if it is foreground.
+                        int x_index = x - bbox.x_min;
+                        int y_index = y - bbox.y_min;
+                        int dxyindex = x_index + (y_index * n_x);
+                        double d1 = dxy[dxyindex];
+                        double d2 = dxy[dxyindex + 1];
+                        double d3 = dxy[dxyindex + n_x];
+                        double d4 = dxy[dxyindex + n_x + 1];
+                        double d = std::min(std::min(d1, d2), std::min(d3, d4));
+                        int index = x + (y * image_fast);
+                        bool in_image =
+                        x >= 0 && x < image_fast && y >= 0 && y < image_slow;
+
+                        if (d <= 1.0) {
+                            // Foreground
+                            if (in_image) {
+                                if (mask[index] == 0) {  // masked)
+                                    success[refl_id] = false;
+                                } else {
+                                    auto data = image.data.data()[index];
+                                    intensity_accumulators[refl_id] += data;
+                                    nfg_accumulators[refl_id] += 1;
+                                    Vector3d I_times_c = {
+                                    data * (x + 0.5), data * (y + 0.5), data * (j + 0.5)};
+                                    intensity_times_coord_accumulators[refl_id] +=
+                                    I_times_c;
+                                }
+                            }// else { // NB dials doesn't seem to do this check?
+                            //    success[refl_id] = false;
+                            //}
+                        } else {  // d>1.0
+                            // Background
+                            if (in_image) {
+                                if (mask[index] != 0) {
+                                    // In image, not masked
+                                    auto data = image.data.data()[index];
+                                    bg_accumulators[refl_id] += data;
+                                    nbg_accumulators[refl_id] += 1;
+                                }
                             }
                         }
                     }
@@ -566,11 +648,14 @@ int main(int argc, char **argv) {
     std::vector<double> lp_corrections(num_reflections);
     std::vector<double> xyzobs_px(num_reflections * 3);
     std::vector<double> d_values(num_reflections);
+    std::vector<double> mean_bg(num_reflections);
+    // FIXME need to include robust outlier rejection in background calculation (glm, constant3dmodel)
     for (int i = 0; i < num_reflections; i++) {
         if (nbg_accumulators[i]) {
             double bg =
               nfg_accumulators[i] * bg_accumulators[i]
               / static_cast<double>(nbg_accumulators[i]);  // average bg * num fg pixels
+            mean_bg[i] = bg;
             double I = intensity_accumulators[i] - bg;
             intensities[i] = I;
             double m_n = nfg_accumulators[i] / nbg_accumulators[i];
@@ -633,6 +718,10 @@ int main(int argc, char **argv) {
     integrated_data.add_column("xyzobs.px.value", num_reflections, 3, xyzobs_px);
     integrated_data.add_column("s1", num_reflections, 3, s1);
     integrated_data.add_column("id", num_reflections, 1, id);
+    integrated_data.add_column("num_pixels.background", num_reflections, 1, nbg_accumulators);
+    integrated_data.add_column("num_pixels.foreground", num_reflections, 1, nfg_accumulators);
+    integrated_data.add_column("background.sum.value", num_reflections, 1, bg_accumulators);
+    integrated_data.add_column("background.mean", num_reflections, 1, mean_bg);
     std::vector<std::size_t> final_flags(num_reflections, IntegratedSum);
     integrated_data.add_column(std::string("flags"), num_reflections, 1, final_flags);
 

--- a/baseline/integrator/integrator.cc
+++ b/baseline/integrator/integrator.cc
@@ -360,21 +360,40 @@ int main(int argc, char **argv) {
     logger.info("Processing {} reflections", num_reflections);
 
     // Compute bounding boxes using baseline CPU algorithms
-    logger.info("Computing Kabsch bounding boxes using baseline CPU algorithms...");
-    auto computed_bounding_boxes = compute_kabsch_bounding_boxes(s0,
-                                                                 rotation_axis,
-                                                                 s1_vectors,
-                                                                 phi_column,
-                                                                 num_reflections,
-                                                                 sigma_b,
-                                                                 sigma_m,
-                                                                 panel,
-                                                                 scan,
-                                                                 beam);
+    auto computed_bounding_boxes_opt = reflections.column<int>("bbox");
+    std::vector<BoundingBoxExtents> computed_bounding_boxes;
+    if (!computed_bounding_boxes_opt.has_value()) {
+        logger.info("Computing Kabsch bounding boxes using baseline CPU algorithms...");
+        computed_bounding_boxes = compute_kabsch_bounding_boxes(s0,
+                                                                    rotation_axis,
+                                                                    s1_vectors,
+                                                                    phi_column,
+                                                                    num_reflections,
+                                                                    sigma_b,
+                                                                    sigma_m,
+                                                                    panel,
+                                                                    scan,
+                                                                    beam);
 
-    logger.info("Successfully computed {} bounding boxes",
-                computed_bounding_boxes.size());
-
+        logger.info("Successfully computed {} bounding boxes",
+                    computed_bounding_boxes.size());
+        }
+    else {
+        std::vector<int> bbox_data = std::vector<int>(
+          computed_bounding_boxes_opt.value().data_handle(), 
+          computed_bounding_boxes_opt.value().data_handle() + computed_bounding_boxes_opt.value().size());
+        for (int i=0;i<bbox_data.size();i+=6){
+          BoundingBoxExtents bbox;
+          bbox.x_min = bbox_data[i];
+          bbox.x_max = bbox_data[i+1];
+          bbox.y_min = bbox_data[i+2];
+          bbox.y_max = bbox_data[i+3];
+          bbox.z_min = bbox_data[i+4];
+          bbox.z_max = bbox_data[i+5];
+          computed_bounding_boxes.push_back(bbox);
+        }
+    }
+    
     // Map reflections by z layer (image number)
     logger.info("Mapping reflections by image number (z layer)");
     std::unordered_map<int, std::vector<size_t>> reflections_by_image;

--- a/baseline/integrator/integrator.cc
+++ b/baseline/integrator/integrator.cc
@@ -101,6 +101,7 @@ class BaselineIntegratorArgumentParser : public FFSArgumentParser {
 };
 #pragma endregion Argument Parsing
 constexpr double DEG2RAD = M_PI / 180.0;
+constexpr double RAD2DEG = 180.0 / M_PI;
 class CoordinateSystem {
   public:
     CoordinateSystem(Vector3d m2, Vector3d s0, Vector3d s1, double phi) : s1_(s1), phi_(phi) {
@@ -120,6 +121,9 @@ class CoordinateSystem {
           scaled_e2_.dot(s_dash - s1_),
           zeta_ * (phi_dash - phi_)};
       return coord;
+    }
+    double zeta() const {
+      return zeta_;
     }
   private:
     Vector3d s1_;
@@ -400,6 +404,8 @@ int main(int argc, char **argv) {
     std::vector<int> bg_accumulators(num_reflections);
     std::vector<int> nbg_accumulators(num_reflections);
     std::vector<int> nfg_accumulators(num_reflections);
+    std::vector<int> nbgbad_accumulators(num_reflections);
+    std::vector<bool> success(num_reflections, true);
 
     for (size_t refl_id = 0; refl_id < num_reflections; ++refl_id) {
         const auto &bbox = computed_bounding_boxes[refl_id];
@@ -429,10 +435,9 @@ int main(int argc, char **argv) {
 
     // Now load some image data:
     std::string filename = expt.imagesequence().filename();
-    h5read_handle *obj = h5read_open(filename.c_str());
-    size_t n_images = h5read_get_number_of_images(obj);
-    uint16_t image_slow = h5read_get_image_slow(obj);
-    uint16_t image_fast = h5read_get_image_fast(obj);
+    auto reader = H5Read(filename);
+    size_t n_images = reader.get_number_of_images();
+    auto [image_slow, image_fast] = reader.image_shape();
     double s0_length = beam.get_s0().norm();
     double phi0 = scan.get_oscillation()[0];
     double dphi = scan.get_oscillation()[1];
@@ -449,9 +454,12 @@ int main(int argc, char **argv) {
     double delta_b_r2 = 1.0 / (delta_b * delta_b);
     double delta_m = sigma_m * 3.0;
     double delta_m_r2 = 1.0 / (delta_m * delta_m);
-
+    auto mask = reader.get_mask().value();
     for (size_t j = 0; j < n_images; j++) {
-      image_t *image = h5read_get_image(obj, j);
+      if (!reader.is_image_available(j)) {
+        continue;
+      }
+      auto image = reader.get_image(j);
       std::cout << "Processing image " << j +1 << std::endl;
       size_t zero = 0;
       size_t masked = 0;
@@ -497,22 +505,35 @@ int main(int argc, char **argv) {
           for (int y = bbox.y_min; y<bbox.y_max; y++){
             if (x >=0 && x < image_fast && y >=0 && y < image_slow){
               int index = x + (y * image_fast);
-              if (image->mask[index] != 0){
-                int data = image->data[index];
+              //std::cout << index << std::endl;
+              int x_index = x - bbox.x_min;
+              int y_index = y - bbox.y_min;
+              int dxyindex = x_index + (y_index * n_x);
+              double d1 = dxy_start[dxyindex];
+              double d2 = dxy_start[dxyindex+1];
+              double d3 = dxy_start[dxyindex+n_x];
+              double d4 = dxy_start[dxyindex+n_x+1];
+              double d5 = dxy_end[dxyindex];
+              double d6 = dxy_end[dxyindex+1];
+              double d7 = dxy_end[dxyindex+n_x];
+              double d8 = dxy_end[dxyindex+n_x+1];
+              double d = std::min(std::min(std::min(d1, d2), std::min(d3, d4)),
+                                  std::min(std::min(d5, d6), std::min(d7, d8)));
+              if (mask[index] == 0){
+                // masked, might be ok if bg
+                if (d > 1.0){
+                  nbgbad_accumulators[refl_id] += 1;
+                }
+                else {
+                  success[refl_id] = false;
+                }
+              } else {
+                // Not masked
+                uint16_t data = image.data.data()[index];
+                //std::cout << "Read data" << std::endl;
                 // Need to work out if foreground or background.
-                int x_index = x - bbox.x_min;
-                int y_index = y - bbox.y_min;
-                int dxyindex = x_index + (y_index * n_x);
-                double d1 = dxy_start[dxyindex];
-                double d2 = dxy_start[dxyindex+1];
-                double d3 = dxy_start[dxyindex+n_x];
-                double d4 = dxy_start[dxyindex+n_x+1];
-                double d5 = dxy_end[dxyindex];
-                double d6 = dxy_end[dxyindex+1];
-                double d7 = dxy_end[dxyindex+n_x];
-                double d8 = dxy_end[dxyindex+n_x+1];
-                double d = std::min(std::min(std::min(d1, d2), std::min(d3, d4)),
-                                    std::min(std::min(d5, d6), std::min(d7, d8)));
+                
+                //std::cout << "Calculated d" << std::endl;
                 if (d > 1.0){
                   bg_accumulators[refl_id] += data;
                   nbg_accumulators[refl_id] += 1;
@@ -526,9 +547,10 @@ int main(int argc, char **argv) {
           }
         }
       }
-      h5read_free_image(image);
+      //h5read_free_image(image);
+      //std::cout << "Processed image " << j +1 << std::endl;
     }
-    h5read_free(obj);
+    //h5read_free(obj);
 
     // Convert to reflection table format
     std::vector<double> computed_bbox_data;
@@ -550,24 +572,72 @@ int main(int argc, char **argv) {
     //integrated_data.add_column(
     //  "baseline_bbox", std::vector<size_t>{num_reflections, 6}, computed_bbox_data);
     std::vector<double> intensities(num_reflections);
+    std::vector<double> variances(num_reflections);
+    std::vector<double> partialities(num_reflections);
     for (int i=0;i<num_reflections;i++){
       if (nbg_accumulators[i]){
-        intensities[i] = intensity_accumulators[i] - (nfg_accumulators[i] * bg_accumulators[i] / static_cast<double>(nbg_accumulators[i]));
+        double bg = nfg_accumulators[i] * bg_accumulators[i] / static_cast<double>(nbg_accumulators[i]); // average bg * num fg pixels
+        double I = intensity_accumulators[i] - bg;
+        intensities[i] = I;
+        double m_n = nfg_accumulators[i] / nbg_accumulators[i];
+        variances[i] = std::abs(I) + (std::abs(bg) * (1.0 + m_n));
       }
-      
+      else {
+        success[i] = false;
+      }
     }
+    // Calculate the partiality of all reflections
+    for (int i=0;i<num_reflections;i++){
+      double xyzcal_px_z = phi_column(i,2) * RAD2DEG / osc_width;
+      // then convert to phi
+      // convert bbox start and end to phi.
+
+      double phi = osc_start + ((xyzcal_px_z + 1 - image_range_start)*osc_width);
+      double phia = osc_start + ((computed_bounding_boxes[i].z_min + 1 - image_range_start)*osc_width);
+      double phib = osc_start + ((computed_bounding_boxes[i].z_max + 1 - image_range_start)*osc_width);
+
+      double zeta = coord_system_vector[i].zeta();
+      double c = std::abs(zeta) / (std::sqrt(2.0) * sigma_m);
+      double p = 0.5 * (std::erf(c * (phib - phi)) - std::erf(c * (phia - phi)));
+      partialities[i] = p;
+    }
+
     integrated_data.add_column(
-      "intensity", num_reflections,1,intensities
+      "intensity.sum.value", num_reflections,1,intensities
+    );
+    integrated_data.add_column(
+      "intensity.sum.variance", num_reflections,1,variances
+    );
+    integrated_data.add_column(
+      "partiality", num_reflections, 1, partialities
     );
     integrated_data.add_column(
       "miller_index", num_reflections,3, hkl_vectors
     );
+    std::vector<double> xyzcal_mm = std::vector<double>(
+      phi_column.data_handle(), phi_column.data_handle() + phi_column.size()
+    );
+    std::vector<double> s1 = std::vector<double>(
+      s1_vectors.data_handle(), s1_vectors.data_handle() + s1_vectors.size()
+    );
+    std::vector<int> id = std::vector<int>(num_reflections, 0);
+    integrated_data.add_column("xyzcal.mm", num_reflections, 3, xyzcal_mm);
+    integrated_data.add_column("s1", num_reflections, 3, s1);
+    integrated_data.add_column("id", num_reflections, 1, id);
+    ReflectionTable success_data = integrated_data.select(success);
+    int n_integrated = success_data.column<double>("intensity.sum.value").value().extent(0);
 
-    integrated_data.write(output_file);
+
+    // Other things to output
+    // d, flags, id, intensity.sum.variance, lp, partiality, xyzcal.px?,
+    // xyzobs.mm.value, xyzobs.mm.variance, xyzobs.px.value, xyzobs.px.variance
+
+    success_data.write(output_file);
     logger.info("Baseline integration complete!");
     logger.info("Summary:");
     logger.info("  {} reflections processed", num_reflections);
     logger.info("  {} bounding boxes computed", computed_bounding_boxes.size());
+    logger.info("  {} reflections successfully integrated", n_integrated);
     logger.info("Results saved to: {}", output_file);
 
     return 0;

--- a/baseline/integrator/integrator.cc
+++ b/baseline/integrator/integrator.cc
@@ -412,6 +412,10 @@ int main(int argc, char **argv) {
     }
     logger.info("Reflections mapped across {} unique images",
                 reflections_by_image.size());
+    
+    for (const auto& [image, refl_list] : reflections_by_image) {
+        logger.info("Image {} has {} reflections", image, refl_list.size());
+    }
 
     // Now load some image data:
     std::string filename = expt.imagesequence().filename();
@@ -491,8 +495,8 @@ int main(int argc, char **argv) {
           }
         }
         //std::cout << "Made dxy array" << std::endl;
-        for (int x = bbox.x_min; x<bbox.x_max-1; x++){
-          for (int y = bbox.y_min; y<bbox.y_max-1; y++){
+        for (int x = bbox.x_min; x<bbox.x_max; x++){
+          for (int y = bbox.y_min; y<bbox.y_max; y++){
             if (x >=0 && x < image_fast && y >=0 && y < image_slow){
               int index = x + (y * image_fast);
               //std::cout << x << " " << y << " " << index << std::endl;
@@ -523,7 +527,6 @@ int main(int argc, char **argv) {
                 }
               }
             }
-              
           }
         }
         
@@ -641,7 +644,7 @@ int main(int argc, char **argv) {
     std::vector<double> intensities(num_reflections);
     for (int i=0;i<num_reflections;i++){
       if (nbg_accumulators[i]){
-        intensities[i] = intensity_accumulators[i] - (nfg_accumulators[i] * bg_accumulators[i] / nbg_accumulators[i]);
+        intensities[i] = intensity_accumulators[i] - (nfg_accumulators[i] * bg_accumulators[i] / static_cast<double>(nbg_accumulators[i]));
       }
       
     }

--- a/baseline/integrator/integrator.cc
+++ b/baseline/integrator/integrator.cc
@@ -29,6 +29,7 @@
 #include "math/math_utils.cuh"
 #include "predict.cc"
 #include "sigma_estimation.cc"
+#include "background.cc"
 #include "version.hpp"
 
 using json = nlohmann::json;
@@ -103,6 +104,12 @@ class BaselineIntegratorArgumentParser : public FFSArgumentParser {
           .help(
             "Foreground algorithm choice - dials or ellipsoid.")
           .default_value<std::string>("ellipsoid");
+
+        add_argument("--min_zeta")
+          .help(
+            "Reflections close to the rotation axis, with a zeta below this threshold will not be integrated.")
+          .default_value<float>(0.05)
+          .scan<'f', float>();
 
         add_argument("output")
           .help("Output file path")
@@ -213,6 +220,7 @@ int main(int argc, char **argv) {
     // code in this program.
     float sigma_b = 0.0;
     float sigma_m = 0.0;
+    float min_zeta = parser.get<float>("min_zeta");
     if (parser.is_used("sigma_m")) {
         sigma_m = degrees_to_radians(
           parser.get<float>("sigma_m"));  // Use radians for calculations
@@ -416,7 +424,7 @@ int main(int argc, char **argv) {
     // Set up data arrays to fill during accumulation
     std::vector<int> intensity_accumulators(num_reflections);
     std::vector<Vector3d> intensity_times_coord_accumulators(num_reflections);
-    std::vector<int> bg_accumulators(num_reflections);
+    std::vector<BackgroundAggregator> bg_accumulators(num_reflections);
     std::vector<int> nbg_accumulators(num_reflections);
     std::vector<int> nfg_accumulators(num_reflections);
     std::vector<bool> success(num_reflections, true);
@@ -428,11 +436,17 @@ int main(int argc, char **argv) {
     double phi0 = scan.get_oscillation()[0];
     double dphi = scan.get_oscillation()[1];
     const Vector3d m2 = gonio.get_rotation_axis();
+    std::vector<bool> dont_integrate(num_reflections, false);
     for (int i = 0; i < num_reflections; i++) {
         Vector3d s1_this = Eigen::Map<Vector3d>(&s1_vectors(i, 0));
-        coord_system_vector.push_back(
-          CoordinateSystem(m2, s0, s1_this, phi_column(i, 2)));
+        CoordinateSystem cs(m2, s0, s1_this, phi_column(i, 2));
+        coord_system_vector.push_back(cs);
+        if (std::abs(cs.zeta()) < min_zeta){
+            dont_integrate[i] = true;
+            success[i] = false;
+        }
     }
+
     double delta_b = sigma_b * 3.0;
     double delta_b_r2 = 1.0 / (delta_b * delta_b);
     double delta_m = sigma_m * 3.0;
@@ -453,6 +467,9 @@ int main(int argc, char **argv) {
         logger.info("Processing image {}", j + 1);
         for (size_t k = 0; k < reflections_by_image[j].size(); k++) {
             size_t refl_id = reflections_by_image[j][k];
+            if (dont_integrate[refl_id]){
+                continue;
+            }
             const auto &bbox = computed_bounding_boxes[refl_id];
             if (fg_algorithm == "ellipsoid"){
                 // calculate dxy array (arrays of distances in kabsch space from pixel corners to xyzcal)
@@ -530,16 +547,16 @@ int main(int argc, char **argv) {
                                     intensity_times_coord_accumulators[refl_id] +=
                                     I_times_c;
                                 }
-                            } else { // NB dials doesn't seem to do this check.
+                            } else {
                                 success[refl_id] = false;
                             }
                         } else {  // d>1.0
                             // Background
                             if (in_image) {
                                 if (mask[index] != 0) {
-                                    // In image, not masked=
-                                    uint16_t data = image.data.data()[index];
-                                    bg_accumulators[refl_id] += data;
+                                    // In image, not masked
+                                    auto data = image.data.data()[index];
+                                    bg_accumulators[refl_id].add(data);
                                     nbg_accumulators[refl_id] += 1;
                                 }
                             }
@@ -602,16 +619,16 @@ int main(int argc, char **argv) {
                                     intensity_times_coord_accumulators[refl_id] +=
                                     I_times_c;
                                 }
-                            }// else { // NB dials doesn't seem to do this check?
-                            //    success[refl_id] = false;
-                            //}
+                            } else {
+                                success[refl_id] = false;
+                            }
                         } else {  // d>1.0
                             // Background
                             if (in_image) {
                                 if (mask[index] != 0) {
                                     // In image, not masked
                                     auto data = image.data.data()[index];
-                                    bg_accumulators[refl_id] += data;
+                                    bg_accumulators[refl_id].add(data);
                                     nbg_accumulators[refl_id] += 1;
                                 }
                             }
@@ -649,13 +666,13 @@ int main(int argc, char **argv) {
     std::vector<double> xyzobs_px(num_reflections * 3);
     std::vector<double> d_values(num_reflections);
     std::vector<double> mean_bg(num_reflections);
+    std::vector<double> bg_sum_value(num_reflections);
     // FIXME need to include robust outlier rejection in background calculation (glm, constant3dmodel)
     for (int i = 0; i < num_reflections; i++) {
         if (nbg_accumulators[i]) {
-            double bg =
-              nfg_accumulators[i] * bg_accumulators[i]
-              / static_cast<double>(nbg_accumulators[i]);  // average bg * num fg pixels
+            auto [bg, total_bg_counts] = compute_background_constant_3d(bg_accumulators[i]);
             mean_bg[i] = bg;
+            bg_sum_value[i] = total_bg_counts;
             double I = intensity_accumulators[i] - bg;
             intensities[i] = I;
             double m_n = nfg_accumulators[i] / nbg_accumulators[i];
@@ -666,8 +683,10 @@ int main(int argc, char **argv) {
                 xyzobs_px[i * 3] = com[0];
                 xyzobs_px[i * 3 + 1] = com[1];
                 xyzobs_px[i * 3 + 2] = com[2];
-            } else {
-                success[i] = false;
+            } else { // zero intensity, so com is just centre of box (dials convention from centroid/simple/algorithm.h).
+                xyzobs_px[i * 3] = 0.5 * (computed_bounding_boxes[i].x_min + computed_bounding_boxes[i].x_max);
+                xyzobs_px[i * 3 + 1] = 0.5 * (computed_bounding_boxes[i].y_min + computed_bounding_boxes[i].y_max);
+                xyzobs_px[i * 3 + 2] = 0.5 * (computed_bounding_boxes[i].z_min + computed_bounding_boxes[i].z_max);
             }
         } else {
             success[i] = false;
@@ -720,7 +739,7 @@ int main(int argc, char **argv) {
     integrated_data.add_column("id", num_reflections, 1, id);
     integrated_data.add_column("num_pixels.background", num_reflections, 1, nbg_accumulators); // Useful for debug but not required for downstream
     integrated_data.add_column("num_pixels.foreground", num_reflections, 1, nfg_accumulators); // Useful for debug but not required for downstream
-    integrated_data.add_column("background.sum.value", num_reflections, 1, bg_accumulators); // Useful for debug but not required for downstream
+    integrated_data.add_column("background.sum.value", num_reflections, 1, bg_sum_value); // Useful for debug but not required for downstream
     integrated_data.add_column("background.mean", num_reflections, 1, mean_bg); // Useful for debug but not required for downstream
     std::vector<std::size_t> final_flags(num_reflections, IntegratedSum);
     integrated_data.add_column(std::string("flags"), num_reflections, 1, final_flags);

--- a/baseline/integrator/integrator.cc
+++ b/baseline/integrator/integrator.cc
@@ -20,6 +20,7 @@
 #include <vector>
 
 #include "arg_parser.hpp"
+#include "background.cc"
 #include "common.hpp"
 #include "extent.cc"
 #include "ffs_logger.hpp"
@@ -29,7 +30,6 @@
 #include "math/math_utils.cuh"
 #include "predict.cc"
 #include "sigma_estimation.cc"
-#include "background.cc"
 #include "version.hpp"
 
 using json = nlohmann::json;
@@ -100,14 +100,14 @@ class BaselineIntegratorArgumentParser : public FFSArgumentParser {
           .default_value<int>(6)
           .scan<'i', int>();
 
-        add_argument("-a","--algorithm")
-          .help(
-            "Foreground algorithm choice - dials or ellipsoid.")
+        add_argument("-a", "--algorithm")
+          .help("Foreground algorithm choice - dials or ellipsoid.")
           .default_value<std::string>("ellipsoid");
 
         add_argument("--min_zeta")
           .help(
-            "Reflections close to the rotation axis, with a zeta below this threshold will not be integrated.")
+            "Reflections close to the rotation axis, with a zeta below this threshold "
+            "will not be integrated.")
           .default_value<float>(0.05)
           .scan<'f', float>();
 
@@ -132,8 +132,9 @@ int main(int argc, char **argv) {
     float timeout = parser.get<float>("timeout");
     std::string output_file = parser.get<std::string>("output");
     std::string fg_algorithm = parser.get<std::string>("algorithm");
-    if ((fg_algorithm != "dials") && (fg_algorithm != "ellipsoid")){
-        throw std::invalid_argument("Invalid algorithm specified (must be 'dials' or 'ellipsoid')");
+    if ((fg_algorithm != "dials") && (fg_algorithm != "ellipsoid")) {
+        throw std::invalid_argument(
+          "Invalid algorithm specified (must be 'dials' or 'ellipsoid')");
     }
 
     // Guard against missing files
@@ -441,7 +442,7 @@ int main(int argc, char **argv) {
         Vector3d s1_this = Eigen::Map<Vector3d>(&s1_vectors(i, 0));
         CoordinateSystem cs(m2, s0, s1_this, phi_column(i, 2));
         coord_system_vector.push_back(cs);
-        if (std::abs(cs.zeta()) < min_zeta){
+        if (std::abs(cs.zeta()) < min_zeta) {
             dont_integrate[i] = true;
             success[i] = false;
         }
@@ -467,16 +468,17 @@ int main(int argc, char **argv) {
         logger.info("Processing image {}", j + 1);
         for (size_t k = 0; k < reflections_by_image[j].size(); k++) {
             size_t refl_id = reflections_by_image[j][k];
-            if (dont_integrate[refl_id]){
+            if (dont_integrate[refl_id]) {
                 continue;
             }
             const auto &bbox = computed_bounding_boxes[refl_id];
-            if (fg_algorithm == "ellipsoid"){
+            if (fg_algorithm == "ellipsoid") {
                 // calculate dxy array (arrays of distances in kabsch space from pixel corners to xyzcal)
                 int n_x = bbox.x_max - bbox.x_min + 1;
                 int n_y = bbox.y_max - bbox.y_min + 1;
-                std::vector<double> dxy_start(n_x * n_y);  // start of image (in rotation)
-                std::vector<double> dxy_end(n_x * n_y);    // end of image (in rotation)
+                std::vector<double> dxy_start(n_x
+                                              * n_y);    // start of image (in rotation)
+                std::vector<double> dxy_end(n_x * n_y);  // end of image (in rotation)
                 double phidash_start = (phi0 + (j * dphi)) * DEG2RAD;
                 double phidash_end = (phi0 + ((j + 1) * dphi)) * DEG2RAD;
                 double phi_c = phi_column(refl_id, 2);
@@ -486,30 +488,31 @@ int main(int argc, char **argv) {
                     for (int y = 0; y < n_y; y++) {
                         int index = x + (y * (n_x));
                         std::array<double, 2> px_mm =
-                        panel.px_to_mm(x + bbox.x_min, y + bbox.y_min);
+                          panel.px_to_mm(x + bbox.x_min, y + bbox.y_min);
                         Vector3d s1_ = panel.get_lab_coord(px_mm[0], px_mm[1]);
                         s1_.normalize();
                         Vector3d s1dash = s1_ * s0_length;
                         Vector3d epsilon_coords_start =
-                        cs.coords_from_s1vector(s1dash, phidash_start);
+                          cs.coords_from_s1vector(s1dash, phidash_start);
                         Vector3d epsilon_coords_end =
-                        cs.coords_from_s1vector(s1dash, phidash_end);
+                          cs.coords_from_s1vector(s1dash, phidash_end);
                         if ((phidash_start > phi_c) && (phi_c < phidash_end)) {
                             epsilon_coords_start[2] = 0.0;
                             epsilon_coords_end[2] = 0.0;
                         }
 
                         dxy_start[index] =
-                        ((epsilon_coords_start[0] * epsilon_coords_start[0]
+                          ((epsilon_coords_start[0] * epsilon_coords_start[0]
                             + epsilon_coords_start[1] * epsilon_coords_start[1])
-                        * delta_b_r2)
-                        + ((epsilon_coords_start[2] * epsilon_coords_start[2])
-                            * delta_m_r2);
+                           * delta_b_r2)
+                          + ((epsilon_coords_start[2] * epsilon_coords_start[2])
+                             * delta_m_r2);
                         dxy_end[index] =
-                        ((epsilon_coords_end[0] * epsilon_coords_end[0]
+                          ((epsilon_coords_end[0] * epsilon_coords_end[0]
                             + epsilon_coords_end[1] * epsilon_coords_end[1])
-                        * delta_b_r2)
-                        + ((epsilon_coords_end[2] * epsilon_coords_end[2]) * delta_m_r2);
+                           * delta_b_r2)
+                          + ((epsilon_coords_end[2] * epsilon_coords_end[2])
+                             * delta_m_r2);
                     }
                 }
                 // Now loop through pixels in bbox, adding to foreground or background if unmasked and in image.
@@ -528,11 +531,12 @@ int main(int argc, char **argv) {
                         double d6 = dxy_end[dxyindex + 1];
                         double d7 = dxy_end[dxyindex + n_x];
                         double d8 = dxy_end[dxyindex + n_x + 1];
-                        double d = std::min(std::min(std::min(d1, d2), std::min(d3, d4)),
-                                            std::min(std::min(d5, d6), std::min(d7, d8)));
+                        double d =
+                          std::min(std::min(std::min(d1, d2), std::min(d3, d4)),
+                                   std::min(std::min(d5, d6), std::min(d7, d8)));
                         int index = x + (y * image_fast);
                         bool in_image =
-                        x >= 0 && x < image_fast && y >= 0 && y < image_slow;
+                          x >= 0 && x < image_fast && y >= 0 && y < image_slow;
                         if (d <= 1.0) {
                             // Foreground
                             if (in_image) {
@@ -542,10 +546,11 @@ int main(int argc, char **argv) {
                                     auto data = image.data.data()[index];
                                     intensity_accumulators[refl_id] += data;
                                     nfg_accumulators[refl_id] += 1;
-                                    Vector3d I_times_c = {
-                                    data * (x + 0.5), data * (y + 0.5), data * (j + 0.5)};
+                                    Vector3d I_times_c = {data * (x + 0.5),
+                                                          data * (y + 0.5),
+                                                          data * (j + 0.5)};
                                     intensity_times_coord_accumulators[refl_id] +=
-                                    I_times_c;
+                                      I_times_c;
                                 }
                             } else {
                                 success[refl_id] = false;
@@ -568,24 +573,25 @@ int main(int argc, char **argv) {
                 int n_x = bbox.x_max - bbox.x_min + 1;
                 int n_y = bbox.y_max - bbox.y_min + 1;
                 std::vector<double> dxy(n_x * n_y);
-                double phi = phi0 + (j * dphi) * DEG2RAD; // Required for calls but not actually used as don't use e3.
+                double phi =
+                  phi0
+                  + (j * dphi)
+                      * DEG2RAD;  // Required for calls but not actually used as don't use e3.
                 CoordinateSystem cs = coord_system_vector[refl_id];
                 Vector3d s1_this = Eigen::Map<Vector3d>(&s1_vectors(refl_id, 0));
                 for (int x = 0; x < n_x; x++) {
                     for (int y = 0; y < n_y; y++) {
                         int index = x + (y * (n_x));
                         std::array<double, 2> px_mm =
-                        panel.px_to_mm(x + bbox.x_min, y + bbox.y_min);
+                          panel.px_to_mm(x + bbox.x_min, y + bbox.y_min);
                         Vector3d s1_ = panel.get_lab_coord(px_mm[0], px_mm[1]);
                         s1_.normalize();
                         Vector3d s1dash = s1_ * s0_length;
-                        Vector3d epsilon_coords =
-                        cs.coords_from_s1vector(s1dash, phi);
+                        Vector3d epsilon_coords = cs.coords_from_s1vector(s1dash, phi);
 
-                        dxy[index] =
-                        ((epsilon_coords[0] * epsilon_coords[0]
-                            + epsilon_coords[1] * epsilon_coords[1])
-                        * delta_b_r2);
+                        dxy[index] = ((epsilon_coords[0] * epsilon_coords[0]
+                                       + epsilon_coords[1] * epsilon_coords[1])
+                                      * delta_b_r2);
                     }
                 }
                 // Now loop through pixels in bbox, adding to foreground or background if unmasked and in image.
@@ -603,7 +609,7 @@ int main(int argc, char **argv) {
                         double d = std::min(std::min(d1, d2), std::min(d3, d4));
                         int index = x + (y * image_fast);
                         bool in_image =
-                        x >= 0 && x < image_fast && y >= 0 && y < image_slow;
+                          x >= 0 && x < image_fast && y >= 0 && y < image_slow;
 
                         if (d <= 1.0) {
                             // Foreground
@@ -614,10 +620,11 @@ int main(int argc, char **argv) {
                                     auto data = image.data.data()[index];
                                     intensity_accumulators[refl_id] += data;
                                     nfg_accumulators[refl_id] += 1;
-                                    Vector3d I_times_c = {
-                                    data * (x + 0.5), data * (y + 0.5), data * (j + 0.5)};
+                                    Vector3d I_times_c = {data * (x + 0.5),
+                                                          data * (y + 0.5),
+                                                          data * (j + 0.5)};
                                     intensity_times_coord_accumulators[refl_id] +=
-                                    I_times_c;
+                                      I_times_c;
                                 }
                             } else {
                                 success[refl_id] = false;
@@ -670,7 +677,8 @@ int main(int argc, char **argv) {
     // FIXME need to include robust outlier rejection in background calculation (glm, constant3dmodel)
     for (int i = 0; i < num_reflections; i++) {
         if (nbg_accumulators[i]) {
-            auto [bg, total_bg_counts] = compute_background_constant_3d(bg_accumulators[i]);
+            auto [bg, total_bg_counts] =
+              compute_background_constant_3d(bg_accumulators[i]);
             mean_bg[i] = bg;
             bg_sum_value[i] = total_bg_counts;
             double I = intensity_accumulators[i] - bg;
@@ -683,10 +691,16 @@ int main(int argc, char **argv) {
                 xyzobs_px[i * 3] = com[0];
                 xyzobs_px[i * 3 + 1] = com[1];
                 xyzobs_px[i * 3 + 2] = com[2];
-            } else { // zero intensity, so com is just centre of box (dials convention from centroid/simple/algorithm.h).
-                xyzobs_px[i * 3] = 0.5 * (computed_bounding_boxes[i].x_min + computed_bounding_boxes[i].x_max);
-                xyzobs_px[i * 3 + 1] = 0.5 * (computed_bounding_boxes[i].y_min + computed_bounding_boxes[i].y_max);
-                xyzobs_px[i * 3 + 2] = 0.5 * (computed_bounding_boxes[i].z_min + computed_bounding_boxes[i].z_max);
+            } else {  // zero intensity, so com is just centre of box (dials convention from centroid/simple/algorithm.h).
+                xyzobs_px[i * 3] = 0.5
+                                   * (computed_bounding_boxes[i].x_min
+                                      + computed_bounding_boxes[i].x_max);
+                xyzobs_px[i * 3 + 1] = 0.5
+                                       * (computed_bounding_boxes[i].y_min
+                                          + computed_bounding_boxes[i].y_max);
+                xyzobs_px[i * 3 + 2] = 0.5
+                                       * (computed_bounding_boxes[i].z_min
+                                          + computed_bounding_boxes[i].z_max);
             }
         } else {
             success[i] = false;
@@ -737,10 +751,26 @@ int main(int argc, char **argv) {
     integrated_data.add_column("xyzobs.px.value", num_reflections, 3, xyzobs_px);
     integrated_data.add_column("s1", num_reflections, 3, s1);
     integrated_data.add_column("id", num_reflections, 1, id);
-    integrated_data.add_column("num_pixels.background", num_reflections, 1, nbg_accumulators); // Useful for debug but not required for downstream
-    integrated_data.add_column("num_pixels.foreground", num_reflections, 1, nfg_accumulators); // Useful for debug but not required for downstream
-    integrated_data.add_column("background.sum.value", num_reflections, 1, bg_sum_value); // Useful for debug but not required for downstream
-    integrated_data.add_column("background.mean", num_reflections, 1, mean_bg); // Useful for debug but not required for downstream
+    integrated_data.add_column(
+      "num_pixels.background",
+      num_reflections,
+      1,
+      nbg_accumulators);  // Useful for debug but not required for downstream
+    integrated_data.add_column(
+      "num_pixels.foreground",
+      num_reflections,
+      1,
+      nfg_accumulators);  // Useful for debug but not required for downstream
+    integrated_data.add_column(
+      "background.sum.value",
+      num_reflections,
+      1,
+      bg_sum_value);  // Useful for debug but not required for downstream
+    integrated_data.add_column(
+      "background.mean",
+      num_reflections,
+      1,
+      mean_bg);  // Useful for debug but not required for downstream
     std::vector<std::size_t> final_flags(num_reflections, IntegratedSum);
     integrated_data.add_column(std::string("flags"), num_reflections, 1, final_flags);
 

--- a/baseline/integrator/integrator.cc
+++ b/baseline/integrator/integrator.cc
@@ -31,9 +31,6 @@
 
 using json = nlohmann::json;
 
-// Define a 2D mdspan type alias for convenience
-using mdspan_2d =
-  std::experimental::mdspan<double, std::experimental::dextents<size_t, 2>>;
 
 #pragma region Argument Parsing
 class BaselineIntegratorArgumentParser : public FFSArgumentParser {
@@ -98,8 +95,8 @@ class BaselineIntegratorArgumentParser : public FFSArgumentParser {
 
         add_argument("output")
           .help("Output file path")
-          .metavar("output.h5")
-          .default_value<std::string>("output.h5");
+          .metavar("integrated.refl")
+          .default_value<std::string>("integrated.refl");
     }
 };
 #pragma endregion Argument Parsing
@@ -392,6 +389,8 @@ int main(int argc, char **argv) {
           bbox.z_max = bbox_data[i+5];
           computed_bounding_boxes.push_back(bbox);
         }
+        logger.info("Successfully loaded {} bounding boxes from input reflections",
+                    computed_bounding_boxes.size());
     }
     
     // Map reflections by z layer (image number)
@@ -413,9 +412,20 @@ int main(int argc, char **argv) {
     logger.info("Reflections mapped across {} unique images",
                 reflections_by_image.size());
     
-    for (const auto& [image, refl_list] : reflections_by_image) {
-        logger.info("Image {} has {} reflections", image, refl_list.size());
+
+    std::vector<int> keys;
+    keys.reserve(reflections_by_image.size());
+    for (const auto& kv : reflections_by_image) {
+        keys.push_back(kv.first);
     }
+    std::sort(keys.begin(), keys.end());
+
+    
+    for (int image : keys) {
+        const auto& refl_list = reflections_by_image.at(image);
+        logger.info("Image {} has {} reflections", image+1, refl_list.size());
+    }
+
 
     // Now load some image data:
     std::string filename = expt.imagesequence().filename();
@@ -426,9 +436,7 @@ int main(int argc, char **argv) {
     double s0_length = beam.get_s0().norm();
     double phi0 = scan.get_oscillation()[0];
     double dphi = scan.get_oscillation()[1];
-    std::cout << "Phi0 " << phi0 << " dphi " << dphi << std::endl;
     // make a vector of coordinate systems for each reflection.
-    std::cout << "Making CS vector" << std::endl;
     std::vector<CoordinateSystem> coord_system_vector = {};
     coord_system_vector.reserve(num_reflections);
     const Vector3d m2 = gonio.get_rotation_axis();
@@ -437,12 +445,10 @@ int main(int argc, char **argv) {
       coord_system_vector.push_back(CoordinateSystem(
         m2, s0, s1_this, phi_column(i,2)));
     }
-    std::cout << "Made CS vector" << std::endl;
     double delta_b = sigma_b * 3.0;
     double delta_b_r2 = 1.0 / (delta_b * delta_b);
     double delta_m = sigma_m * 3.0;
     double delta_m_r2 = 1.0 / (delta_m * delta_m);
-    std::cout << "delta_b_r2 " << delta_b_r2 << " delta_m_r2 " << delta_m_r2 << std::endl;
 
     for (size_t j = 0; j < n_images; j++) {
       image_t *image = h5read_get_image(obj, j);
@@ -451,12 +457,8 @@ int main(int argc, char **argv) {
       size_t masked = 0;
       size_t total = 0;
       size_t signal = 0;
-      //for (size_t k=0;k<1;k++){
       for (size_t k=0;k<reflections_by_image[j].size();k++){
         size_t refl_id = reflections_by_image[j][k];
-        //std::cout << "Image " << j << " refl_id " << refl_id << std::endl;
-        //std::cout << "Image fast " << image_fast << std::endl;
-        //std::cout << "Image slow " << image_slow << std::endl;
         const auto &bbox = computed_bounding_boxes[refl_id];
         
         // calculate dxy array
@@ -467,7 +469,6 @@ int main(int argc, char **argv) {
         double phidash_start = (phi0 + (j * dphi)) * DEG2RAD;
         double phidash_end = (phi0 + ((j + 1) * dphi)) * DEG2RAD;
         double phi_c = phi_column(refl_id,2);
-        //std::cout << "Phis s e c: "<< phidash_start << ' ' << phidash_end << " " << phi_c << std::endl;
         CoordinateSystem cs = coord_system_vector[refl_id];
         Vector3d s1_this = Eigen::Map<Vector3d>(&s1_vectors(refl_id,0));
         for (int x = 0; x<n_x; x++){
@@ -477,8 +478,6 @@ int main(int argc, char **argv) {
             Vector3d s1_ = panel.get_lab_coord(px_mm[0], px_mm[1]);
             s1_.normalize();
             Vector3d s1dash = s1_ * s0_length;
-            //std::cout << "s1dash " << s1dash[0] << " " << s1dash[1] << " " << s1dash[2] << std::endl;
-            //std::cout << "s1c " << s1_this[0] << " " << s1_this[1] << " " << s1_this[2] << std::endl;
             Vector3d epsilon_coords_start = cs.coords_from_s1vector(s1dash, phidash_start);
             Vector3d epsilon_coords_end = cs.coords_from_s1vector(s1dash, phidash_end);
             if ((phidash_start > phi_c) && (phi_c < phidash_end)) {
@@ -494,12 +493,10 @@ int main(int argc, char **argv) {
                  * delta_b_r2) + ((epsilon_coords_end[2] * epsilon_coords_end[2]) * delta_m_r2);
           }
         }
-        //std::cout << "Made dxy array" << std::endl;
         for (int x = bbox.x_min; x<bbox.x_max; x++){
           for (int y = bbox.y_min; y<bbox.y_max; y++){
             if (x >=0 && x < image_fast && y >=0 && y < image_slow){
               int index = x + (y * image_fast);
-              //std::cout << x << " " << y << " " << index << std::endl;
               if (image->mask[index] != 0){
                 int data = image->data[index];
                 // Need to work out if foreground or background.
@@ -516,7 +513,6 @@ int main(int argc, char **argv) {
                 double d8 = dxy_end[dxyindex+n_x+1];
                 double d = std::min(std::min(std::min(d1, d2), std::min(d3, d4)),
                                     std::min(std::min(d5, d6), std::min(d7, d8)));
-                //std::cout << "Pixel x y d: " << x << " " << y  << " " << d << std::endl;
                 if (d > 1.0){
                   bg_accumulators[refl_id] += data;
                   nbg_accumulators[refl_id] += 1;
@@ -529,8 +525,6 @@ int main(int argc, char **argv) {
             }
           }
         }
-        
-        //std::cout << "Done fg/bg calc" << std::endl;
       }
       h5read_free_image(image);
     }
@@ -549,92 +543,6 @@ int main(int argc, char **argv) {
                                    static_cast<double>(bbox.z_max)});
     }
 
-    // Display some sample results
-    /*logger.info("Sample bounding box results (first 5 reflections):");
-    for (size_t i = 0; i < std::min<size_t>(5, num_reflections); ++i) {
-        const auto &bbox = computed_bounding_boxes[i];
-        logger.info("  bbox[{}]: x=[{:.1f},{:.1f}] y=[{:.1f},{:.1f}] z=[{},{}]",
-                    i,
-                    bbox.x_min,
-                    bbox.x_max,
-                    bbox.y_min,
-                    bbox.y_max,
-                    bbox.z_min,
-                    bbox.z_max);
-    }
-
-    // Compute Kabsch coordinates for sample voxel centers within bounding boxes
-    logger.info(
-      "Computing Kabsch coordinates for voxel centers using baseline CPU "
-      "algorithms...");
-
-    std::vector<double> voxel_kabsch_coords;  // ε₁, ε₂, ε₃ for each voxel center
-    std::vector<int> voxel_reflection_ids;    // Which reflection each voxel belongs to
-    std::vector<double> voxel_positions;      // x, y, z positions for each voxel center
-    std::vector<double> voxel_s1_lengths;     // |s₁| for each voxel center
-
-    // Process a subset of reflections for demonstration (to avoid excessive computation)
-    size_t max_reflections_to_process = std::min<size_t>(10, num_reflections);
-    logger.info("Processing voxels for first {} reflections as demonstration",
-                max_reflections_to_process);
-
-    for (size_t refl_id = 0; refl_id < max_reflections_to_process; ++refl_id) {
-        const auto &bbox = computed_bounding_boxes[refl_id];
-
-        // Get reflection centroid data
-        Eigen::Vector3d s1_c(
-          s1_vectors(refl_id, 0), s1_vectors(refl_id, 1), s1_vectors(refl_id, 2));
-        double phi_c = phi_column(refl_id, 2);
-
-        // Process a sample of voxels in the bounding box (every 5th voxel to keep computation manageable)
-        int step = 5;
-        int voxel_count = 0;
-
-        for (int z = bbox.z_min; z < bbox.z_max; z += step) {
-            double phi_pixel =
-              osc_start + (z - image_range_start + 1.5) * osc_width / 180.0 * M_PI;
-
-            for (int y = static_cast<int>(bbox.y_min); y < static_cast<int>(bbox.y_max);
-                 y += step) {
-                for (int x = static_cast<int>(bbox.x_min);
-                     x < static_cast<int>(bbox.x_max);
-                     x += step) {
-                    // Convert pixel coordinates to lab coordinates
-                    std::array<double, 2> xy_mm = panel.px_to_mm(
-                      static_cast<double>(x) + 0.5, static_cast<double>(y) + 0.5);
-
-                    Vector3d lab_coord =
-                      panel.get_d_matrix() * Vector3d(xy_mm[0], xy_mm[1], 1.0);
-
-                    // Convert lab coordinate to reciprocal space vector
-                    Eigen::Vector3d s_pixel = lab_coord.normalized() / wl;
-
-                    // Use baseline CPU pixel_to_kabsch algorithm
-                    double s1_len_out;
-                    Eigen::Vector3d kabsch_coords = pixel_to_kabsch(
-                      s0, s1_c, phi_c, s_pixel, phi_pixel, rotation_axis, s1_len_out);
-
-                    // Store results
-                    voxel_kabsch_coords.insert(
-                      voxel_kabsch_coords.end(),
-                      {kabsch_coords.x(), kabsch_coords.y(), kabsch_coords.z()});
-                    voxel_reflection_ids.push_back(static_cast<int>(refl_id));
-                    voxel_positions.insert(
-                      voxel_positions.end(),
-                      {xy_mm[0], xy_mm[1], static_cast<double>(z)});
-                    voxel_s1_lengths.push_back(s1_len_out);
-
-                    voxel_count++;
-                }
-            }
-        }
-
-        logger.debug("Processed {} voxels for reflection {}", voxel_count, refl_id);
-    }
-
-    size_t actual_voxels = voxel_reflection_ids.size();
-    logger.info("Processed {} voxel centers total", actual_voxels);
-    */
     // Create results and save to HDF5
     logger.info("Saving results to: {}", output_file);
 
@@ -655,37 +563,12 @@ int main(int argc, char **argv) {
       "miller_index", num_reflections,3, hkl_vectors
     );
 
-    // Create voxel data table
-    /*ReflectionTable voxel_table;
-    if (actual_voxels > 0) {
-        voxel_table.add_column("kabsch_coordinates",
-                               std::vector<size_t>{actual_voxels, 3},
-                               voxel_kabsch_coords);
-        voxel_table.add_column("reflection_id",
-                               std::vector<size_t>{actual_voxels, 1},
-                               std::vector<double>(voxel_reflection_ids.begin(),
-                                                   voxel_reflection_ids.end()));
-        voxel_table.add_column(
-          "pixel_coordinates", std::vector<size_t>{actual_voxels, 3}, voxel_positions);
-        voxel_table.add_column(
-          "voxel_s1_length", std::vector<size_t>{actual_voxels, 1}, voxel_s1_lengths);
-    }*/
-
-    // Write output files
     integrated_data.write(output_file);
-    /*if (actual_voxels > 0) {
-        std::string voxel_output =
-          output_file.substr(0, output_file.find_last_of('.')) + "_voxels.h5";
-        voxel_table.write(voxel_output);
-        logger.info("Voxel data saved to: {}", voxel_output);
-    }
-    */
     logger.info("Baseline integration complete!");
     logger.info("Summary:");
     logger.info("  {} reflections processed", num_reflections);
     logger.info("  {} bounding boxes computed", computed_bounding_boxes.size());
-    //logger.info("  {} voxel centers processed", actual_voxels);
-    //logger.info("Results saved to: {}", output_file);
+    logger.info("Results saved to: {}", output_file);
 
     return 0;
 }


### PR DESCRIPTION
Complete the baseline c++ integrator implementing summation integration.

Input can be the output from the baseline indexer, predicted data, or predicted data containing bboxes.

Outputs a reflection table with sufficient content to be usable for dials.symmetry and dials.scale.

Slow as not yet parallelized over cpu threads, but useful for testing and comparisons. Close to dials equivalence, not expected to be fully equivalent as slightly different approach used for classifying foreground and background.