### PR TITLE
Parallelise the baseline integrator

### DIFF
--- a/baseline/integrator/background.cc
+++ b/baseline/integrator/background.cc
@@ -26,6 +26,21 @@ class BackgroundAggregator {
         return _large_hist;
     }
 
+    void add(const BackgroundAggregator& other) {
+        // Combine small histogram
+        for (size_t i = 0; i < _small_hist.size(); ++i) {
+            _small_hist[i] += other._small_hist[i];
+        }
+
+        // Combine large histogram
+        for (const auto& kv : other._large_hist) {
+            _large_hist[kv.first] += kv.second;
+        }
+
+        // Combine pixel count
+        n_pixels += other.n_pixels;
+    }
+
   private:
     // Use two data structures for the histogram
     // - a small vector for small counts (< VECTOR_LIMIT) (vast majority of pixels, efficient for adding a large number of low-value pixels)

--- a/baseline/integrator/background.cc
+++ b/baseline/integrator/background.cc
@@ -2,31 +2,48 @@
 #include <cstddef>
 #include <unordered_map>
 #include <vector>
+#include <array>
 
-constexpr std::size_t VECTOR_LIMIT = 64;
+static constexpr std::size_t VECTOR_LIMIT = 64;
 
 class BackgroundAggregator {
   public:
-    BackgroundAggregator() {}
+    BackgroundAggregator() = default;
+
+    ~BackgroundAggregator() {
+        delete _large_hist;
+    }
+
     void add(int x) {
         if (x >= 0 && x < VECTOR_LIMIT) {
             ++_small_hist[x];
         } else {
-            ++_large_hist[x];
+
+            if (!_large_hist) {
+                    _large_hist = new std::unordered_map<int, std::size_t>();
+                }
+            ++(*_large_hist)[x];
+
+            //++_large_hist[x];
         }
         ++n_pixels;
     }
+
     int num_pixels() const {
         return n_pixels;
     }
-    std::vector<std::size_t> small_hist() const {
+    /*std::vector<std::size_t> small_hist() const {
         return _small_hist;
     }
     std::unordered_map<int, std::size_t> large_hist() const {
         return _large_hist;
-    }
+    }*/
 
-    void add(const BackgroundAggregator& other) {
+    const auto& small_hist()  const { return _small_hist; }
+    const auto* large_hist()  const { return _large_hist; }
+
+
+    /*void add(const BackgroundAggregator& other) {
         // Combine small histogram
         for (size_t i = 0; i < _small_hist.size(); ++i) {
             _small_hist[i] += other._small_hist[i];
@@ -39,14 +56,35 @@ class BackgroundAggregator {
 
         // Combine pixel count
         n_pixels += other.n_pixels;
+    }*/
+
+
+    void add(const BackgroundAggregator& other) {
+            for (std::size_t i = 0; i < VECTOR_LIMIT; ++i) {
+                _small_hist[i] += other._small_hist[i];
+            }
+
+            if (other._large_hist) {
+                if (!_large_hist) {
+                    _large_hist = new std::unordered_map<int, std::size_t>();
+                }
+                for (const auto& [k, v] : *other._large_hist) {
+                    (*_large_hist)[k] += v;
+                }
+            }
+
+            n_pixels += other.n_pixels;
     }
+
 
   private:
     // Use two data structures for the histogram
     // - a small vector for small counts (< VECTOR_LIMIT) (vast majority of pixels, efficient for adding a large number of low-value pixels)
     // - an unordered map for large counts (sparse, infrequent, efficient for adding a low number of high-value pixels (perhaps outliers))
-    std::vector<std::size_t> _small_hist = std::vector<std::size_t>(VECTOR_LIMIT, 0);
-    std::unordered_map<int, std::size_t> _large_hist;
+    std::array<std::size_t, VECTOR_LIMIT> _small_hist{};
+    //std::vector<std::size_t> _small_hist = std::vector<std::size_t>(VECTOR_LIMIT, 0);
+    //std::unordered_map<int, std::size_t> _large_hist;
+    std::unordered_map<int, std::size_t>* _large_hist = nullptr;
     int n_pixels = 0;
 };
 
@@ -55,7 +93,113 @@ class BackgroundAggregator {
 
 // Actually do simple with tukey outlier
 
-std::tuple<double, double> compute_background_constant_3d(BackgroundAggregator data) {
+#include <tuple>
+#include <vector>
+#include <algorithm>
+#include <stdexcept>
+
+
+std::tuple<double, double>
+compute_background_constant_3d(const BackgroundAggregator& data)
+{
+    constexpr double iqr_multiplier = 1.5;
+
+    const int N = data.num_pixels();
+    if (N == 0) {
+        throw std::runtime_error("No background pixels available");
+    }
+
+    // Quantile positions (1-based counting convention)
+    const std::size_t p25 = (N + 3) / 4;
+    const std::size_t p50 = (N + 1) / 2;
+    const std::size_t p75 = (3 * N + 1) / 4;
+
+    const auto& small_hist = data.small_hist();
+    const auto* large_hist = data.large_hist();  // may be nullptr
+
+    std::size_t cumulative = 0;
+    int q1 = -1, median = -1, q3 = -1;
+
+    // ---- Scan small histogram (fixed array) ----
+    for (std::size_t value = 0; value < small_hist.size(); ++value) {
+        cumulative += small_hist[value];
+
+        if (q1 < 0 && cumulative >= p25) q1 = static_cast<int>(value);
+        if (median < 0 && cumulative >= p50) median = static_cast<int>(value);
+        if (q3 < 0 && cumulative >= p75) {
+            q3 = static_cast<int>(value);
+            break;
+        }
+    }
+
+    // ---- Scan large histogram only if needed ----
+    if (q3 < 0 && large_hist != nullptr) {
+        std::vector<int> keys;
+        keys.reserve(large_hist->size());
+        for (const auto& [k, _] : *large_hist) {
+            keys.push_back(k);
+        }
+        std::sort(keys.begin(), keys.end());
+
+        for (int value : keys) {
+            cumulative += large_hist->at(value);
+
+            if (q1 < 0 && cumulative >= p25) q1 = value;
+            if (median < 0 && cumulative >= p50) median = value;
+            if (q3 < 0 && cumulative >= p75) {
+                q3 = value;
+                break;
+            }
+        }
+    }
+
+    // Sanity check (should not happen unless input is inconsistent)
+    if (q1 < 0 || q3 < 0) {
+        throw std::runtime_error("Failed to compute quartiles for background");
+    }
+
+    const int iqr = q3 - q1;
+    const double lower_bound = q1 - iqr_multiplier * iqr;
+    const double upper_bound = q3 + iqr_multiplier * iqr;
+
+    // ---- Accumulate inliers ----
+    std::size_t included_count = 0;
+    double weighted_sum = 0.0;
+
+    // Small histogram
+    for (std::size_t value = 0; value < small_hist.size(); ++value) {
+        if (value < lower_bound || value > upper_bound) {
+            continue;
+        }
+
+        const std::size_t count = small_hist[value];
+        included_count += count;
+        weighted_sum += static_cast<double>(value) * count;
+    }
+
+    // Large histogram (if present)
+    if (large_hist != nullptr) {
+        for (const auto& [value, count] : *large_hist) {
+            if (value < lower_bound || value > upper_bound) {
+                continue;
+            }
+
+            included_count += count;
+            weighted_sum += static_cast<double>(value) * count;
+        }
+    }
+
+    if (included_count == 0) {
+        throw std::runtime_error("No background data remaining after outlier rejection");
+    }
+
+    const double mean = weighted_sum / static_cast<double>(included_count);
+    return {mean, weighted_sum};
+}
+
+
+/*
+std::tuple<double, double> compute_background_constant_3d(BackgroundAggregator& data) {
     // first do tukey outlier rejection based on 1.5 IQR multiplier.
     double iqr_multiplier = 1.5;
     int N = data.num_pixels();
@@ -64,8 +208,12 @@ std::tuple<double, double> compute_background_constant_3d(BackgroundAggregator d
     std::size_t p50 = (N + 1) / 2;
     std::size_t p75 = (3 * N + 1) / 4;
 
-    std::vector<std::size_t> small_hist = data.small_hist();
-    std::unordered_map<int, std::size_t> large_hist = data.large_hist();
+    //std::vector<std::size_t> small_hist = data.small_hist();
+    //std::unordered_map<int, std::size_t> large_hist = data.large_hist();
+
+    const auto& small_hist = data.small_hist();
+    const auto* large_hist = data.large_hist();
+
 
     // iterate the vector.
     std::size_t cumulative = 0;
@@ -83,7 +231,7 @@ std::tuple<double, double> compute_background_constant_3d(BackgroundAggregator d
     // iterate the hist if not all found.
     if (q3 < 0) {
         std::vector<int> keys;
-        keys.reserve(large_hist.size());
+        keys.reserve(large_hist->size());
         for (auto &[k, _] : large_hist) keys.push_back(k);
 
         std::sort(keys.begin(), keys.end());
@@ -129,4 +277,4 @@ std::tuple<double, double> compute_background_constant_3d(BackgroundAggregator d
 
     return std::make_tuple(weighted_sum / static_cast<double>(included_count),
                            weighted_sum);
-}
+}*/

--- a/baseline/integrator/background.cc
+++ b/baseline/integrator/background.cc
@@ -3,6 +3,8 @@
 #include <unordered_map>
 #include <vector>
 #include <array>
+#include <tuple>
+#include <stdexcept>
 
 static constexpr std::size_t VECTOR_LIMIT = 64;
 
@@ -23,8 +25,6 @@ class BackgroundAggregator {
                     _large_hist = new std::unordered_map<int, std::size_t>();
                 }
             ++(*_large_hist)[x];
-
-            //++_large_hist[x];
         }
         ++n_pixels;
     }
@@ -32,32 +32,8 @@ class BackgroundAggregator {
     int num_pixels() const {
         return n_pixels;
     }
-    /*std::vector<std::size_t> small_hist() const {
-        return _small_hist;
-    }
-    std::unordered_map<int, std::size_t> large_hist() const {
-        return _large_hist;
-    }*/
-
     const auto& small_hist()  const { return _small_hist; }
     const auto* large_hist()  const { return _large_hist; }
-
-
-    /*void add(const BackgroundAggregator& other) {
-        // Combine small histogram
-        for (size_t i = 0; i < _small_hist.size(); ++i) {
-            _small_hist[i] += other._small_hist[i];
-        }
-
-        // Combine large histogram
-        for (const auto& kv : other._large_hist) {
-            _large_hist[kv.first] += kv.second;
-        }
-
-        // Combine pixel count
-        n_pixels += other.n_pixels;
-    }*/
-
 
     void add(const BackgroundAggregator& other) {
             for (std::size_t i = 0; i < VECTOR_LIMIT; ++i) {
@@ -79,26 +55,15 @@ class BackgroundAggregator {
 
   private:
     // Use two data structures for the histogram
-    // - a small vector for small counts (< VECTOR_LIMIT) (vast majority of pixels, efficient for adding a large number of low-value pixels)
-    // - an unordered map for large counts (sparse, infrequent, efficient for adding a low number of high-value pixels (perhaps outliers))
+    // - a small array for small counts (< VECTOR_LIMIT) (vast majority of pixels, efficient for adding a large number of low-value pixels)
+    // - an unordered map pointer for large counts (sparse, infrequent, efficient for adding a low number of high-value pixels (perhaps outliers))
     std::array<std::size_t, VECTOR_LIMIT> _small_hist{};
-    //std::vector<std::size_t> _small_hist = std::vector<std::size_t>(VECTOR_LIMIT, 0);
-    //std::unordered_map<int, std::size_t> _large_hist;
     std::unordered_map<int, std::size_t>* _large_hist = nullptr;
     int n_pixels = 0;
 };
 
-// Compute constant 3d glm background model
-// int min_pixels=10
 
-// Actually do simple with tukey outlier
-
-#include <tuple>
-#include <vector>
-#include <algorithm>
-#include <stdexcept>
-
-
+// Simple background with tukey outlier for now.
 std::tuple<double, double>
 compute_background_constant_3d(const BackgroundAggregator& data)
 {
@@ -196,85 +161,3 @@ compute_background_constant_3d(const BackgroundAggregator& data)
     const double mean = weighted_sum / static_cast<double>(included_count);
     return {mean, weighted_sum};
 }
-
-
-/*
-std::tuple<double, double> compute_background_constant_3d(BackgroundAggregator& data) {
-    // first do tukey outlier rejection based on 1.5 IQR multiplier.
-    double iqr_multiplier = 1.5;
-    int N = data.num_pixels();
-
-    std::size_t p25 = (N + 3) / 4;
-    std::size_t p50 = (N + 1) / 2;
-    std::size_t p75 = (3 * N + 1) / 4;
-
-    //std::vector<std::size_t> small_hist = data.small_hist();
-    //std::unordered_map<int, std::size_t> large_hist = data.large_hist();
-
-    const auto& small_hist = data.small_hist();
-    const auto* large_hist = data.large_hist();
-
-
-    // iterate the vector.
-    std::size_t cumulative = 0;
-    int q1 = -1, median = -1, q3 = -1;
-    for (int value = 0; value < small_hist.size(); ++value) {
-        cumulative += small_hist[value];
-
-        if (q1 < 0 && cumulative >= p25) q1 = value;
-        if (median < 0 && cumulative >= p50) median = value;
-        if (q3 < 0 && cumulative >= p75) {
-            q3 = value;
-            break;  // may be able to stop early
-        }
-    }
-    // iterate the hist if not all found.
-    if (q3 < 0) {
-        std::vector<int> keys;
-        keys.reserve(large_hist->size());
-        for (auto &[k, _] : large_hist) keys.push_back(k);
-
-        std::sort(keys.begin(), keys.end());
-
-        for (int value : keys) {
-            cumulative += large_hist[value];
-
-            if (q1 < 0 && cumulative >= p25) q1 = value;
-            if (median < 0 && cumulative >= p50) median = value;
-            if (q3 < 0 && cumulative >= p75) {
-                q3 = value;
-                break;
-            }
-        }
-    }
-    int iqr = q3 - q1;
-    double upper_bound = q3 + (iqr * iqr_multiplier);
-    double lower_bound = q1 - (iqr * iqr_multiplier);
-
-    std::size_t included_count = 0;
-    double weighted_sum = 0.0;
-
-    // ---- Small values (vector) ----
-    for (std::size_t value = 0; value < small_hist.size(); ++value) {
-        if (value < lower_bound || value > upper_bound) continue;
-
-        std::size_t count = small_hist[value];
-        included_count += count;
-        weighted_sum += value * static_cast<double>(count);
-    }
-
-    // ---- Large outliers (unordered_map) ----
-    for (const auto &[value, count] : large_hist) {
-        if (value < lower_bound || value > upper_bound) continue;
-
-        included_count += count;
-        weighted_sum += value * static_cast<double>(count);
-    }
-
-    // Avoid division by zero if everything was excluded
-    if (included_count == 0)
-        throw std::runtime_error("No counts included in background calculation");
-
-    return std::make_tuple(weighted_sum / static_cast<double>(included_count),
-                           weighted_sum);
-}*/

--- a/baseline/integrator/background.cc
+++ b/baseline/integrator/background.cc
@@ -1,10 +1,10 @@
 #include <algorithm>
+#include <array>
 #include <cstddef>
+#include <stdexcept>
+#include <tuple>
 #include <unordered_map>
 #include <vector>
-#include <array>
-#include <tuple>
-#include <stdexcept>
 
 static constexpr std::size_t VECTOR_LIMIT = 64;
 
@@ -20,10 +20,9 @@ class BackgroundAggregator {
         if (x >= 0 && x < VECTOR_LIMIT) {
             ++_small_hist[x];
         } else {
-
             if (!_large_hist) {
-                    _large_hist = new std::unordered_map<int, std::size_t>();
-                }
+                _large_hist = new std::unordered_map<int, std::size_t>();
+            }
             ++(*_large_hist)[x];
         }
         ++n_pixels;
@@ -32,41 +31,42 @@ class BackgroundAggregator {
     int num_pixels() const {
         return n_pixels;
     }
-    const auto& small_hist()  const { return _small_hist; }
-    const auto* large_hist()  const { return _large_hist; }
-
-    void add(const BackgroundAggregator& other) {
-            for (std::size_t i = 0; i < VECTOR_LIMIT; ++i) {
-                _small_hist[i] += other._small_hist[i];
-            }
-
-            if (other._large_hist) {
-                if (!_large_hist) {
-                    _large_hist = new std::unordered_map<int, std::size_t>();
-                }
-                for (const auto& [k, v] : *other._large_hist) {
-                    (*_large_hist)[k] += v;
-                }
-            }
-
-            n_pixels += other.n_pixels;
+    const auto &small_hist() const {
+        return _small_hist;
+    }
+    const auto *large_hist() const {
+        return _large_hist;
     }
 
+    void add(const BackgroundAggregator &other) {
+        for (std::size_t i = 0; i < VECTOR_LIMIT; ++i) {
+            _small_hist[i] += other._small_hist[i];
+        }
+
+        if (other._large_hist) {
+            if (!_large_hist) {
+                _large_hist = new std::unordered_map<int, std::size_t>();
+            }
+            for (const auto &[k, v] : *other._large_hist) {
+                (*_large_hist)[k] += v;
+            }
+        }
+
+        n_pixels += other.n_pixels;
+    }
 
   private:
     // Use two data structures for the histogram
     // - a small array for small counts (< VECTOR_LIMIT) (vast majority of pixels, efficient for adding a large number of low-value pixels)
     // - an unordered map pointer for large counts (sparse, infrequent, efficient for adding a low number of high-value pixels (perhaps outliers))
     std::array<std::size_t, VECTOR_LIMIT> _small_hist{};
-    std::unordered_map<int, std::size_t>* _large_hist = nullptr;
+    std::unordered_map<int, std::size_t> *_large_hist = nullptr;
     int n_pixels = 0;
 };
 
-
 // Simple background with tukey outlier for now.
-std::tuple<double, double>
-compute_background_constant_3d(const BackgroundAggregator& data)
-{
+std::tuple<double, double> compute_background_constant_3d(
+  const BackgroundAggregator &data) {
     constexpr double iqr_multiplier = 1.5;
 
     const int N = data.num_pixels();
@@ -79,8 +79,8 @@ compute_background_constant_3d(const BackgroundAggregator& data)
     const std::size_t p50 = (N + 1) / 2;
     const std::size_t p75 = (3 * N + 1) / 4;
 
-    const auto& small_hist = data.small_hist();
-    const auto* large_hist = data.large_hist();  // may be nullptr
+    const auto &small_hist = data.small_hist();
+    const auto *large_hist = data.large_hist();  // may be nullptr
 
     std::size_t cumulative = 0;
     int q1 = -1, median = -1, q3 = -1;
@@ -101,7 +101,7 @@ compute_background_constant_3d(const BackgroundAggregator& data)
     if (q3 < 0 && large_hist != nullptr) {
         std::vector<int> keys;
         keys.reserve(large_hist->size());
-        for (const auto& [k, _] : *large_hist) {
+        for (const auto &[k, _] : *large_hist) {
             keys.push_back(k);
         }
         std::sort(keys.begin(), keys.end());
@@ -144,7 +144,7 @@ compute_background_constant_3d(const BackgroundAggregator& data)
 
     // Large histogram (if present)
     if (large_hist != nullptr) {
-        for (const auto& [value, count] : *large_hist) {
+        for (const auto &[value, count] : *large_hist) {
             if (value < lower_bound || value > upper_bound) {
                 continue;
             }
@@ -155,7 +155,8 @@ compute_background_constant_3d(const BackgroundAggregator& data)
     }
 
     if (included_count == 0) {
-        throw std::runtime_error("No background data remaining after outlier rejection");
+        throw std::runtime_error(
+          "No background data remaining after outlier rejection");
     }
 
     const double mean = weighted_sum / static_cast<double>(included_count);

--- a/baseline/integrator/integration_calculations.cc
+++ b/baseline/integrator/integration_calculations.cc
@@ -54,7 +54,7 @@ class CoordinateSystem {
         scaled_e2_ = e2_ / s1_length;
         zeta_ = m2_.dot(e1_);
     }
-    Vector3d coords_from_s1vector(const Vector3d s_dash, double phi_dash) {
+    Vector3d coords_from_s1vector(const Vector3d s_dash, double phi_dash) const {
         Vector3d coord = {scaled_e1_.dot(s_dash - s1_),
                           scaled_e2_.dot(s_dash - s1_),
                           zeta_ * (phi_dash - phi_)};

--- a/baseline/integrator/integrator.cc
+++ b/baseline/integrator/integrator.cc
@@ -412,7 +412,8 @@ Accumulator process_image_range(
                         const Vector3d &s1dash = constants.pixel_to_s1_map[geom_index(
                           x + bbox.x_min, y + bbox.y_min)];
                         // Phi value required for calls but not actually used as don't use e3.
-                        Vector3d epsilon_coords = cs.coords_from_s1vector(s1dash, phidash_start);
+                        Vector3d epsilon_coords =
+                          cs.coords_from_s1vector(s1dash, phidash_start);
 
                         dxy[index] = ((epsilon_coords[0] * epsilon_coords[0]
                                        + epsilon_coords[1] * epsilon_coords[1])

--- a/baseline/integrator/integrator.cc
+++ b/baseline/integrator/integrator.cc
@@ -405,8 +405,8 @@ Accumulator process_image_range(
                     dxy.resize(required);
                 }
                 double phi =
-                  constants.phi0
-                  + (j * constants.dphi)
+                  (constants.phi0
+                  + (j * constants.dphi))
                       * constants
                           .DEG2RAD;  // Required for calls but not actually used as don't use e3.
                 const CoordinateSystem &cs = constants.coord_system_vector[refl_id];
@@ -414,9 +414,11 @@ Accumulator process_image_range(
                 for (int x = 0; x < n_x; x++) {
                     for (int y = 0; y < n_y; y++) {
                         int index = x + (y * (n_x));
-                        const Vector3d &s1dash =
-                          constants.pixel_to_s1_map[(x + bbox.x_min)
-                                                    + (y + bbox.y_min) * image_fast];
+                        //const Vector3d &s1dash =
+                        //  constants.pixel_to_s1_map[(x + bbox.x_min)
+                        //                            + (y + bbox.y_min) * image_fast];
+                        const Vector3d &s1dash = constants.pixel_to_s1_map[geom_index(
+                          x + bbox.x_min, y + bbox.y_min)];
                         Vector3d epsilon_coords = cs.coords_from_s1vector(s1dash, phi);
 
                         dxy[index] = ((epsilon_coords[0] * epsilon_coords[0]

--- a/baseline/integrator/integrator.cc
+++ b/baseline/integrator/integrator.cc
@@ -18,6 +18,7 @@
 #include <nlohmann/json.hpp>
 #include <string>
 #include <vector>
+#include <chrono>
 
 #include "arg_parser.hpp"
 #include "background.cc"
@@ -158,24 +159,6 @@ struct Accumulator {
     }
 };
 
-/*struct Accumulator {
-    std::vector<double> intensity;
-    std::vector<size_t> nfg;
-    std::vector<size_t> nbg;
-    std::vector<Vector3d> intensity_times_coord;
-    std::vector<BackgroundAggregator> bg;
-    std::vector<bool> success;
-
-    Accumulator(size_t n_reflections)
-      : intensity(n_reflections, 0.0),
-        nfg(n_reflections, 0),
-        nbg(n_reflections, 0),
-        intensity_times_coord(n_reflections, Vector3d::Zero()),
-        bg(n_reflections),
-        success(n_reflections, true) {}
-
-};*/
-
 
 struct ImageRange {
     size_t begin;
@@ -198,6 +181,8 @@ std::vector<ImageRange> split_ranges(size_t n_images, size_t n_threads) {
     return ranges;
 }
 
+using PixelGeomBuffer = std::vector<Vector3d>;
+
 struct SharedConstants {
     // --- Sizes ---
     size_t n_reflections;
@@ -205,14 +190,10 @@ struct SharedConstants {
     // --- Reflection selection ---
     const std::vector<bool>& dont_integrate;
     const std::vector<BoundingBoxExtents>& computed_bounding_boxes;
-    const std::vector<CoordinateSystem>& coord_system_vector;
+    std::vector<CoordinateSystem>& coord_system_vector;
 
     // --- Reflection geometry ---
     const mdspan_type<double> phi_column;     // shape: [n_reflections, 3]
-    const mdspan_type<double> s1_vectors;     // shape: [n_reflections, 3]
-
-    // --- Panel / detector ---
-    const Panel& panel;
 
     // --- Scan / rotation ---
     double phi0;
@@ -228,35 +209,45 @@ struct SharedConstants {
     double delta_b_r2;
     double delta_m_r2;
 
+    const PixelGeomBuffer& pixel_geom;
+
+    int geom_width;
+    int geom_height;
+    int global_x_min;
+    int global_y_min;
+
     SharedConstants(
         size_t n_reflections_,
         const std::vector<bool>& dont_integrate_,
         const std::vector<BoundingBoxExtents>& computed_bounding_boxes_,
-        const std::vector<CoordinateSystem>& coord_system_vector_,
+        std::vector<CoordinateSystem>& coord_system_vector_,
         const mdspan_type<double> phi_column_,
-        const mdspan_type<double> s1_vectors_,
-        const Panel& panel_,
         double phi0_,
         double dphi_,
         double s0_length_,
         FGAlgorithm fg_algorithm_,
         double delta_b_r2_,
-        double delta_m_r2_
+        double delta_m_r2_,
+        const PixelGeomBuffer& pixel_geom_,
+        int geom_width_,
+        int geom_height_,
+        int global_x_min_,
+        int global_y_min_
     )
       : n_reflections(n_reflections_),
         dont_integrate(dont_integrate_),
         computed_bounding_boxes(computed_bounding_boxes_),
         coord_system_vector(coord_system_vector_),
         phi_column(phi_column_),
-        s1_vectors(s1_vectors_),
-        panel(panel_),
         phi0(phi0_),
         dphi(dphi_),
         DEG2RAD(M_PI / 180.0),
         s0_length(s0_length_),
         fg_algorithm(std::move(fg_algorithm_)),
         delta_b_r2(delta_b_r2_),
-        delta_m_r2(delta_m_r2_) {}
+        delta_m_r2(delta_m_r2_),
+        pixel_geom(pixel_geom_),
+        geom_width(geom_width_), geom_height(geom_height_), global_x_min(global_x_min_), global_y_min(global_y_min_) {}
 };
 
 
@@ -266,7 +257,7 @@ Accumulator process_image_range(
     std::unordered_map<int, std::vector<size_t>>& reflections_by_image,
     const SharedConstants& constants
 ) {
-    Accumulator accumulator;//(constants.n_reflections);
+    Accumulator accumulator;
 
     std::string filename = expt.imagesequence().filename();
     H5Read reader(filename);
@@ -274,13 +265,27 @@ Accumulator process_image_range(
     auto [image_slow, image_fast] = reader.image_shape();
     auto mask = reader.get_mask().value();
 
+    int global_x_min = constants.global_x_min;
+    int global_y_min = constants.global_y_min;
+    int geom_width = constants.geom_width;
+
+    auto geom_index = [&](int x, int y) -> size_t {
+        return static_cast<size_t>(
+            (x - global_x_min) +
+            (y - global_y_min) * geom_width
+        );
+    };
+
     for (size_t j = range.begin; j < range.end; j++) {
+        auto t1 = std::chrono::system_clock::now();
         if (!reader.is_image_available(j))
             continue;
 
         auto image = reader.get_image(j);
-        logger.info("Processing image {}", j + 1);
+        const auto* img = image.data.data();
+        auto t2 = std::chrono::system_clock::now();
 
+        // calculate dxy array (arrays of distances in kabsch space from pixel corners to xyzcal)
         std::vector<double> dxy_start;// start of image (in rotation)
         std::vector<double> dxy_end;// end of image (in rotation)
         std::vector<double> dxy;
@@ -295,41 +300,32 @@ Accumulator process_image_range(
                 if (constants.dont_integrate[refl_id]) {
                     continue;
                 }
+                auto& a = accumulator[refl_id];
+                if (!a.success)
+                    continue;
+
                 const auto &bbox = constants.computed_bounding_boxes[refl_id];
-                
-                // calculate dxy array (arrays of distances in kabsch space from pixel corners to xyzcal)
                 int n_x = bbox.x_max - bbox.x_min + 1;
                 int n_y = bbox.y_max - bbox.y_min + 1;
-                //std::vector<double> dxy_start(n_x
-                //                              * n_y);    // start of image (in rotation)
-                //std::vector<double> dxy_end(n_x * n_y);  // end of image (in rotation)
 
                 size_t required = static_cast<size_t>(n_x) * n_y;
                 if (dxy_start.size() < required) {
                     dxy_start.resize(required);
                     dxy_end.resize(required);
                 }
-
                 
                 double phi_c = constants.phi_column(refl_id, 2);
-                CoordinateSystem cs = constants.coord_system_vector[refl_id];
-                auto& a = accumulator[refl_id];
-                //Vector3d s1_this = Eigen::Map<Vector3d>(&constants.s1_vectors(refl_id, 0));
-                
+                CoordinateSystem& cs = constants.coord_system_vector[refl_id];
+
                 for (int y = 0; y < n_y; ++y) {
                     int row = y * n_x;
                     for (int x = 0; x < n_x; ++x) {
                         int index = row + x;
+                        const Vector3d& s1dash =
+                            constants.pixel_geom[
+                                geom_index(x+bbox.x_min,y+ bbox.y_min)
+                            ];
 
-
-                        //for (int x = 0; x < n_x; x++) {
-                        //for (int y = 0; y < n_y; y++) {
-                        //int index = x + (y * (n_x));
-                        std::array<double, 2> px_mm =
-                          constants.panel.px_to_mm(x + bbox.x_min, y + bbox.y_min);
-                        Vector3d s1_ = constants.panel.get_lab_coord(px_mm[0], px_mm[1]);
-                        s1_.normalize();
-                        Vector3d s1dash = s1_ * constants.s0_length;
                         Vector3d epsilon_coords_start =
                           cs.coords_from_s1vector(s1dash, phidash_start);
                         Vector3d epsilon_coords_end =
@@ -377,9 +373,6 @@ Accumulator process_image_range(
                         d = std::min(d, d6);
                         d = std::min(d, d7);
                         d = std::min(d, d8);
-                        /*double d =
-                          std::min(std::min(std::min(d1, d2), std::min(d3, d4)),
-                                   std::min(std::min(d5, d6), std::min(d7, d8)));*/
                         int index = x + (y * image_fast);
                         bool in_image =
                           x >= 0 && x < image_fast && y >= 0 && y < image_slow;
@@ -390,14 +383,12 @@ Accumulator process_image_range(
                                 if (mask[index] == 0) {  // masked
                                     a.success = false;
                                 } else {
-                                    auto data = image.data.data()[index];
+                                    auto data = img[index];
                                     a.intensity += data;
                                     a.nfg += 1;
-                                    Vector3d I_times_c = {data * (x + 0.5),
-                                                          data * (y + 0.5),
-                                                          data * (j + 0.5)};
-                                    a.intensity_times_coord +=
-                                      I_times_c;
+                                    a.intensity_times_coord[0] += data * (x + 0.5);
+                                    a.intensity_times_coord[1] += data * (y + 0.5);
+                                    a.intensity_times_coord[2] += data * (j + 0.5);
                                 }
                             } else {
                                 a.success = false;
@@ -407,7 +398,7 @@ Accumulator process_image_range(
                             if (in_image) {
                                 if (mask[index] != 0) {
                                     // In image, not masked
-                                    auto data = image.data.data()[index];
+                                    auto data = img[index];
                                     a.bg.add(data);
                                     a.nbg += 1;
                                 }
@@ -425,11 +416,15 @@ Accumulator process_image_range(
                 if (constants.dont_integrate[refl_id]) {
                     continue;
                 }
+                auto& a = accumulator[refl_id];
+                if (!a.success)
+                    continue;
+
                 const auto &bbox = constants.computed_bounding_boxes[refl_id];
                 // dials algorithm - a fixed ellipse (2D) across all images in the bbox
                 int n_x = bbox.x_max - bbox.x_min + 1;
                 int n_y = bbox.y_max - bbox.y_min + 1;
-                //std::vector<double> dxy(n_x * n_y);
+
                 size_t required = static_cast<size_t>(n_x) * n_y;
                 if (dxy.size() < required) {
                     dxy.resize(required);
@@ -438,17 +433,15 @@ Accumulator process_image_range(
                   constants.phi0
                   + (j * constants.dphi)
                       * constants.DEG2RAD;  // Required for calls but not actually used as don't use e3.
-                CoordinateSystem cs = constants.coord_system_vector[refl_id];
-                auto& a = accumulator[refl_id];
-                //Vector3d s1_this = Eigen::Map<Vector3d>(&constants.s1_vectors(refl_id, 0));
+                CoordinateSystem& cs = constants.coord_system_vector[refl_id];
+
                 for (int x = 0; x < n_x; x++) {
                     for (int y = 0; y < n_y; y++) {
                         int index = x + (y * (n_x));
-                        std::array<double, 2> px_mm =
-                          constants.panel.px_to_mm(x + bbox.x_min, y + bbox.y_min);
-                        Vector3d s1_ = constants.panel.get_lab_coord(px_mm[0], px_mm[1]);
-                        s1_.normalize();
-                        Vector3d s1dash = s1_ * constants.s0_length;
+                        const Vector3d& s1dash =
+                            constants.pixel_geom[
+                                (x + bbox.x_min) + (y + bbox.y_min) * image_fast
+                            ];
                         Vector3d epsilon_coords = cs.coords_from_s1vector(s1dash, phi);
 
                         dxy[index] = ((epsilon_coords[0] * epsilon_coords[0]
@@ -472,7 +465,6 @@ Accumulator process_image_range(
                         d = std::min(d, d2);
                         d = std::min(d, d3);
                         d = std::min(d, d4);
-                        //double d = std::min(std::min(d1, d2), std::min(d3, d4));
                         int index = x + (y * image_fast);
                         bool in_image =
                           x >= 0 && x < image_fast && y >= 0 && y < image_slow;
@@ -483,14 +475,12 @@ Accumulator process_image_range(
                                 if (mask[index] == 0) {  // masked)
                                     a.success = false;
                                 } else {
-                                    auto data = image.data.data()[index];
+                                    auto data = img[index];
                                     a.intensity += data;
                                     a.nfg += 1;
-                                    Vector3d I_times_c = {data * (x + 0.5),
-                                                          data * (y + 0.5),
-                                                          data * (j + 0.5)};
-                                    a.intensity_times_coord +=
-                                      I_times_c;
+                                    a.intensity_times_coord[0] += data * (x + 0.5);
+                                    a.intensity_times_coord[1] += data * (y + 0.5);
+                                    a.intensity_times_coord[2] += data * (j + 0.5);
                                 }
                             } else {
                                 a.success = false;
@@ -500,7 +490,7 @@ Accumulator process_image_range(
                             if (in_image) {
                                 if (mask[index] != 0) {
                                     // In image, not masked
-                                    auto data = image.data.data()[index];
+                                    auto data = img[index];
                                     a.bg.add(data);
                                     a.nbg += 1;
                                 }
@@ -511,6 +501,11 @@ Accumulator process_image_range(
             }
             break;
         }
+        auto t3 = std::chrono::system_clock::now();
+        std::chrono::duration<double> elapsed_time_load = t2 - t1;
+        std::chrono::duration<double> elapsed_time_process = t3 - t2;
+        logger.info("Processed image {}, load time {:.6f}s, process time {:.6f}s", j+1, elapsed_time_load.count(), elapsed_time_process.count());
+        
     }
     return accumulator;
 }
@@ -867,6 +862,20 @@ int main(int argc, char **argv) {
 
     logger.info("Calculated coordinate systems");
 
+    // Precompute the pixel to mm mapping for the whole image, as this is constant throughout the integration
+    // First work out global x,y limits, as bboxes extend beyond the image.
+    int global_x_min =  std::numeric_limits<int>::max();
+    int global_x_max = -std::numeric_limits<int>::max();
+    int global_y_min =  std::numeric_limits<int>::max();
+    int global_y_max = -std::numeric_limits<int>::max();
+
+    for (const auto& bbox : computed_bounding_boxes) {
+        global_x_min = std::min(global_x_min, static_cast<int>(bbox.x_min));
+        global_x_max = std::max(global_x_max, static_cast<int>(bbox.x_max));
+        global_y_min = std::min(global_y_min, static_cast<int>(bbox.y_min));
+        global_y_max = std::max(global_y_max, static_cast<int>(bbox.y_max));
+    }
+
     // Now load some image data and loop through:
     std::string filename = expt.imagesequence().filename();
     auto reader = H5Read(filename);
@@ -874,17 +883,40 @@ int main(int argc, char **argv) {
     auto [image_slow, image_fast] = reader.image_shape();
     auto mask = reader.get_mask().value();
 
+    int geom_width  = global_x_max - global_x_min + 1;
+    int geom_height = global_y_max - global_y_min + 1;
+
+    PixelGeomBuffer pixel_geom(geom_width * geom_height);
+
+    auto geom_index = [&](int x, int y) -> size_t {
+        return static_cast<size_t>(
+            (x - global_x_min) +
+            (y - global_y_min) * geom_width
+        );
+    };
+    
+    for (int y = global_y_min; y <= global_y_max; ++y) {
+        for (int x = global_x_min; x <= global_x_max; ++x) {
+            auto px_mm = panel.px_to_mm(x, y);
+            Vector3d s1 = panel.get_lab_coord(px_mm[0], px_mm[1]);
+            s1.normalize();
+            pixel_geom[geom_index(x, y)] =
+                s1 * s0_length;
+        }
+    }
+
     SharedConstants constants = SharedConstants(
         num_reflections, dont_integrate,
         computed_bounding_boxes,
         coord_system_vector,
-        phi_column, s1_vectors, panel,
-        phi0, dphi, s0_length, fg_algorithm, delta_b_r2, delta_m_r2);
+        phi_column,
+        phi0, dphi, s0_length, fg_algorithm, delta_b_r2, delta_m_r2, pixel_geom,
+        geom_width, geom_height, global_x_min, global_y_min);
+    
     logger.info("Made shared constants");
 
     std::vector<ImageRange> ranges = split_ranges(n_images, nthreads);
     std::vector<std::thread> workers;
-    //std::vector<Accumulator> thread_accs(nthreads);
 
     std::vector<Accumulator> thread_accs;
     thread_accs.reserve(nthreads);
@@ -910,7 +942,6 @@ int main(int argc, char **argv) {
     std::vector<int> nbg_accumulators(num_reflections);
     std::vector<int> nfg_accumulators(num_reflections);
 
-
     for (const auto& acc : thread_accs) {
         for (const auto& [r, partial] : acc.data) {
             intensity_accumulators[r] += partial.intensity;
@@ -923,208 +954,6 @@ int main(int argc, char **argv) {
         }
     }
 
-
-    /*for (const auto& acc : thread_accs) {
-        for (size_t r = 0; r < num_reflections; r++) {
-            intensity_accumulators[r] += acc.intensity[r];
-            nfg_accumulators[r] += acc.nfg[r];
-            nbg_accumulators[r] += acc.nbg[r];
-            bg_accumulators[r].add(acc.bg[r]);
-            intensity_times_coord_accumulators[r] += acc.intensity_times_coord[r];
-            success[r] = static_cast<bool>(success[r]) && acc.success[r];
-        }
-    }*/
-
-
-    
-
-    /*Accumulator accumulator = Accumulator(num_reflections);
-
-    for (size_t j = 0; j < n_images; j++) {
-        if (!reader.is_image_available(j)) {
-            continue;
-        }
-        auto image = reader.get_image(j);
-        logger.info("Processing image {}", j + 1);
-        for (size_t k = 0; k < reflections_by_image[j].size(); k++) {
-            size_t refl_id = reflections_by_image[j][k];
-            if (constants.dont_integrate[refl_id]) {
-                continue;
-            }
-            const auto &bbox = constants.computed_bounding_boxes[refl_id];
-            if (constants.fg_algorithm == "ellipsoid") {
-                // calculate dxy array (arrays of distances in kabsch space from pixel corners to xyzcal)
-                int n_x = bbox.x_max - bbox.x_min + 1;
-                int n_y = bbox.y_max - bbox.y_min + 1;
-                std::vector<double> dxy_start(n_x
-                                              * n_y);    // start of image (in rotation)
-                std::vector<double> dxy_end(n_x * n_y);  // end of image (in rotation)
-                double phidash_start = (constants.phi0 + (j * constants.dphi)) * constants.DEG2RAD;
-                double phidash_end = (constants.phi0 + ((j + 1) * constants.dphi)) * constants.DEG2RAD;
-                double phi_c = constants.phi_column(refl_id, 2);
-                CoordinateSystem cs = constants.coord_system_vector[refl_id];
-                Vector3d s1_this = Eigen::Map<Vector3d>(&constants.s1_vectors(refl_id, 0));
-                for (int x = 0; x < n_x; x++) {
-                    for (int y = 0; y < n_y; y++) {
-                        int index = x + (y * (n_x));
-                        std::array<double, 2> px_mm =
-                          constants.panel.px_to_mm(x + bbox.x_min, y + bbox.y_min);
-                        Vector3d s1_ = constants.panel.get_lab_coord(px_mm[0], px_mm[1]);
-                        s1_.normalize();
-                        Vector3d s1dash = s1_ * constants.s0_length;
-                        Vector3d epsilon_coords_start =
-                          cs.coords_from_s1vector(s1dash, phidash_start);
-                        Vector3d epsilon_coords_end =
-                          cs.coords_from_s1vector(s1dash, phidash_end);
-                        if ((phidash_start > phi_c) && (phi_c < phidash_end)) {
-                            epsilon_coords_start[2] = 0.0;
-                            epsilon_coords_end[2] = 0.0;
-                        }
-
-                        dxy_start[index] =
-                          ((epsilon_coords_start[0] * epsilon_coords_start[0]
-                            + epsilon_coords_start[1] * epsilon_coords_start[1])
-                           * constants.delta_b_r2)
-                          + ((epsilon_coords_start[2] * epsilon_coords_start[2])
-                             * constants.delta_m_r2);
-                        dxy_end[index] =
-                          ((epsilon_coords_end[0] * epsilon_coords_end[0]
-                            + epsilon_coords_end[1] * epsilon_coords_end[1])
-                           * constants.delta_b_r2)
-                          + ((epsilon_coords_end[2] * epsilon_coords_end[2])
-                             * constants.delta_m_r2);
-                    }
-                }
-                // Now loop through pixels in bbox, adding to foreground or background if unmasked and in image.
-                for (int x = bbox.x_min; x < bbox.x_max; x++) {
-                    for (int y = bbox.y_min; y < bbox.y_max; y++) {
-                        // The bounding box may extend beyond the image - if so, this is ok if it is only background
-                        // but not if it is foreground.
-                        int x_index = x - bbox.x_min;
-                        int y_index = y - bbox.y_min;
-                        int dxyindex = x_index + (y_index * n_x);
-                        double d1 = dxy_start[dxyindex];
-                        double d2 = dxy_start[dxyindex + 1];
-                        double d3 = dxy_start[dxyindex + n_x];
-                        double d4 = dxy_start[dxyindex + n_x + 1];
-                        double d5 = dxy_end[dxyindex];
-                        double d6 = dxy_end[dxyindex + 1];
-                        double d7 = dxy_end[dxyindex + n_x];
-                        double d8 = dxy_end[dxyindex + n_x + 1];
-                        double d =
-                          std::min(std::min(std::min(d1, d2), std::min(d3, d4)),
-                                   std::min(std::min(d5, d6), std::min(d7, d8)));
-                        int index = x + (y * image_fast);
-                        bool in_image =
-                          x >= 0 && x < image_fast && y >= 0 && y < image_slow;
-                        if (d <= 1.0) {
-                            // Foreground
-                            if (in_image) {
-                                if (mask[index] == 0) {  // masked
-                                    accumulator.success[refl_id] = false;
-                                } else {
-                                    auto data = image.data.data()[index];
-                                    accumulator.intensity[refl_id] += data;
-                                    accumulator.nfg[refl_id] += 1;
-                                    Vector3d I_times_c = {data * (x + 0.5),
-                                                          data * (y + 0.5),
-                                                          data * (j + 0.5)};
-                                    accumulator.intensity_times_coord[refl_id] +=
-                                      I_times_c;
-                                }
-                            } else {
-                                accumulator.success[refl_id] = false;
-                            }
-                        } else {  // d>1.0
-                            // Background
-                            if (in_image) {
-                                if (mask[index] != 0) {
-                                    // In image, not masked
-                                    auto data = image.data.data()[index];
-                                    accumulator.bg[refl_id].add(data);
-                                    accumulator.nbg[refl_id] += 1;
-                                }
-                            }
-                        }
-                    }
-                }
-            } else {
-                // dials algorithm - a fixed ellipse (2D) across all images in the bbox
-                int n_x = bbox.x_max - bbox.x_min + 1;
-                int n_y = bbox.y_max - bbox.y_min + 1;
-                std::vector<double> dxy(n_x * n_y);
-                double phi =
-                  constants.phi0
-                  + (j * constants.dphi)
-                      * constants.DEG2RAD;  // Required for calls but not actually used as don't use e3.
-                CoordinateSystem cs = constants.coord_system_vector[refl_id];
-                Vector3d s1_this = Eigen::Map<Vector3d>(&constants.s1_vectors(refl_id, 0));
-                for (int x = 0; x < n_x; x++) {
-                    for (int y = 0; y < n_y; y++) {
-                        int index = x + (y * (n_x));
-                        std::array<double, 2> px_mm =
-                          constants.panel.px_to_mm(x + bbox.x_min, y + bbox.y_min);
-                        Vector3d s1_ = constants.panel.get_lab_coord(px_mm[0], px_mm[1]);
-                        s1_.normalize();
-                        Vector3d s1dash = s1_ * constants.s0_length;
-                        Vector3d epsilon_coords = cs.coords_from_s1vector(s1dash, phi);
-
-                        dxy[index] = ((epsilon_coords[0] * epsilon_coords[0]
-                                       + epsilon_coords[1] * epsilon_coords[1])
-                                      * constants.delta_b_r2);
-                    }
-                }
-                // Now loop through pixels in bbox, adding to foreground or background if unmasked and in image.
-                for (int x = bbox.x_min; x < bbox.x_max; x++) {
-                    for (int y = bbox.y_min; y < bbox.y_max; y++) {
-                        // The bounding box may extend beyond the image - if so, this is ok if it iis only background
-                        // but not if it is foreground.
-                        int x_index = x - bbox.x_min;
-                        int y_index = y - bbox.y_min;
-                        int dxyindex = x_index + (y_index * n_x);
-                        double d1 = dxy[dxyindex];
-                        double d2 = dxy[dxyindex + 1];
-                        double d3 = dxy[dxyindex + n_x];
-                        double d4 = dxy[dxyindex + n_x + 1];
-                        double d = std::min(std::min(d1, d2), std::min(d3, d4));
-                        int index = x + (y * image_fast);
-                        bool in_image =
-                          x >= 0 && x < image_fast && y >= 0 && y < image_slow;
-
-                        if (d <= 1.0) {
-                            // Foreground
-                            if (in_image) {
-                                if (mask[index] == 0) {  // masked)
-                                    accumulator.success[refl_id] = false;
-                                } else {
-                                    auto data = image.data.data()[index];
-                                    accumulator.intensity[refl_id] += data;
-                                    accumulator.nfg[refl_id] += 1;
-                                    Vector3d I_times_c = {data * (x + 0.5),
-                                                          data * (y + 0.5),
-                                                          data * (j + 0.5)};
-                                    accumulator.intensity_times_coord[refl_id] +=
-                                      I_times_c;
-                                }
-                            } else {
-                                accumulator.success[refl_id] = false;
-                            }
-                        } else {  // d>1.0
-                            // Background
-                            if (in_image) {
-                                if (mask[index] != 0) {
-                                    // In image, not masked
-                                    auto data = image.data.data()[index];
-                                    accumulator.bg[refl_id].add(data);
-                                    accumulator.nbg[refl_id] += 1;
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }*/
 #pragma endregion Loop over images and perform summation
 
 #pragma region Finalize calculations
@@ -1255,10 +1084,6 @@ int main(int argc, char **argv) {
     integrated_data.add_column(std::string("flags"), num_reflections, 1, final_flags);
 
     // Only output successfully integrated reflections.
-    /*for (int i=0;i<accumulator.success.size();i++){
-        success[i] = success[i] && accumulator.success[i];
-    }*/
-
     ReflectionTable success_data = integrated_data.select(success);
     int n_integrated =
       success_data.column<double>("intensity.sum.value").value().extent(0);

--- a/baseline/integrator/integrator.cc
+++ b/baseline/integrator/integrator.cc
@@ -181,16 +181,14 @@ std::vector<ImageRange> split_ranges(size_t n_images, size_t n_threads) {
     return ranges;
 }
 
-using PixelGeomBuffer = std::vector<Vector3d>;
+using PixelToS1Buffer = std::vector<Vector3d>;
 
 struct SharedConstants {
-    // --- Sizes ---
-    size_t n_reflections;
 
     // --- Reflection selection ---
     const std::vector<bool>& dont_integrate;
     const std::vector<BoundingBoxExtents>& computed_bounding_boxes;
-    std::vector<CoordinateSystem>& coord_system_vector;
+    const std::vector<CoordinateSystem>& coord_system_vector;
 
     // --- Reflection geometry ---
     const mdspan_type<double> phi_column;     // shape: [n_reflections, 3]
@@ -200,54 +198,47 @@ struct SharedConstants {
     double dphi;
     double DEG2RAD;
 
-    // --- Beam ---
-    double s0_length;
-
     // --- Foreground/background model ---
     FGAlgorithm fg_algorithm;   // "ellipsoid" or "dials"
 
     double delta_b_r2;
     double delta_m_r2;
 
-    const PixelGeomBuffer& pixel_geom;
+    const PixelToS1Buffer& pixel_to_s1_map;
 
-    int geom_width;
-    int geom_height;
+    int bbox_extent_width;
     int global_x_min;
     int global_y_min;
 
     SharedConstants(
-        size_t n_reflections_,
         const std::vector<bool>& dont_integrate_,
         const std::vector<BoundingBoxExtents>& computed_bounding_boxes_,
-        std::vector<CoordinateSystem>& coord_system_vector_,
+        const std::vector<CoordinateSystem>& coord_system_vector_,
         const mdspan_type<double> phi_column_,
         double phi0_,
         double dphi_,
-        double s0_length_,
         FGAlgorithm fg_algorithm_,
         double delta_b_r2_,
         double delta_m_r2_,
-        const PixelGeomBuffer& pixel_geom_,
-        int geom_width_,
-        int geom_height_,
+        const PixelToS1Buffer& pixel_to_s1_map_,
+        int bbox_extent_width_,
         int global_x_min_,
         int global_y_min_
     )
-      : n_reflections(n_reflections_),
-        dont_integrate(dont_integrate_),
+      : dont_integrate(dont_integrate_),
         computed_bounding_boxes(computed_bounding_boxes_),
         coord_system_vector(coord_system_vector_),
         phi_column(phi_column_),
         phi0(phi0_),
         dphi(dphi_),
         DEG2RAD(M_PI / 180.0),
-        s0_length(s0_length_),
         fg_algorithm(std::move(fg_algorithm_)),
         delta_b_r2(delta_b_r2_),
         delta_m_r2(delta_m_r2_),
-        pixel_geom(pixel_geom_),
-        geom_width(geom_width_), geom_height(geom_height_), global_x_min(global_x_min_), global_y_min(global_y_min_) {}
+        pixel_to_s1_map(pixel_to_s1_map_),
+        bbox_extent_width(bbox_extent_width_),
+        global_x_min(global_x_min_),
+        global_y_min(global_y_min_) {}
 };
 
 
@@ -267,12 +258,12 @@ Accumulator process_image_range(
 
     int global_x_min = constants.global_x_min;
     int global_y_min = constants.global_y_min;
-    int geom_width = constants.geom_width;
+    int bbox_extent_width = constants.bbox_extent_width;
 
     auto geom_index = [&](int x, int y) -> size_t {
         return static_cast<size_t>(
             (x - global_x_min) +
-            (y - global_y_min) * geom_width
+            (y - global_y_min) * bbox_extent_width
         );
     };
 
@@ -315,14 +306,14 @@ Accumulator process_image_range(
                 }
                 
                 double phi_c = constants.phi_column(refl_id, 2);
-                CoordinateSystem& cs = constants.coord_system_vector[refl_id];
+                const CoordinateSystem& cs = constants.coord_system_vector[refl_id];
 
                 for (int y = 0; y < n_y; ++y) {
                     int row = y * n_x;
                     for (int x = 0; x < n_x; ++x) {
                         int index = row + x;
                         const Vector3d& s1dash =
-                            constants.pixel_geom[
+                            constants.pixel_to_s1_map[
                                 geom_index(x+bbox.x_min,y+ bbox.y_min)
                             ];
 
@@ -433,13 +424,13 @@ Accumulator process_image_range(
                   constants.phi0
                   + (j * constants.dphi)
                       * constants.DEG2RAD;  // Required for calls but not actually used as don't use e3.
-                CoordinateSystem& cs = constants.coord_system_vector[refl_id];
+                const CoordinateSystem& cs = constants.coord_system_vector[refl_id];
 
                 for (int x = 0; x < n_x; x++) {
                     for (int y = 0; y < n_y; y++) {
                         int index = x + (y * (n_x));
                         const Vector3d& s1dash =
-                            constants.pixel_geom[
+                            constants.pixel_to_s1_map[
                                 (x + bbox.x_min) + (y + bbox.y_min) * image_fast
                             ];
                         Vector3d epsilon_coords = cs.coords_from_s1vector(s1dash, phi);
@@ -883,15 +874,15 @@ int main(int argc, char **argv) {
     auto [image_slow, image_fast] = reader.image_shape();
     auto mask = reader.get_mask().value();
 
-    int geom_width  = global_x_max - global_x_min + 1;
-    int geom_height = global_y_max - global_y_min + 1;
+    int bbox_extent_width  = global_x_max - global_x_min + 1;
+    int bbox_extent_height = global_y_max - global_y_min + 1;
 
-    PixelGeomBuffer pixel_geom(geom_width * geom_height);
+    PixelToS1Buffer pixel_to_s1_map(bbox_extent_width * bbox_extent_height);
 
     auto geom_index = [&](int x, int y) -> size_t {
         return static_cast<size_t>(
             (x - global_x_min) +
-            (y - global_y_min) * geom_width
+            (y - global_y_min) * bbox_extent_width
         );
     };
     
@@ -900,18 +891,18 @@ int main(int argc, char **argv) {
             auto px_mm = panel.px_to_mm(x, y);
             Vector3d s1 = panel.get_lab_coord(px_mm[0], px_mm[1]);
             s1.normalize();
-            pixel_geom[geom_index(x, y)] =
+            pixel_to_s1_map[geom_index(x, y)] =
                 s1 * s0_length;
         }
     }
 
     SharedConstants constants = SharedConstants(
-        num_reflections, dont_integrate,
+        dont_integrate,
         computed_bounding_boxes,
         coord_system_vector,
         phi_column,
-        phi0, dphi, s0_length, fg_algorithm, delta_b_r2, delta_m_r2, pixel_geom,
-        geom_width, geom_height, global_x_min, global_y_min);
+        phi0, dphi, fg_algorithm, delta_b_r2, delta_m_r2, pixel_to_s1_map,
+        bbox_extent_width, global_x_min, global_y_min);
     
     logger.info("Made shared constants");
 

--- a/baseline/integrator/integrator.cc
+++ b/baseline/integrator/integrator.cc
@@ -240,10 +240,10 @@ struct SharedConstants {
 Accumulator process_image_range(
     ImageRange range,
     Experiment<MonochromaticBeam>& expt,
-    const std::vector<std::vector<size_t>>& reflections_by_image,
+    std::unordered_map<int, std::vector<size_t>>& reflections_by_image,
     const SharedConstants& constants
 ) {
-    Accumulator acc(constants.n_reflections);
+    Accumulator accumulator(constants.n_reflections);
 
     std::string filename = expt.imagesequence().filename();
     H5Read reader(filename);
@@ -256,12 +256,189 @@ Accumulator process_image_range(
             continue;
 
         auto image = reader.get_image(j);
+        logger.info("Processing image {}", j + 1);
+        for (size_t k = 0; k < reflections_by_image[j].size(); k++) {
+            size_t refl_id = reflections_by_image[j][k];
+            if (constants.dont_integrate[refl_id]) {
+                continue;
+            }
+            const auto &bbox = constants.computed_bounding_boxes[refl_id];
+            if (constants.fg_algorithm == "ellipsoid") {
+                // calculate dxy array (arrays of distances in kabsch space from pixel corners to xyzcal)
+                int n_x = bbox.x_max - bbox.x_min + 1;
+                int n_y = bbox.y_max - bbox.y_min + 1;
+                std::vector<double> dxy_start(n_x
+                                              * n_y);    // start of image (in rotation)
+                std::vector<double> dxy_end(n_x * n_y);  // end of image (in rotation)
+                double phidash_start = (constants.phi0 + (j * constants.dphi)) * constants.DEG2RAD;
+                double phidash_end = (constants.phi0 + ((j + 1) * constants.dphi)) * constants.DEG2RAD;
+                double phi_c = constants.phi_column(refl_id, 2);
+                CoordinateSystem cs = constants.coord_system_vector[refl_id];
+                Vector3d s1_this = Eigen::Map<Vector3d>(&constants.s1_vectors(refl_id, 0));
+                for (int x = 0; x < n_x; x++) {
+                    for (int y = 0; y < n_y; y++) {
+                        int index = x + (y * (n_x));
+                        std::array<double, 2> px_mm =
+                          constants.panel.px_to_mm(x + bbox.x_min, y + bbox.y_min);
+                        Vector3d s1_ = constants.panel.get_lab_coord(px_mm[0], px_mm[1]);
+                        s1_.normalize();
+                        Vector3d s1dash = s1_ * constants.s0_length;
+                        Vector3d epsilon_coords_start =
+                          cs.coords_from_s1vector(s1dash, phidash_start);
+                        Vector3d epsilon_coords_end =
+                          cs.coords_from_s1vector(s1dash, phidash_end);
+                        if ((phidash_start > phi_c) && (phi_c < phidash_end)) {
+                            epsilon_coords_start[2] = 0.0;
+                            epsilon_coords_end[2] = 0.0;
+                        }
 
-        // ---- your existing inner loops go here ----
-        // Replace all writes to global accumulators with acc.*
+                        dxy_start[index] =
+                          ((epsilon_coords_start[0] * epsilon_coords_start[0]
+                            + epsilon_coords_start[1] * epsilon_coords_start[1])
+                           * constants.delta_b_r2)
+                          + ((epsilon_coords_start[2] * epsilon_coords_start[2])
+                             * constants.delta_m_r2);
+                        dxy_end[index] =
+                          ((epsilon_coords_end[0] * epsilon_coords_end[0]
+                            + epsilon_coords_end[1] * epsilon_coords_end[1])
+                           * constants.delta_b_r2)
+                          + ((epsilon_coords_end[2] * epsilon_coords_end[2])
+                             * constants.delta_m_r2);
+                    }
+                }
+                // Now loop through pixels in bbox, adding to foreground or background if unmasked and in image.
+                for (int x = bbox.x_min; x < bbox.x_max; x++) {
+                    for (int y = bbox.y_min; y < bbox.y_max; y++) {
+                        // The bounding box may extend beyond the image - if so, this is ok if it is only background
+                        // but not if it is foreground.
+                        int x_index = x - bbox.x_min;
+                        int y_index = y - bbox.y_min;
+                        int dxyindex = x_index + (y_index * n_x);
+                        double d1 = dxy_start[dxyindex];
+                        double d2 = dxy_start[dxyindex + 1];
+                        double d3 = dxy_start[dxyindex + n_x];
+                        double d4 = dxy_start[dxyindex + n_x + 1];
+                        double d5 = dxy_end[dxyindex];
+                        double d6 = dxy_end[dxyindex + 1];
+                        double d7 = dxy_end[dxyindex + n_x];
+                        double d8 = dxy_end[dxyindex + n_x + 1];
+                        double d =
+                          std::min(std::min(std::min(d1, d2), std::min(d3, d4)),
+                                   std::min(std::min(d5, d6), std::min(d7, d8)));
+                        int index = x + (y * image_fast);
+                        bool in_image =
+                          x >= 0 && x < image_fast && y >= 0 && y < image_slow;
+                        if (d <= 1.0) {
+                            // Foreground
+                            if (in_image) {
+                                if (mask[index] == 0) {  // masked
+                                    accumulator.success[refl_id] = false;
+                                } else {
+                                    auto data = image.data.data()[index];
+                                    accumulator.intensity[refl_id] += data;
+                                    accumulator.nfg[refl_id] += 1;
+                                    Vector3d I_times_c = {data * (x + 0.5),
+                                                          data * (y + 0.5),
+                                                          data * (j + 0.5)};
+                                    accumulator.intensity_times_coord[refl_id] +=
+                                      I_times_c;
+                                }
+                            } else {
+                                accumulator.success[refl_id] = false;
+                            }
+                        } else {  // d>1.0
+                            // Background
+                            if (in_image) {
+                                if (mask[index] != 0) {
+                                    // In image, not masked
+                                    auto data = image.data.data()[index];
+                                    accumulator.bg[refl_id].add(data);
+                                    accumulator.nbg[refl_id] += 1;
+                                }
+                            }
+                        }
+                    }
+                }
+            } else {
+                // dials algorithm - a fixed ellipse (2D) across all images in the bbox
+                int n_x = bbox.x_max - bbox.x_min + 1;
+                int n_y = bbox.y_max - bbox.y_min + 1;
+                std::vector<double> dxy(n_x * n_y);
+                double phi =
+                  constants.phi0
+                  + (j * constants.dphi)
+                      * constants.DEG2RAD;  // Required for calls but not actually used as don't use e3.
+                CoordinateSystem cs = constants.coord_system_vector[refl_id];
+                Vector3d s1_this = Eigen::Map<Vector3d>(&constants.s1_vectors(refl_id, 0));
+                for (int x = 0; x < n_x; x++) {
+                    for (int y = 0; y < n_y; y++) {
+                        int index = x + (y * (n_x));
+                        std::array<double, 2> px_mm =
+                          constants.panel.px_to_mm(x + bbox.x_min, y + bbox.y_min);
+                        Vector3d s1_ = constants.panel.get_lab_coord(px_mm[0], px_mm[1]);
+                        s1_.normalize();
+                        Vector3d s1dash = s1_ * constants.s0_length;
+                        Vector3d epsilon_coords = cs.coords_from_s1vector(s1dash, phi);
+
+                        dxy[index] = ((epsilon_coords[0] * epsilon_coords[0]
+                                       + epsilon_coords[1] * epsilon_coords[1])
+                                      * constants.delta_b_r2);
+                    }
+                }
+                // Now loop through pixels in bbox, adding to foreground or background if unmasked and in image.
+                for (int x = bbox.x_min; x < bbox.x_max; x++) {
+                    for (int y = bbox.y_min; y < bbox.y_max; y++) {
+                        // The bounding box may extend beyond the image - if so, this is ok if it iis only background
+                        // but not if it is foreground.
+                        int x_index = x - bbox.x_min;
+                        int y_index = y - bbox.y_min;
+                        int dxyindex = x_index + (y_index * n_x);
+                        double d1 = dxy[dxyindex];
+                        double d2 = dxy[dxyindex + 1];
+                        double d3 = dxy[dxyindex + n_x];
+                        double d4 = dxy[dxyindex + n_x + 1];
+                        double d = std::min(std::min(d1, d2), std::min(d3, d4));
+                        int index = x + (y * image_fast);
+                        bool in_image =
+                          x >= 0 && x < image_fast && y >= 0 && y < image_slow;
+
+                        if (d <= 1.0) {
+                            // Foreground
+                            if (in_image) {
+                                if (mask[index] == 0) {  // masked)
+                                    accumulator.success[refl_id] = false;
+                                } else {
+                                    auto data = image.data.data()[index];
+                                    accumulator.intensity[refl_id] += data;
+                                    accumulator.nfg[refl_id] += 1;
+                                    Vector3d I_times_c = {data * (x + 0.5),
+                                                          data * (y + 0.5),
+                                                          data * (j + 0.5)};
+                                    accumulator.intensity_times_coord[refl_id] +=
+                                      I_times_c;
+                                }
+                            } else {
+                                accumulator.success[refl_id] = false;
+                            }
+                        } else {  // d>1.0
+                            // Background
+                            if (in_image) {
+                                if (mask[index] != 0) {
+                                    // In image, not masked
+                                    auto data = image.data.data()[index];
+                                    accumulator.bg[refl_id].add(data);
+                                    accumulator.nbg[refl_id] += 1;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
     }
 
-    return acc;
+    return accumulator;
 }
 
 
@@ -622,9 +799,24 @@ int main(int argc, char **argv) {
     auto [image_slow, image_fast] = reader.image_shape();
     auto mask = reader.get_mask().value();
 
-    /*std::vector<ImageRange> = split_ranges(n_images, nthreads);
+    SharedConstants constants = SharedConstants(
+        num_reflections, dont_integrate,
+        computed_bounding_boxes,
+        coord_system_vector,
+        phi_column, s1_vectors, panel,
+        phi0, dphi, s0_length, fg_algorithm, delta_b_r2, delta_m_r2);
+
+    std::vector<ImageRange> ranges = split_ranges(n_images, nthreads);
     std::vector<std::thread> workers;
-    std::vector<Accumulator> thread_accs(nthreads);
+    //std::vector<Accumulator> thread_accs(nthreads);
+
+    std::vector<Accumulator> thread_accs;
+    thread_accs.reserve(nthreads);
+
+    for (size_t t = 0; t < nthreads; t++) {
+        thread_accs.emplace_back(num_reflections);
+    }
+
 
     for (size_t t = 0; t < nthreads; t++) {
         workers.emplace_back([&, t] {
@@ -636,26 +828,21 @@ int main(int argc, char **argv) {
     for (auto& th : workers)
         th.join();
 
-    for (const auto& acc : partials) {
-        for (size_t r = 0; r < n_reflections; r++) {
+    for (const auto& acc : thread_accs) {
+        for (size_t r = 0; r < num_reflections; r++) {
             intensity_accumulators[r] += acc.intensity[r];
             nfg_accumulators[r] += acc.nfg[r];
             nbg_accumulators[r] += acc.nbg[r];
-            bg_accumulators[r].merge(acc.bg[r]);
+            bg_accumulators[r].add(acc.bg[r]);
             intensity_times_coord_accumulators[r] += acc.intensity_times_coord[r];
             success[r] = success[r] && acc.success[r];
         }
-    }*/
+    }
 
 
-    SharedConstants constants = SharedConstants(
-        num_reflections, dont_integrate,
-        computed_bounding_boxes,
-        coord_system_vector,
-        phi_column, s1_vectors, panel,
-        phi0, dphi, s0_length, fg_algorithm, delta_b_r2, delta_m_r2);
+    
 
-    Accumulator accumulator = Accumulator(num_reflections);
+    /*Accumulator accumulator = Accumulator(num_reflections);
 
     for (size_t j = 0; j < n_images; j++) {
         if (!reader.is_image_available(j)) {
@@ -841,7 +1028,7 @@ int main(int argc, char **argv) {
                 }
             }
         }
-    }
+    }*/
 #pragma endregion Loop over images and perform summation
 
 #pragma region Finalize calculations
@@ -873,18 +1060,18 @@ int main(int argc, char **argv) {
     std::vector<double> bg_sum_value(num_reflections);
     // FIXME need to include robust outlier rejection in background calculation (glm, constant3dmodel)
     for (int i = 0; i < num_reflections; i++) {
-        if (accumulator.nbg[i]) {
+        if (nbg_accumulators[i]) {
             auto [bg, total_bg_counts] =
-              compute_background_constant_3d(accumulator.bg[i]);
+              compute_background_constant_3d(bg_accumulators[i]);
             mean_bg[i] = bg;
             bg_sum_value[i] = total_bg_counts;
-            double I = accumulator.intensity[i] - bg;
+            double I = intensity_accumulators[i] - bg;
             intensities[i] = I;
-            double m_n = accumulator.nfg[i] / accumulator.nbg[i];
+            double m_n = nfg_accumulators[i] / nbg_accumulators[i];
             variances[i] = std::abs(I) + (std::abs(bg) * (1.0 + m_n));
-            if ((accumulator.nfg[i] > 0) && (accumulator.intensity[i] > 0)) {
+            if ((nfg_accumulators[i] > 0) && (intensity_accumulators[i] > 0)) {
                 Vector3d com =
-                  accumulator.intensity_times_coord[i] / accumulator.intensity[i];
+                  intensity_times_coord_accumulators[i] / intensity_accumulators[i];
                 xyzobs_px[i * 3] = com[0];
                 xyzobs_px[i * 3 + 1] = com[1];
                 xyzobs_px[i * 3 + 2] = com[2];
@@ -900,7 +1087,7 @@ int main(int argc, char **argv) {
                                           + computed_bounding_boxes[i].z_max);
             }
         } else {
-            accumulator.success[i] = false;
+            success[i] = false;
         }
     }
     // Calculate the partiality, LP, d of all reflections
@@ -972,9 +1159,9 @@ int main(int argc, char **argv) {
     integrated_data.add_column(std::string("flags"), num_reflections, 1, final_flags);
 
     // Only output successfully integrated reflections.
-    for (int i=0;i<accumulator.success.size();i++){
+    /*for (int i=0;i<accumulator.success.size();i++){
         success[i] = success[i] && accumulator.success[i];
-    }
+    }*/
 
     ReflectionTable success_data = integrated_data.select(success);
     int n_integrated =

--- a/baseline/integrator/integrator.cc
+++ b/baseline/integrator/integrator.cc
@@ -132,7 +132,33 @@ class BaselineIntegratorArgumentParser : public FFSArgumentParser {
 };
 #pragma endregion Argument Parsing
 
+struct ReflectionAccum {
+    double intensity = 0.0;
+    size_t nfg = 0;
+    size_t nbg = 0;
+    Vector3d intensity_times_coord = Vector3d::Zero();
+    BackgroundAggregator bg;
+    bool success = true;
+
+    void merge(const ReflectionAccum& other) {
+        intensity += other.intensity;
+        nfg += other.nfg;
+        nbg += other.nbg;
+        intensity_times_coord += other.intensity_times_coord;
+        bg.add(other.bg);
+        success = success && other.success;
+    }
+};
+
 struct Accumulator {
+    std::unordered_map<size_t, ReflectionAccum> data;
+
+    ReflectionAccum& operator[](size_t r) {
+        return data[r];  // default-constructs if missing
+    }
+};
+
+/*struct Accumulator {
     std::vector<double> intensity;
     std::vector<size_t> nfg;
     std::vector<size_t> nbg;
@@ -148,7 +174,7 @@ struct Accumulator {
         bg(n_reflections),
         success(n_reflections, true) {}
 
-};
+};*/
 
 
 struct ImageRange {
@@ -240,7 +266,7 @@ Accumulator process_image_range(
     std::unordered_map<int, std::vector<size_t>>& reflections_by_image,
     const SharedConstants& constants
 ) {
-    Accumulator accumulator(constants.n_reflections);
+    Accumulator accumulator;//(constants.n_reflections);
 
     std::string filename = expt.imagesequence().filename();
     H5Read reader(filename);
@@ -287,6 +313,7 @@ Accumulator process_image_range(
                 
                 double phi_c = constants.phi_column(refl_id, 2);
                 CoordinateSystem cs = constants.coord_system_vector[refl_id];
+                auto& a = accumulator[refl_id];
                 //Vector3d s1_this = Eigen::Map<Vector3d>(&constants.s1_vectors(refl_id, 0));
                 
                 for (int y = 0; y < n_y; ++y) {
@@ -356,23 +383,24 @@ Accumulator process_image_range(
                         int index = x + (y * image_fast);
                         bool in_image =
                           x >= 0 && x < image_fast && y >= 0 && y < image_slow;
+                        
                         if (d <= 1.0) {
                             // Foreground
                             if (in_image) {
                                 if (mask[index] == 0) {  // masked
-                                    accumulator.success[refl_id] = false;
+                                    a.success = false;
                                 } else {
                                     auto data = image.data.data()[index];
-                                    accumulator.intensity[refl_id] += data;
-                                    accumulator.nfg[refl_id] += 1;
+                                    a.intensity += data;
+                                    a.nfg += 1;
                                     Vector3d I_times_c = {data * (x + 0.5),
                                                           data * (y + 0.5),
                                                           data * (j + 0.5)};
-                                    accumulator.intensity_times_coord[refl_id] +=
+                                    a.intensity_times_coord +=
                                       I_times_c;
                                 }
                             } else {
-                                accumulator.success[refl_id] = false;
+                                a.success = false;
                             }
                         } else {  // d>1.0
                             // Background
@@ -380,8 +408,8 @@ Accumulator process_image_range(
                                 if (mask[index] != 0) {
                                     // In image, not masked
                                     auto data = image.data.data()[index];
-                                    accumulator.bg[refl_id].add(data);
-                                    accumulator.nbg[refl_id] += 1;
+                                    a.bg.add(data);
+                                    a.nbg += 1;
                                 }
                             }
                         }
@@ -411,6 +439,7 @@ Accumulator process_image_range(
                   + (j * constants.dphi)
                       * constants.DEG2RAD;  // Required for calls but not actually used as don't use e3.
                 CoordinateSystem cs = constants.coord_system_vector[refl_id];
+                auto& a = accumulator[refl_id];
                 //Vector3d s1_this = Eigen::Map<Vector3d>(&constants.s1_vectors(refl_id, 0));
                 for (int x = 0; x < n_x; x++) {
                     for (int y = 0; y < n_y; y++) {
@@ -452,19 +481,19 @@ Accumulator process_image_range(
                             // Foreground
                             if (in_image) {
                                 if (mask[index] == 0) {  // masked)
-                                    accumulator.success[refl_id] = false;
+                                    a.success = false;
                                 } else {
                                     auto data = image.data.data()[index];
-                                    accumulator.intensity[refl_id] += data;
-                                    accumulator.nfg[refl_id] += 1;
+                                    a.intensity += data;
+                                    a.nfg += 1;
                                     Vector3d I_times_c = {data * (x + 0.5),
                                                           data * (y + 0.5),
                                                           data * (j + 0.5)};
-                                    accumulator.intensity_times_coord[refl_id] +=
+                                    a.intensity_times_coord +=
                                       I_times_c;
                                 }
                             } else {
-                                accumulator.success[refl_id] = false;
+                                a.success = false;
                             }
                         } else {  // d>1.0
                             // Background
@@ -472,8 +501,8 @@ Accumulator process_image_range(
                                 if (mask[index] != 0) {
                                     // In image, not masked
                                     auto data = image.data.data()[index];
-                                    accumulator.bg[refl_id].add(data);
-                                    accumulator.nbg[refl_id] += 1;
+                                    a.bg.add(data);
+                                    a.nbg += 1;
                                 }
                             }
                         }
@@ -810,11 +839,7 @@ int main(int argc, char **argv) {
 
 #pragma region Loop over images and perform summation
     // Set up data arrays to fill during accumulation
-    std::vector<int> intensity_accumulators(num_reflections);
-    std::vector<Vector3d> intensity_times_coord_accumulators(num_reflections);
-    std::vector<BackgroundAggregator> bg_accumulators(num_reflections);
-    std::vector<int> nbg_accumulators(num_reflections);
-    std::vector<int> nfg_accumulators(num_reflections);
+    
     std::vector<bool> success(num_reflections, true);
     std::vector<CoordinateSystem> coord_system_vector =
       {};  // a vector of coordinate systems for each reflection.
@@ -865,7 +890,7 @@ int main(int argc, char **argv) {
     thread_accs.reserve(nthreads);
 
     for (size_t t = 0; t < nthreads; t++) {
-        thread_accs.emplace_back(num_reflections);
+        thread_accs.emplace_back();
     }
 
     logger.info("About to start parallelisation");
@@ -879,7 +904,27 @@ int main(int argc, char **argv) {
     for (auto& th : workers)
         th.join();
 
+    std::vector<int> intensity_accumulators(num_reflections);
+    std::vector<Vector3d> intensity_times_coord_accumulators(num_reflections);
+    std::vector<BackgroundAggregator> bg_accumulators(num_reflections);
+    std::vector<int> nbg_accumulators(num_reflections);
+    std::vector<int> nfg_accumulators(num_reflections);
+
+
     for (const auto& acc : thread_accs) {
+        for (const auto& [r, partial] : acc.data) {
+            intensity_accumulators[r] += partial.intensity;
+            nfg_accumulators[r] += partial.nfg;
+            nbg_accumulators[r] += partial.nbg;
+            intensity_times_coord_accumulators[r] +=
+                partial.intensity_times_coord;
+            bg_accumulators[r].add(partial.bg);
+            success[r] = static_cast<bool>(partial.success) && success[r];
+        }
+    }
+
+
+    /*for (const auto& acc : thread_accs) {
         for (size_t r = 0; r < num_reflections; r++) {
             intensity_accumulators[r] += acc.intensity[r];
             nfg_accumulators[r] += acc.nfg[r];
@@ -888,7 +933,7 @@ int main(int argc, char **argv) {
             intensity_times_coord_accumulators[r] += acc.intensity_times_coord[r];
             success[r] = static_cast<bool>(success[r]) && acc.success[r];
         }
-    }
+    }*/
 
 
     

--- a/baseline/integrator/integrator.cc
+++ b/baseline/integrator/integrator.cc
@@ -4,6 +4,7 @@
  */
 
 #include <Eigen/Dense>
+#include <chrono>
 #include <dx2/beam.hpp>
 #include <dx2/detector.hpp>
 #include <dx2/experiment.hpp>
@@ -18,7 +19,6 @@
 #include <nlohmann/json.hpp>
 #include <string>
 #include <vector>
-#include <chrono>
 
 #include "arg_parser.hpp"
 #include "background.cc"
@@ -40,12 +40,7 @@ constexpr size_t IntegratedSum = (1 << 8);
 constexpr double DEG2RAD = M_PI / 180.0;
 constexpr double RAD2DEG = 180.0 / M_PI;
 
-
-enum class FGAlgorithm : uint8_t {
-    Ellipsoid,
-    Dials
-};
-
+enum class FGAlgorithm : uint8_t { Ellipsoid, Dials };
 
 #pragma region Argument Parsing
 class BaselineIntegratorArgumentParser : public FFSArgumentParser {
@@ -141,7 +136,7 @@ struct ReflectionAccum {
     BackgroundAggregator bg;
     bool success = true;
 
-    void merge(const ReflectionAccum& other) {
+    void merge(const ReflectionAccum &other) {
         intensity += other.intensity;
         nfg += other.nfg;
         nbg += other.nbg;
@@ -154,22 +149,21 @@ struct ReflectionAccum {
 struct Accumulator {
     std::unordered_map<size_t, ReflectionAccum> data;
 
-    ReflectionAccum& operator[](size_t r) {
+    ReflectionAccum &operator[](size_t r) {
         return data[r];  // default-constructs if missing
     }
 };
 
-
 struct ImageRange {
     size_t begin;
-    size_t end;   // half-open [begin, end)
+    size_t end;  // half-open [begin, end)
 };
 
 std::vector<ImageRange> split_ranges(size_t n_images, size_t n_threads) {
     std::vector<ImageRange> ranges(n_threads);
 
     size_t base = n_images / n_threads;
-    size_t rem  = n_images % n_threads;
+    size_t rem = n_images % n_threads;
 
     size_t current = 0;
     for (size_t t = 0; t < n_threads; t++) {
@@ -184,14 +178,13 @@ std::vector<ImageRange> split_ranges(size_t n_images, size_t n_threads) {
 using PixelToS1Buffer = std::vector<Vector3d>;
 
 struct SharedConstants {
-
     // --- Reflection selection ---
-    const std::vector<bool>& dont_integrate;
-    const std::vector<BoundingBoxExtents>& computed_bounding_boxes;
-    const std::vector<CoordinateSystem>& coord_system_vector;
+    const std::vector<bool> &dont_integrate;
+    const std::vector<BoundingBoxExtents> &computed_bounding_boxes;
+    const std::vector<CoordinateSystem> &coord_system_vector;
 
     // --- Reflection geometry ---
-    const mdspan_type<double> phi_column;     // shape: [n_reflections, 3]
+    const mdspan_type<double> phi_column;  // shape: [n_reflections, 3]
 
     // --- Scan / rotation ---
     double phi0;
@@ -199,55 +192,51 @@ struct SharedConstants {
     double DEG2RAD;
 
     // --- Foreground/background model ---
-    FGAlgorithm fg_algorithm;   // "ellipsoid" or "dials"
+    FGAlgorithm fg_algorithm;  // "ellipsoid" or "dials"
 
     double delta_b_r2;
     double delta_m_r2;
 
-    const PixelToS1Buffer& pixel_to_s1_map;
+    const PixelToS1Buffer &pixel_to_s1_map;
 
     int bbox_extent_width;
     int global_x_min;
     int global_y_min;
 
-    SharedConstants(
-        const std::vector<bool>& dont_integrate_,
-        const std::vector<BoundingBoxExtents>& computed_bounding_boxes_,
-        const std::vector<CoordinateSystem>& coord_system_vector_,
-        const mdspan_type<double> phi_column_,
-        double phi0_,
-        double dphi_,
-        FGAlgorithm fg_algorithm_,
-        double delta_b_r2_,
-        double delta_m_r2_,
-        const PixelToS1Buffer& pixel_to_s1_map_,
-        int bbox_extent_width_,
-        int global_x_min_,
-        int global_y_min_
-    )
-      : dont_integrate(dont_integrate_),
-        computed_bounding_boxes(computed_bounding_boxes_),
-        coord_system_vector(coord_system_vector_),
-        phi_column(phi_column_),
-        phi0(phi0_),
-        dphi(dphi_),
-        DEG2RAD(M_PI / 180.0),
-        fg_algorithm(std::move(fg_algorithm_)),
-        delta_b_r2(delta_b_r2_),
-        delta_m_r2(delta_m_r2_),
-        pixel_to_s1_map(pixel_to_s1_map_),
-        bbox_extent_width(bbox_extent_width_),
-        global_x_min(global_x_min_),
-        global_y_min(global_y_min_) {}
+    SharedConstants(const std::vector<bool> &dont_integrate_,
+                    const std::vector<BoundingBoxExtents> &computed_bounding_boxes_,
+                    const std::vector<CoordinateSystem> &coord_system_vector_,
+                    const mdspan_type<double> phi_column_,
+                    double phi0_,
+                    double dphi_,
+                    FGAlgorithm fg_algorithm_,
+                    double delta_b_r2_,
+                    double delta_m_r2_,
+                    const PixelToS1Buffer &pixel_to_s1_map_,
+                    int bbox_extent_width_,
+                    int global_x_min_,
+                    int global_y_min_)
+        : dont_integrate(dont_integrate_),
+          computed_bounding_boxes(computed_bounding_boxes_),
+          coord_system_vector(coord_system_vector_),
+          phi_column(phi_column_),
+          phi0(phi0_),
+          dphi(dphi_),
+          DEG2RAD(M_PI / 180.0),
+          fg_algorithm(std::move(fg_algorithm_)),
+          delta_b_r2(delta_b_r2_),
+          delta_m_r2(delta_m_r2_),
+          pixel_to_s1_map(pixel_to_s1_map_),
+          bbox_extent_width(bbox_extent_width_),
+          global_x_min(global_x_min_),
+          global_y_min(global_y_min_) {}
 };
 
-
 Accumulator process_image_range(
-    ImageRange range,
-    Experiment<MonochromaticBeam>& expt,
-    std::unordered_map<int, std::vector<size_t>>& reflections_by_image,
-    const SharedConstants& constants
-) {
+  ImageRange range,
+  Experiment<MonochromaticBeam> &expt,
+  std::unordered_map<int, std::vector<size_t>> &reflections_by_image,
+  const SharedConstants &constants) {
     Accumulator accumulator;
 
     std::string filename = expt.imagesequence().filename();
@@ -261,29 +250,28 @@ Accumulator process_image_range(
     int bbox_extent_width = constants.bbox_extent_width;
 
     auto geom_index = [&](int x, int y) -> size_t {
-        return static_cast<size_t>(
-            (x - global_x_min) +
-            (y - global_y_min) * bbox_extent_width
-        );
+        return static_cast<size_t>((x - global_x_min)
+                                   + (y - global_y_min) * bbox_extent_width);
     };
 
     for (size_t j = range.begin; j < range.end; j++) {
         auto t1 = std::chrono::system_clock::now();
-        if (!reader.is_image_available(j))
-            continue;
+        if (!reader.is_image_available(j)) continue;
 
         auto image = reader.get_image(j);
-        const auto* img = image.data.data();
+        const auto *img = image.data.data();
         auto t2 = std::chrono::system_clock::now();
 
         // calculate dxy array (arrays of distances in kabsch space from pixel corners to xyzcal)
-        std::vector<double> dxy_start;// start of image (in rotation)
-        std::vector<double> dxy_end;// end of image (in rotation)
+        std::vector<double> dxy_start;  // start of image (in rotation)
+        std::vector<double> dxy_end;    // end of image (in rotation)
         std::vector<double> dxy;
-        double phidash_start = (constants.phi0 + (j * constants.dphi)) * constants.DEG2RAD;
-        double phidash_end = (constants.phi0 + ((j + 1) * constants.dphi)) * constants.DEG2RAD;
+        double phidash_start =
+          (constants.phi0 + (j * constants.dphi)) * constants.DEG2RAD;
+        double phidash_end =
+          (constants.phi0 + ((j + 1) * constants.dphi)) * constants.DEG2RAD;
 
-        switch (constants.fg_algorithm){
+        switch (constants.fg_algorithm) {
         case FGAlgorithm::Ellipsoid:
 
             for (size_t k = 0; k < reflections_by_image[j].size(); k++) {
@@ -291,9 +279,8 @@ Accumulator process_image_range(
                 if (constants.dont_integrate[refl_id]) {
                     continue;
                 }
-                auto& a = accumulator[refl_id];
-                if (!a.success)
-                    continue;
+                auto &a = accumulator[refl_id];
+                if (!a.success) continue;
 
                 const auto &bbox = constants.computed_bounding_boxes[refl_id];
                 int n_x = bbox.x_max - bbox.x_min + 1;
@@ -304,18 +291,16 @@ Accumulator process_image_range(
                     dxy_start.resize(required);
                     dxy_end.resize(required);
                 }
-                
+
                 double phi_c = constants.phi_column(refl_id, 2);
-                const CoordinateSystem& cs = constants.coord_system_vector[refl_id];
+                const CoordinateSystem &cs = constants.coord_system_vector[refl_id];
 
                 for (int y = 0; y < n_y; ++y) {
                     int row = y * n_x;
                     for (int x = 0; x < n_x; ++x) {
                         int index = row + x;
-                        const Vector3d& s1dash =
-                            constants.pixel_to_s1_map[
-                                geom_index(x+bbox.x_min,y+ bbox.y_min)
-                            ];
+                        const Vector3d &s1dash = constants.pixel_to_s1_map[geom_index(
+                          x + bbox.x_min, y + bbox.y_min)];
 
                         Vector3d epsilon_coords_start =
                           cs.coords_from_s1vector(s1dash, phidash_start);
@@ -367,7 +352,7 @@ Accumulator process_image_range(
                         int index = x + (y * image_fast);
                         bool in_image =
                           x >= 0 && x < image_fast && y >= 0 && y < image_slow;
-                        
+
                         if (d <= 1.0) {
                             // Foreground
                             if (in_image) {
@@ -407,9 +392,8 @@ Accumulator process_image_range(
                 if (constants.dont_integrate[refl_id]) {
                     continue;
                 }
-                auto& a = accumulator[refl_id];
-                if (!a.success)
-                    continue;
+                auto &a = accumulator[refl_id];
+                if (!a.success) continue;
 
                 const auto &bbox = constants.computed_bounding_boxes[refl_id];
                 // dials algorithm - a fixed ellipse (2D) across all images in the bbox
@@ -423,16 +407,16 @@ Accumulator process_image_range(
                 double phi =
                   constants.phi0
                   + (j * constants.dphi)
-                      * constants.DEG2RAD;  // Required for calls but not actually used as don't use e3.
-                const CoordinateSystem& cs = constants.coord_system_vector[refl_id];
+                      * constants
+                          .DEG2RAD;  // Required for calls but not actually used as don't use e3.
+                const CoordinateSystem &cs = constants.coord_system_vector[refl_id];
 
                 for (int x = 0; x < n_x; x++) {
                     for (int y = 0; y < n_y; y++) {
                         int index = x + (y * (n_x));
-                        const Vector3d& s1dash =
-                            constants.pixel_to_s1_map[
-                                (x + bbox.x_min) + (y + bbox.y_min) * image_fast
-                            ];
+                        const Vector3d &s1dash =
+                          constants.pixel_to_s1_map[(x + bbox.x_min)
+                                                    + (y + bbox.y_min) * image_fast];
                         Vector3d epsilon_coords = cs.coords_from_s1vector(s1dash, phi);
 
                         dxy[index] = ((epsilon_coords[0] * epsilon_coords[0]
@@ -495,18 +479,19 @@ Accumulator process_image_range(
         auto t3 = std::chrono::system_clock::now();
         std::chrono::duration<double> elapsed_time_load = t2 - t1;
         std::chrono::duration<double> elapsed_time_process = t3 - t2;
-        logger.info("Processed image {}, load time {:.6f}s, process time {:.6f}s", j+1, elapsed_time_load.count(), elapsed_time_process.count());
-        
+        logger.info("Processed image {}, load time {:.6f}s, process time {:.6f}s",
+                    j + 1,
+                    elapsed_time_load.count(),
+                    elapsed_time_process.count());
     }
     return accumulator;
 }
 
-FGAlgorithm parse_fg_algorithm(const std::string& name) {
+FGAlgorithm parse_fg_algorithm(const std::string &name) {
     if (name == "ellipsoid") return FGAlgorithm::Ellipsoid;
-    if (name == "dials")     return FGAlgorithm::Dials;
+    if (name == "dials") return FGAlgorithm::Dials;
     throw std::runtime_error("Unknown foreground algorithm: " + name);
 }
-
 
 #pragma region Application Entry
 int main(int argc, char **argv) {
@@ -520,7 +505,7 @@ int main(int argc, char **argv) {
 
     float timeout = parser.get<float>("timeout");
     std::string output_file = parser.get<std::string>("output");
-    
+
     FGAlgorithm fg_algorithm = parse_fg_algorithm(parser.get<std::string>("algorithm"));
 
     // Guard against missing files
@@ -825,7 +810,7 @@ int main(int argc, char **argv) {
 
 #pragma region Loop over images and perform summation
     // Set up data arrays to fill during accumulation
-    
+
     std::vector<bool> success(num_reflections, true);
     std::vector<CoordinateSystem> coord_system_vector =
       {};  // a vector of coordinate systems for each reflection.
@@ -855,12 +840,12 @@ int main(int argc, char **argv) {
 
     // Precompute the pixel to mm mapping for the whole image, as this is constant throughout the integration
     // First work out global x,y limits, as bboxes extend beyond the image.
-    int global_x_min =  std::numeric_limits<int>::max();
+    int global_x_min = std::numeric_limits<int>::max();
     int global_x_max = -std::numeric_limits<int>::max();
-    int global_y_min =  std::numeric_limits<int>::max();
+    int global_y_min = std::numeric_limits<int>::max();
     int global_y_max = -std::numeric_limits<int>::max();
 
-    for (const auto& bbox : computed_bounding_boxes) {
+    for (const auto &bbox : computed_bounding_boxes) {
         global_x_min = std::min(global_x_min, static_cast<int>(bbox.x_min));
         global_x_max = std::max(global_x_max, static_cast<int>(bbox.x_max));
         global_y_min = std::min(global_y_min, static_cast<int>(bbox.y_min));
@@ -874,36 +859,39 @@ int main(int argc, char **argv) {
     auto [image_slow, image_fast] = reader.image_shape();
     auto mask = reader.get_mask().value();
 
-    int bbox_extent_width  = global_x_max - global_x_min + 1;
+    int bbox_extent_width = global_x_max - global_x_min + 1;
     int bbox_extent_height = global_y_max - global_y_min + 1;
 
     PixelToS1Buffer pixel_to_s1_map(bbox_extent_width * bbox_extent_height);
 
     auto geom_index = [&](int x, int y) -> size_t {
-        return static_cast<size_t>(
-            (x - global_x_min) +
-            (y - global_y_min) * bbox_extent_width
-        );
+        return static_cast<size_t>((x - global_x_min)
+                                   + (y - global_y_min) * bbox_extent_width);
     };
-    
+
     for (int y = global_y_min; y <= global_y_max; ++y) {
         for (int x = global_x_min; x <= global_x_max; ++x) {
             auto px_mm = panel.px_to_mm(x, y);
             Vector3d s1 = panel.get_lab_coord(px_mm[0], px_mm[1]);
             s1.normalize();
-            pixel_to_s1_map[geom_index(x, y)] =
-                s1 * s0_length;
+            pixel_to_s1_map[geom_index(x, y)] = s1 * s0_length;
         }
     }
 
-    SharedConstants constants = SharedConstants(
-        dont_integrate,
-        computed_bounding_boxes,
-        coord_system_vector,
-        phi_column,
-        phi0, dphi, fg_algorithm, delta_b_r2, delta_m_r2, pixel_to_s1_map,
-        bbox_extent_width, global_x_min, global_y_min);
-    
+    SharedConstants constants = SharedConstants(dont_integrate,
+                                                computed_bounding_boxes,
+                                                coord_system_vector,
+                                                phi_column,
+                                                phi0,
+                                                dphi,
+                                                fg_algorithm,
+                                                delta_b_r2,
+                                                delta_m_r2,
+                                                pixel_to_s1_map,
+                                                bbox_extent_width,
+                                                global_x_min,
+                                                global_y_min);
+
     logger.info("Made shared constants");
 
     std::vector<ImageRange> ranges = split_ranges(n_images, nthreads);
@@ -919,13 +907,12 @@ int main(int argc, char **argv) {
     logger.info("About to start parallelisation");
     for (size_t t = 0; t < nthreads; t++) {
         workers.emplace_back([&, t] {
-            thread_accs[t] =
-                std::move(process_image_range(ranges[t], expt, reflections_by_image, constants));
+            thread_accs[t] = std::move(
+              process_image_range(ranges[t], expt, reflections_by_image, constants));
         });
     }
 
-    for (auto& th : workers)
-        th.join();
+    for (auto &th : workers) th.join();
 
     std::vector<int> intensity_accumulators(num_reflections);
     std::vector<Vector3d> intensity_times_coord_accumulators(num_reflections);
@@ -933,13 +920,12 @@ int main(int argc, char **argv) {
     std::vector<int> nbg_accumulators(num_reflections);
     std::vector<int> nfg_accumulators(num_reflections);
 
-    for (const auto& acc : thread_accs) {
-        for (const auto& [r, partial] : acc.data) {
+    for (const auto &acc : thread_accs) {
+        for (const auto &[r, partial] : acc.data) {
             intensity_accumulators[r] += partial.intensity;
             nfg_accumulators[r] += partial.nfg;
             nbg_accumulators[r] += partial.nbg;
-            intensity_times_coord_accumulators[r] +=
-                partial.intensity_times_coord;
+            intensity_times_coord_accumulators[r] += partial.intensity_times_coord;
             bg_accumulators[r].add(partial.bg);
             success[r] = static_cast<bool>(partial.success) && success[r];
         }

--- a/baseline/integrator/integrator.cc
+++ b/baseline/integrator/integrator.cc
@@ -115,9 +115,155 @@ class BaselineIntegratorArgumentParser : public FFSArgumentParser {
           .help("Output file path")
           .metavar("integrated.refl")
           .default_value<std::string>("integrated.refl");
+
+        add_argument("--nthreads")  // mainly for testing.
+          .help(
+            "The number of threads to use for the image integration loop."
+            "Defaults to the value of std::thread::hardware_concurrency.")
+          .scan<'u', size_t>();
     }
 };
 #pragma endregion Argument Parsing
+
+struct Accumulator {
+    std::vector<double> intensity;
+    std::vector<size_t> nfg;
+    std::vector<size_t> nbg;
+    std::vector<Vector3d> intensity_times_coord;
+    std::vector<BackgroundAggregator> bg;
+    std::vector<bool> success;
+
+    Accumulator(size_t n_reflections)
+      : intensity(n_reflections, 0.0),
+        nfg(n_reflections, 0),
+        nbg(n_reflections, 0),
+        intensity_times_coord(n_reflections, Vector3d::Zero()),
+        bg(n_reflections),
+        success(n_reflections, true) {}
+
+    /*(const Accumulator& other) {
+        for (size_t r = 0; r < intensity.size(); r++) {
+            intensity[r] += other.intensity[r];
+            nfg[r] += other.nfg[r];
+            nbg[r] += other.nbg[r];
+            intensity_times_coord[r] += other.intensity_times_coord[r];
+            bg[r].merge(other.bg[r]);
+            success[r] = success[r] && other.success[r];
+        }
+    }*/
+};
+
+
+struct ImageRange {
+    size_t begin;
+    size_t end;   // half-open [begin, end)
+};
+
+std::vector<ImageRange> split_ranges(size_t n_images, size_t n_threads) {
+    std::vector<ImageRange> ranges(n_threads);
+
+    size_t base = n_images / n_threads;
+    size_t rem  = n_images % n_threads;
+
+    size_t current = 0;
+    for (size_t t = 0; t < n_threads; t++) {
+        size_t count = base + (t < rem ? 1 : 0);
+        ranges[t] = {current, current + count};
+        current += count;
+    }
+
+    return ranges;
+}
+
+struct SharedConstants {
+    // --- Sizes ---
+    size_t n_reflections;
+
+    // --- Reflection selection ---
+    const std::vector<bool>& dont_integrate;
+    const std::vector<BoundingBoxExtents>& computed_bounding_boxes;
+    const std::vector<CoordinateSystem>& coord_system_vector;
+
+    // --- Reflection geometry ---
+    const mdspan_type<double> phi_column;     // shape: [n_reflections, 3]
+    const mdspan_type<double> s1_vectors;     // shape: [n_reflections, 3]
+
+    // --- Panel / detector ---
+    const Panel& panel;
+
+    // --- Scan / rotation ---
+    double phi0;
+    double dphi;
+    double DEG2RAD;
+
+    // --- Beam ---
+    double s0_length;
+
+    // --- Foreground/background model ---
+    std::string fg_algorithm;   // "ellipsoid" or "dials"
+
+    double delta_b_r2;
+    double delta_m_r2;
+
+    SharedConstants(
+        size_t n_reflections_,
+        const std::vector<bool>& dont_integrate_,
+        const std::vector<BoundingBoxExtents>& computed_bounding_boxes_,
+        const std::vector<CoordinateSystem>& coord_system_vector_,
+        const mdspan_type<double> phi_column_,
+        const mdspan_type<double> s1_vectors_,
+        const Panel& panel_,
+        double phi0_,
+        double dphi_,
+        double s0_length_,
+        std::string fg_algorithm_,
+        double delta_b_r2_,
+        double delta_m_r2_
+    )
+      : n_reflections(n_reflections_),
+        dont_integrate(dont_integrate_),
+        computed_bounding_boxes(computed_bounding_boxes_),
+        coord_system_vector(coord_system_vector_),
+        phi_column(phi_column_),
+        s1_vectors(s1_vectors_),
+        panel(panel_),
+        phi0(phi0_),
+        dphi(dphi_),
+        DEG2RAD(M_PI / 180.0),
+        s0_length(s0_length_),
+        fg_algorithm(std::move(fg_algorithm_)),
+        delta_b_r2(delta_b_r2_),
+        delta_m_r2(delta_m_r2_) {}
+};
+
+
+Accumulator process_image_range(
+    ImageRange range,
+    Experiment<MonochromaticBeam>& expt,
+    const std::vector<std::vector<size_t>>& reflections_by_image,
+    const SharedConstants& constants
+) {
+    Accumulator acc(constants.n_reflections);
+
+    std::string filename = expt.imagesequence().filename();
+    H5Read reader(filename);
+
+    auto [image_slow, image_fast] = reader.image_shape();
+    auto mask = reader.get_mask().value();
+
+    for (size_t j = range.begin; j < range.end; j++) {
+        if (!reader.is_image_available(j))
+            continue;
+
+        auto image = reader.get_image(j);
+
+        // ---- your existing inner loops go here ----
+        // Replace all writes to global accumulators with acc.*
+    }
+
+    return acc;
+}
+
 
 #pragma region Application Entry
 int main(int argc, char **argv) {
@@ -285,6 +431,14 @@ int main(int argc, char **argv) {
           "Input data have the predict flag set, treating as predicted data.");
     }
 
+    size_t nthreads;
+    if (parser.is_used("nthreads")) {
+        nthreads = parser.get<size_t>("nthreads");
+    } else {
+        size_t max_threads = std::thread::hardware_concurrency();
+        nthreads = max_threads ? max_threads : 1;
+    };
+
     mdspan_type<double> phi_column;
     mdspan_type<double> s1_vectors;
     std::vector<int> hkl_vectors;
@@ -306,8 +460,6 @@ int main(int argc, char **argv) {
         // FIXME: Need a better dmin_default from .expt file (like in DIALS)
         double dmin_default = dmin_min;
         double param_dmin = dmin_default;
-        size_t max_threads = std::thread::hardware_concurrency();
-        size_t nthreads = max_threads ? max_threads : 1;
         int buffer_size = 0;
         output_data =
           predict_rotation(expt, sv_data, param_dmin, buffer_size, nthreads);
@@ -470,6 +622,41 @@ int main(int argc, char **argv) {
     auto [image_slow, image_fast] = reader.image_shape();
     auto mask = reader.get_mask().value();
 
+    /*std::vector<ImageRange> = split_ranges(n_images, nthreads);
+    std::vector<std::thread> workers;
+    std::vector<Accumulator> thread_accs(nthreads);
+
+    for (size_t t = 0; t < nthreads; t++) {
+        workers.emplace_back([&, t] {
+            thread_accs[t] =
+                process_image_range(ranges[t], expt, reflections_by_image, constants);
+        });
+    }
+
+    for (auto& th : workers)
+        th.join();
+
+    for (const auto& acc : partials) {
+        for (size_t r = 0; r < n_reflections; r++) {
+            intensity_accumulators[r] += acc.intensity[r];
+            nfg_accumulators[r] += acc.nfg[r];
+            nbg_accumulators[r] += acc.nbg[r];
+            bg_accumulators[r].merge(acc.bg[r]);
+            intensity_times_coord_accumulators[r] += acc.intensity_times_coord[r];
+            success[r] = success[r] && acc.success[r];
+        }
+    }*/
+
+
+    SharedConstants constants = SharedConstants(
+        num_reflections, dont_integrate,
+        computed_bounding_boxes,
+        coord_system_vector,
+        phi_column, s1_vectors, panel,
+        phi0, dphi, s0_length, fg_algorithm, delta_b_r2, delta_m_r2);
+
+    Accumulator accumulator = Accumulator(num_reflections);
+
     for (size_t j = 0; j < n_images; j++) {
         if (!reader.is_image_available(j)) {
             continue;
@@ -478,30 +665,30 @@ int main(int argc, char **argv) {
         logger.info("Processing image {}", j + 1);
         for (size_t k = 0; k < reflections_by_image[j].size(); k++) {
             size_t refl_id = reflections_by_image[j][k];
-            if (dont_integrate[refl_id]) {
+            if (constants.dont_integrate[refl_id]) {
                 continue;
             }
-            const auto &bbox = computed_bounding_boxes[refl_id];
-            if (fg_algorithm == "ellipsoid") {
+            const auto &bbox = constants.computed_bounding_boxes[refl_id];
+            if (constants.fg_algorithm == "ellipsoid") {
                 // calculate dxy array (arrays of distances in kabsch space from pixel corners to xyzcal)
                 int n_x = bbox.x_max - bbox.x_min + 1;
                 int n_y = bbox.y_max - bbox.y_min + 1;
                 std::vector<double> dxy_start(n_x
                                               * n_y);    // start of image (in rotation)
                 std::vector<double> dxy_end(n_x * n_y);  // end of image (in rotation)
-                double phidash_start = (phi0 + (j * dphi)) * DEG2RAD;
-                double phidash_end = (phi0 + ((j + 1) * dphi)) * DEG2RAD;
-                double phi_c = phi_column(refl_id, 2);
-                CoordinateSystem cs = coord_system_vector[refl_id];
-                Vector3d s1_this = Eigen::Map<Vector3d>(&s1_vectors(refl_id, 0));
+                double phidash_start = (constants.phi0 + (j * constants.dphi)) * constants.DEG2RAD;
+                double phidash_end = (constants.phi0 + ((j + 1) * constants.dphi)) * constants.DEG2RAD;
+                double phi_c = constants.phi_column(refl_id, 2);
+                CoordinateSystem cs = constants.coord_system_vector[refl_id];
+                Vector3d s1_this = Eigen::Map<Vector3d>(&constants.s1_vectors(refl_id, 0));
                 for (int x = 0; x < n_x; x++) {
                     for (int y = 0; y < n_y; y++) {
                         int index = x + (y * (n_x));
                         std::array<double, 2> px_mm =
-                          panel.px_to_mm(x + bbox.x_min, y + bbox.y_min);
-                        Vector3d s1_ = panel.get_lab_coord(px_mm[0], px_mm[1]);
+                          constants.panel.px_to_mm(x + bbox.x_min, y + bbox.y_min);
+                        Vector3d s1_ = constants.panel.get_lab_coord(px_mm[0], px_mm[1]);
                         s1_.normalize();
-                        Vector3d s1dash = s1_ * s0_length;
+                        Vector3d s1dash = s1_ * constants.s0_length;
                         Vector3d epsilon_coords_start =
                           cs.coords_from_s1vector(s1dash, phidash_start);
                         Vector3d epsilon_coords_end =
@@ -514,15 +701,15 @@ int main(int argc, char **argv) {
                         dxy_start[index] =
                           ((epsilon_coords_start[0] * epsilon_coords_start[0]
                             + epsilon_coords_start[1] * epsilon_coords_start[1])
-                           * delta_b_r2)
+                           * constants.delta_b_r2)
                           + ((epsilon_coords_start[2] * epsilon_coords_start[2])
-                             * delta_m_r2);
+                             * constants.delta_m_r2);
                         dxy_end[index] =
                           ((epsilon_coords_end[0] * epsilon_coords_end[0]
                             + epsilon_coords_end[1] * epsilon_coords_end[1])
-                           * delta_b_r2)
+                           * constants.delta_b_r2)
                           + ((epsilon_coords_end[2] * epsilon_coords_end[2])
-                             * delta_m_r2);
+                             * constants.delta_m_r2);
                     }
                 }
                 // Now loop through pixels in bbox, adding to foreground or background if unmasked and in image.
@@ -551,19 +738,19 @@ int main(int argc, char **argv) {
                             // Foreground
                             if (in_image) {
                                 if (mask[index] == 0) {  // masked
-                                    success[refl_id] = false;
+                                    accumulator.success[refl_id] = false;
                                 } else {
                                     auto data = image.data.data()[index];
-                                    intensity_accumulators[refl_id] += data;
-                                    nfg_accumulators[refl_id] += 1;
+                                    accumulator.intensity[refl_id] += data;
+                                    accumulator.nfg[refl_id] += 1;
                                     Vector3d I_times_c = {data * (x + 0.5),
                                                           data * (y + 0.5),
                                                           data * (j + 0.5)};
-                                    intensity_times_coord_accumulators[refl_id] +=
+                                    accumulator.intensity_times_coord[refl_id] +=
                                       I_times_c;
                                 }
                             } else {
-                                success[refl_id] = false;
+                                accumulator.success[refl_id] = false;
                             }
                         } else {  // d>1.0
                             // Background
@@ -571,8 +758,8 @@ int main(int argc, char **argv) {
                                 if (mask[index] != 0) {
                                     // In image, not masked
                                     auto data = image.data.data()[index];
-                                    bg_accumulators[refl_id].add(data);
-                                    nbg_accumulators[refl_id] += 1;
+                                    accumulator.bg[refl_id].add(data);
+                                    accumulator.nbg[refl_id] += 1;
                                 }
                             }
                         }
@@ -584,24 +771,24 @@ int main(int argc, char **argv) {
                 int n_y = bbox.y_max - bbox.y_min + 1;
                 std::vector<double> dxy(n_x * n_y);
                 double phi =
-                  phi0
-                  + (j * dphi)
-                      * DEG2RAD;  // Required for calls but not actually used as don't use e3.
-                CoordinateSystem cs = coord_system_vector[refl_id];
-                Vector3d s1_this = Eigen::Map<Vector3d>(&s1_vectors(refl_id, 0));
+                  constants.phi0
+                  + (j * constants.dphi)
+                      * constants.DEG2RAD;  // Required for calls but not actually used as don't use e3.
+                CoordinateSystem cs = constants.coord_system_vector[refl_id];
+                Vector3d s1_this = Eigen::Map<Vector3d>(&constants.s1_vectors(refl_id, 0));
                 for (int x = 0; x < n_x; x++) {
                     for (int y = 0; y < n_y; y++) {
                         int index = x + (y * (n_x));
                         std::array<double, 2> px_mm =
-                          panel.px_to_mm(x + bbox.x_min, y + bbox.y_min);
-                        Vector3d s1_ = panel.get_lab_coord(px_mm[0], px_mm[1]);
+                          constants.panel.px_to_mm(x + bbox.x_min, y + bbox.y_min);
+                        Vector3d s1_ = constants.panel.get_lab_coord(px_mm[0], px_mm[1]);
                         s1_.normalize();
-                        Vector3d s1dash = s1_ * s0_length;
+                        Vector3d s1dash = s1_ * constants.s0_length;
                         Vector3d epsilon_coords = cs.coords_from_s1vector(s1dash, phi);
 
                         dxy[index] = ((epsilon_coords[0] * epsilon_coords[0]
                                        + epsilon_coords[1] * epsilon_coords[1])
-                                      * delta_b_r2);
+                                      * constants.delta_b_r2);
                     }
                 }
                 // Now loop through pixels in bbox, adding to foreground or background if unmasked and in image.
@@ -625,19 +812,19 @@ int main(int argc, char **argv) {
                             // Foreground
                             if (in_image) {
                                 if (mask[index] == 0) {  // masked)
-                                    success[refl_id] = false;
+                                    accumulator.success[refl_id] = false;
                                 } else {
                                     auto data = image.data.data()[index];
-                                    intensity_accumulators[refl_id] += data;
-                                    nfg_accumulators[refl_id] += 1;
+                                    accumulator.intensity[refl_id] += data;
+                                    accumulator.nfg[refl_id] += 1;
                                     Vector3d I_times_c = {data * (x + 0.5),
                                                           data * (y + 0.5),
                                                           data * (j + 0.5)};
-                                    intensity_times_coord_accumulators[refl_id] +=
+                                    accumulator.intensity_times_coord[refl_id] +=
                                       I_times_c;
                                 }
                             } else {
-                                success[refl_id] = false;
+                                accumulator.success[refl_id] = false;
                             }
                         } else {  // d>1.0
                             // Background
@@ -645,8 +832,8 @@ int main(int argc, char **argv) {
                                 if (mask[index] != 0) {
                                     // In image, not masked
                                     auto data = image.data.data()[index];
-                                    bg_accumulators[refl_id].add(data);
-                                    nbg_accumulators[refl_id] += 1;
+                                    accumulator.bg[refl_id].add(data);
+                                    accumulator.nbg[refl_id] += 1;
                                 }
                             }
                         }
@@ -686,18 +873,18 @@ int main(int argc, char **argv) {
     std::vector<double> bg_sum_value(num_reflections);
     // FIXME need to include robust outlier rejection in background calculation (glm, constant3dmodel)
     for (int i = 0; i < num_reflections; i++) {
-        if (nbg_accumulators[i]) {
+        if (accumulator.nbg[i]) {
             auto [bg, total_bg_counts] =
-              compute_background_constant_3d(bg_accumulators[i]);
+              compute_background_constant_3d(accumulator.bg[i]);
             mean_bg[i] = bg;
             bg_sum_value[i] = total_bg_counts;
-            double I = intensity_accumulators[i] - bg;
+            double I = accumulator.intensity[i] - bg;
             intensities[i] = I;
-            double m_n = nfg_accumulators[i] / nbg_accumulators[i];
+            double m_n = accumulator.nfg[i] / accumulator.nbg[i];
             variances[i] = std::abs(I) + (std::abs(bg) * (1.0 + m_n));
-            if ((nfg_accumulators[i] > 0) && (intensity_accumulators[i] > 0)) {
+            if ((accumulator.nfg[i] > 0) && (accumulator.intensity[i] > 0)) {
                 Vector3d com =
-                  intensity_times_coord_accumulators[i] / intensity_accumulators[i];
+                  accumulator.intensity_times_coord[i] / accumulator.intensity[i];
                 xyzobs_px[i * 3] = com[0];
                 xyzobs_px[i * 3 + 1] = com[1];
                 xyzobs_px[i * 3 + 2] = com[2];
@@ -713,7 +900,7 @@ int main(int argc, char **argv) {
                                           + computed_bounding_boxes[i].z_max);
             }
         } else {
-            success[i] = false;
+            accumulator.success[i] = false;
         }
     }
     // Calculate the partiality, LP, d of all reflections
@@ -785,6 +972,10 @@ int main(int argc, char **argv) {
     integrated_data.add_column(std::string("flags"), num_reflections, 1, final_flags);
 
     // Only output successfully integrated reflections.
+    for (int i=0;i<accumulator.success.size();i++){
+        success[i] = success[i] && accumulator.success[i];
+    }
+
     ReflectionTable success_data = integrated_data.select(success);
     int n_integrated =
       success_data.column<double>("intensity.sum.value").value().extent(0);

--- a/baseline/integrator/integrator.cc
+++ b/baseline/integrator/integrator.cc
@@ -404,21 +404,15 @@ Accumulator process_image_range(
                 if (dxy.size() < required) {
                     dxy.resize(required);
                 }
-                double phi =
-                  (constants.phi0 + (j * constants.dphi))
-                  * constants
-                      .DEG2RAD;  // Required for calls but not actually used as don't use e3.
                 const CoordinateSystem &cs = constants.coord_system_vector[refl_id];
 
                 for (int x = 0; x < n_x; x++) {
                     for (int y = 0; y < n_y; y++) {
                         int index = x + (y * (n_x));
-                        //const Vector3d &s1dash =
-                        //  constants.pixel_to_s1_map[(x + bbox.x_min)
-                        //                            + (y + bbox.y_min) * image_fast];
                         const Vector3d &s1dash = constants.pixel_to_s1_map[geom_index(
                           x + bbox.x_min, y + bbox.y_min)];
-                        Vector3d epsilon_coords = cs.coords_from_s1vector(s1dash, phi);
+                        // Phi value required for calls but not actually used as don't use e3.
+                        Vector3d epsilon_coords = cs.coords_from_s1vector(s1dash, phidash_start);
 
                         dxy[index] = ((epsilon_coords[0] * epsilon_coords[0]
                                        + epsilon_coords[1] * epsilon_coords[1])
@@ -428,7 +422,7 @@ Accumulator process_image_range(
                 // Now loop through pixels in bbox, adding to foreground or background if unmasked and in image.
                 for (int x = bbox.x_min; x < bbox.x_max; x++) {
                     for (int y = bbox.y_min; y < bbox.y_max; y++) {
-                        // The bounding box may extend beyond the image - if so, this is ok if it iis only background
+                        // The bounding box may extend beyond the image - if so, this is ok if it is only background
                         // but not if it is foreground.
                         int x_index = x - bbox.x_min;
                         int y_index = y - bbox.y_min;
@@ -936,7 +930,9 @@ int main(int argc, char **argv) {
 
 #pragma region Finalize calculations
     // Convert bbox data to reflection table format
-    std::vector<double> computed_bbox_data;
+    // FIXME - these are not yet output as seems to cause an issue with dials?
+    /*
+    std::vector<int> computed_bbox_data;
     computed_bbox_data.reserve(num_reflections * 6);
     for (const auto &bbox : computed_bounding_boxes) {
         computed_bbox_data.insert(computed_bbox_data.end(),
@@ -944,13 +940,12 @@ int main(int argc, char **argv) {
                                    bbox.x_max,
                                    bbox.y_min,
                                    bbox.y_max,
-                                   static_cast<double>(bbox.z_min),
-                                   static_cast<double>(bbox.z_max)});
+                                   bbox.z_min,
+                                   bbox.z_max});
     }
-    // FIXME - these are not yet output as seems to cause an issue with dials?
     // Add computed bounding boxes to reflection table
     //integrated_data.add_column(
-    //  "baseline_bbox", std::vector<size_t>{num_reflections, 6}, computed_bbox_data);
+    //  "baseline_bbox", std::vector<size_t>{num_reflections, 6}, computed_bbox_data);*/
 
     // Do the calculations to determine the background-subtracted intensities as well as other quantities of interest.
     std::vector<double> intensities(num_reflections);

--- a/baseline/integrator/integrator.cc
+++ b/baseline/integrator/integrator.cc
@@ -39,6 +39,13 @@ constexpr size_t IntegratedSum = (1 << 8);
 constexpr double DEG2RAD = M_PI / 180.0;
 constexpr double RAD2DEG = 180.0 / M_PI;
 
+
+enum class FGAlgorithm : uint8_t {
+    Ellipsoid,
+    Dials
+};
+
+
 #pragma region Argument Parsing
 class BaselineIntegratorArgumentParser : public FFSArgumentParser {
   public:
@@ -141,16 +148,6 @@ struct Accumulator {
         bg(n_reflections),
         success(n_reflections, true) {}
 
-    /*(const Accumulator& other) {
-        for (size_t r = 0; r < intensity.size(); r++) {
-            intensity[r] += other.intensity[r];
-            nfg[r] += other.nfg[r];
-            nbg[r] += other.nbg[r];
-            intensity_times_coord[r] += other.intensity_times_coord[r];
-            bg[r].merge(other.bg[r]);
-            success[r] = success[r] && other.success[r];
-        }
-    }*/
 };
 
 
@@ -200,7 +197,7 @@ struct SharedConstants {
     double s0_length;
 
     // --- Foreground/background model ---
-    std::string fg_algorithm;   // "ellipsoid" or "dials"
+    FGAlgorithm fg_algorithm;   // "ellipsoid" or "dials"
 
     double delta_b_r2;
     double delta_m_r2;
@@ -216,7 +213,7 @@ struct SharedConstants {
         double phi0_,
         double dphi_,
         double s0_length_,
-        std::string fg_algorithm_,
+        FGAlgorithm fg_algorithm_,
         double delta_b_r2_,
         double delta_m_r2_
     )
@@ -257,27 +254,50 @@ Accumulator process_image_range(
 
         auto image = reader.get_image(j);
         logger.info("Processing image {}", j + 1);
-        for (size_t k = 0; k < reflections_by_image[j].size(); k++) {
-            size_t refl_id = reflections_by_image[j][k];
-            if (constants.dont_integrate[refl_id]) {
-                continue;
-            }
-            const auto &bbox = constants.computed_bounding_boxes[refl_id];
-            if (constants.fg_algorithm == "ellipsoid") {
+
+        std::vector<double> dxy_start;// start of image (in rotation)
+        std::vector<double> dxy_end;// end of image (in rotation)
+        std::vector<double> dxy;
+        double phidash_start = (constants.phi0 + (j * constants.dphi)) * constants.DEG2RAD;
+        double phidash_end = (constants.phi0 + ((j + 1) * constants.dphi)) * constants.DEG2RAD;
+
+        switch (constants.fg_algorithm){
+        case FGAlgorithm::Ellipsoid:
+
+            for (size_t k = 0; k < reflections_by_image[j].size(); k++) {
+                size_t refl_id = reflections_by_image[j][k];
+                if (constants.dont_integrate[refl_id]) {
+                    continue;
+                }
+                const auto &bbox = constants.computed_bounding_boxes[refl_id];
+                
                 // calculate dxy array (arrays of distances in kabsch space from pixel corners to xyzcal)
                 int n_x = bbox.x_max - bbox.x_min + 1;
                 int n_y = bbox.y_max - bbox.y_min + 1;
-                std::vector<double> dxy_start(n_x
-                                              * n_y);    // start of image (in rotation)
-                std::vector<double> dxy_end(n_x * n_y);  // end of image (in rotation)
-                double phidash_start = (constants.phi0 + (j * constants.dphi)) * constants.DEG2RAD;
-                double phidash_end = (constants.phi0 + ((j + 1) * constants.dphi)) * constants.DEG2RAD;
+                //std::vector<double> dxy_start(n_x
+                //                              * n_y);    // start of image (in rotation)
+                //std::vector<double> dxy_end(n_x * n_y);  // end of image (in rotation)
+
+                size_t required = static_cast<size_t>(n_x) * n_y;
+                if (dxy_start.size() < required) {
+                    dxy_start.resize(required);
+                    dxy_end.resize(required);
+                }
+
+                
                 double phi_c = constants.phi_column(refl_id, 2);
                 CoordinateSystem cs = constants.coord_system_vector[refl_id];
-                Vector3d s1_this = Eigen::Map<Vector3d>(&constants.s1_vectors(refl_id, 0));
-                for (int x = 0; x < n_x; x++) {
-                    for (int y = 0; y < n_y; y++) {
-                        int index = x + (y * (n_x));
+                //Vector3d s1_this = Eigen::Map<Vector3d>(&constants.s1_vectors(refl_id, 0));
+                
+                for (int y = 0; y < n_y; ++y) {
+                    int row = y * n_x;
+                    for (int x = 0; x < n_x; ++x) {
+                        int index = row + x;
+
+
+                        //for (int x = 0; x < n_x; x++) {
+                        //for (int y = 0; y < n_y; y++) {
+                        //int index = x + (y * (n_x));
                         std::array<double, 2> px_mm =
                           constants.panel.px_to_mm(x + bbox.x_min, y + bbox.y_min);
                         Vector3d s1_ = constants.panel.get_lab_coord(px_mm[0], px_mm[1]);
@@ -322,9 +342,17 @@ Accumulator process_image_range(
                         double d6 = dxy_end[dxyindex + 1];
                         double d7 = dxy_end[dxyindex + n_x];
                         double d8 = dxy_end[dxyindex + n_x + 1];
-                        double d =
+                        double d = d1;
+                        d = std::min(d, d2);
+                        d = std::min(d, d3);
+                        d = std::min(d, d4);
+                        d = std::min(d, d5);
+                        d = std::min(d, d6);
+                        d = std::min(d, d7);
+                        d = std::min(d, d8);
+                        /*double d =
                           std::min(std::min(std::min(d1, d2), std::min(d3, d4)),
-                                   std::min(std::min(d5, d6), std::min(d7, d8)));
+                                   std::min(std::min(d5, d6), std::min(d7, d8)));*/
                         int index = x + (y * image_fast);
                         bool in_image =
                           x >= 0 && x < image_fast && y >= 0 && y < image_slow;
@@ -359,17 +387,31 @@ Accumulator process_image_range(
                         }
                     }
                 }
-            } else {
+            }
+            break;
+
+        case FGAlgorithm::Dials:
+
+            for (size_t k = 0; k < reflections_by_image[j].size(); k++) {
+                size_t refl_id = reflections_by_image[j][k];
+                if (constants.dont_integrate[refl_id]) {
+                    continue;
+                }
+                const auto &bbox = constants.computed_bounding_boxes[refl_id];
                 // dials algorithm - a fixed ellipse (2D) across all images in the bbox
                 int n_x = bbox.x_max - bbox.x_min + 1;
                 int n_y = bbox.y_max - bbox.y_min + 1;
-                std::vector<double> dxy(n_x * n_y);
+                //std::vector<double> dxy(n_x * n_y);
+                size_t required = static_cast<size_t>(n_x) * n_y;
+                if (dxy.size() < required) {
+                    dxy.resize(required);
+                }
                 double phi =
                   constants.phi0
                   + (j * constants.dphi)
                       * constants.DEG2RAD;  // Required for calls but not actually used as don't use e3.
                 CoordinateSystem cs = constants.coord_system_vector[refl_id];
-                Vector3d s1_this = Eigen::Map<Vector3d>(&constants.s1_vectors(refl_id, 0));
+                //Vector3d s1_this = Eigen::Map<Vector3d>(&constants.s1_vectors(refl_id, 0));
                 for (int x = 0; x < n_x; x++) {
                     for (int y = 0; y < n_y; y++) {
                         int index = x + (y * (n_x));
@@ -397,7 +439,11 @@ Accumulator process_image_range(
                         double d2 = dxy[dxyindex + 1];
                         double d3 = dxy[dxyindex + n_x];
                         double d4 = dxy[dxyindex + n_x + 1];
-                        double d = std::min(std::min(d1, d2), std::min(d3, d4));
+                        double d = d1;
+                        d = std::min(d, d2);
+                        d = std::min(d, d3);
+                        d = std::min(d, d4);
+                        //double d = std::min(std::min(d1, d2), std::min(d3, d4));
                         int index = x + (y * image_fast);
                         bool in_image =
                           x >= 0 && x < image_fast && y >= 0 && y < image_slow;
@@ -434,11 +480,16 @@ Accumulator process_image_range(
                     }
                 }
             }
+            break;
         }
-
     }
-
     return accumulator;
+}
+
+FGAlgorithm parse_fg_algorithm(const std::string& name) {
+    if (name == "ellipsoid") return FGAlgorithm::Ellipsoid;
+    if (name == "dials")     return FGAlgorithm::Dials;
+    throw std::runtime_error("Unknown foreground algorithm: " + name);
 }
 
 
@@ -454,11 +505,8 @@ int main(int argc, char **argv) {
 
     float timeout = parser.get<float>("timeout");
     std::string output_file = parser.get<std::string>("output");
-    std::string fg_algorithm = parser.get<std::string>("algorithm");
-    if ((fg_algorithm != "dials") && (fg_algorithm != "ellipsoid")) {
-        throw std::invalid_argument(
-          "Invalid algorithm specified (must be 'dials' or 'ellipsoid')");
-    }
+    
+    FGAlgorithm fg_algorithm = parse_fg_algorithm(parser.get<std::string>("algorithm"));
 
     // Guard against missing files
     if (!std::filesystem::exists(reflection_file)) {
@@ -792,6 +840,8 @@ int main(int argc, char **argv) {
     double delta_m = sigma_m * 3.0;
     double delta_m_r2 = 1.0 / (delta_m * delta_m);
 
+    logger.info("Calculated coordinate systems");
+
     // Now load some image data and loop through:
     std::string filename = expt.imagesequence().filename();
     auto reader = H5Read(filename);
@@ -805,6 +855,7 @@ int main(int argc, char **argv) {
         coord_system_vector,
         phi_column, s1_vectors, panel,
         phi0, dphi, s0_length, fg_algorithm, delta_b_r2, delta_m_r2);
+    logger.info("Made shared constants");
 
     std::vector<ImageRange> ranges = split_ranges(n_images, nthreads);
     std::vector<std::thread> workers;
@@ -817,11 +868,11 @@ int main(int argc, char **argv) {
         thread_accs.emplace_back(num_reflections);
     }
 
-
+    logger.info("About to start parallelisation");
     for (size_t t = 0; t < nthreads; t++) {
         workers.emplace_back([&, t] {
             thread_accs[t] =
-                process_image_range(ranges[t], expt, reflections_by_image, constants);
+                std::move(process_image_range(ranges[t], expt, reflections_by_image, constants));
         });
     }
 
@@ -835,7 +886,7 @@ int main(int argc, char **argv) {
             nbg_accumulators[r] += acc.nbg[r];
             bg_accumulators[r].add(acc.bg[r]);
             intensity_times_coord_accumulators[r] += acc.intensity_times_coord[r];
-            success[r] = success[r] && acc.success[r];
+            success[r] = static_cast<bool>(success[r]) && acc.success[r];
         }
     }
 

--- a/baseline/integrator/integrator.cc
+++ b/baseline/integrator/integrator.cc
@@ -405,10 +405,9 @@ Accumulator process_image_range(
                     dxy.resize(required);
                 }
                 double phi =
-                  (constants.phi0
-                  + (j * constants.dphi))
-                      * constants
-                          .DEG2RAD;  // Required for calls but not actually used as don't use e3.
+                  (constants.phi0 + (j * constants.dphi))
+                  * constants
+                      .DEG2RAD;  // Required for calls but not actually used as don't use e3.
                 const CoordinateSystem &cs = constants.coord_system_vector[refl_id];
 
                 for (int x = 0; x < n_x; x++) {


### PR DESCRIPTION
Add some simple parallelization to the baseline integrator.

The image range is split into chunks, with each thread working on a chunk. Each thread accumulates processed data (total intensity, background histograms, _not_ pixel values) for its reflections, and then the overall data is aggregated at the end including reflections that span multiple chunks.

Each thread has its own reader for simplicity, although this does not give true parallelism due to contention when using hdf5. Image loading seems to max out at around 30 fps.
The actual integration calculations (Kabsch-space mapping, foreground/background assignment) take around 10 fps per cpu for sigma_b, sigma_m = (0.03, 0.1), which does parallelize well. Calculation time was improved by precomputing the pixel_to_s1 mapping for all pixels.
