### PR TITLE
Fix bug in baseline indexer refinement - detector updating

### DIFF
--- a/baseline/indexer/indexer.cc
+++ b/baseline/indexer/indexer.cc
@@ -436,12 +436,11 @@ int main(int argc, char **argv) {
             reflections.add_column(std::string("entering"), enterings);
             const ReflectionTable filtered = reflections.select(selection);
 
-            refine_crystal(expt.crystal(),
-                           filtered,
-                           gonio,
-                           expt.beam(),
-                           expt.detector().panels()[0],
-                           scan_width);
+            // panels() returns a const ref, so refine on a mutable copy
+            Panel refine_panel = expt.detector().panels()[0];
+            refine_crystal(
+              expt.crystal(), filtered, gonio, expt.beam(), refine_panel, scan_width);
+            expt.detector().update(refine_panel.get_d_matrix());
         }
     }
 

--- a/tests/test_baseline_indexer.py
+++ b/tests/test_baseline_indexer.py
@@ -204,8 +204,8 @@ def test_baseline_indexer(tmp_path, dials_data):
         assert len(flags) == 703
         n_indexed = np.sum(np.array(flags, dtype=int) == 36)
         n_unindexed = np.sum(np.array(flags, dtype=int) == 32)
-        assert n_indexed == 55
-        assert n_unindexed == 648
+        assert n_indexed == 66
+        assert n_unindexed == 637
 
 
 def test_baseline_indexer_c2sum(tmp_path, dials_data):


### PR DESCRIPTION
Move to latest dx2 commit "Return const references from member accessors", which reveals the detector model was not being updated at the end of each refinement cycle.