### PR TITLE
Add Tukey/IQR constant background estimation to the GPU integrator

### DIFF
--- a/baseline/integrator/integrator.cc
+++ b/baseline/integrator/integrator.cc
@@ -109,6 +109,13 @@ class BaselineIntegratorArgumentParser : public FFSArgumentParser {
           .help("Foreground algorithm choice - dials or ellipsoid.")
           .default_value<std::string>("ellipsoid");
 
+        add_argument("--background")
+          .help(
+            "Constant (Tukey/IQR) background implementation - constant/tukey/dials "
+            "for the independent dials-like baseline, or shared/core for the shared "
+            "GPU core. glm is not yet implemented.")
+          .default_value<std::string>("constant");
+
         add_argument("--min_zeta")
           .help(
             "Reflections close to the rotation axis, with a zeta below this threshold "
@@ -492,6 +499,19 @@ FGAlgorithm parse_fg_algorithm(const std::string &name) {
     throw std::runtime_error("Unknown foreground algorithm: " + name);
 }
 
+ConstantBackgroundImpl parse_background_impl(const std::string &name) {
+    if (name == "constant" || name == "tukey" || name == "dials") {
+        return ConstantBackgroundImpl::DialsIndependent;
+    }
+    if (name == "shared" || name == "core") {
+        return ConstantBackgroundImpl::SharedCore;
+    }
+    if (name == "glm") {
+        throw std::runtime_error("GLM background model not yet implemented");
+    }
+    throw std::runtime_error("Unknown background model: " + name);
+}
+
 #pragma region Application Entry
 int main(int argc, char **argv) {
     logger.info("Baseline Integrator Version: {}", FFS_VERSION);
@@ -506,6 +526,13 @@ int main(int argc, char **argv) {
     std::string output_file = parser.get<std::string>("output");
 
     FGAlgorithm fg_algorithm = parse_fg_algorithm(parser.get<std::string>("algorithm"));
+
+    ConstantBackgroundImpl background_impl =
+      parse_background_impl(parser.get<std::string>("background"));
+    logger.info("Background model: constant ({})",
+                background_impl == ConstantBackgroundImpl::SharedCore
+                  ? "shared core"
+                  : "independent dials-like");
 
     // Guard against missing files
     if (!std::filesystem::exists(reflection_file)) {
@@ -970,7 +997,7 @@ int main(int argc, char **argv) {
     for (int i = 0; i < num_reflections; i++) {
         if (nbg_accumulators[i]) {
             auto [bg, total_bg_counts] =
-              compute_background_constant_3d(bg_accumulators[i]);
+              compute_background_constant_3d(bg_accumulators[i], background_impl);
             mean_bg[i] = bg;
             bg_sum_value[i] = total_bg_counts;
             double I = intensity_accumulators[i] - bg;

--- a/include/integrator/background.cuh
+++ b/include/integrator/background.cuh
@@ -1,0 +1,44 @@
+/**
+ * @file background.cuh
+ * @brief GPU per-reflection background reduction.
+ *
+ * After the Kabsch kernel has accumulated a per-reflection background
+ * histogram on the device, this reduces each reflection's histogram into a
+ * background estimate (mean, inlier weighted sum, pixel count, success) using
+ * the selected BackgroundModel. The reduction runs entirely on the device and
+ * reuses the single-source model code in integrator/background.hpp, so it
+ * produces the same result as the baseline CPU path.
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include "integrator/background.hpp"
+
+/**
+ * @brief Reduce per-reflection background histograms into background estimates.
+ *
+ * One thread handles one reflection: it views its slice of the histogram
+ * (NUM_BG_BINS bins plus the overflow tail) and evaluates the chosen model.
+ *
+ * @param model Background model to apply (Constant = Tukey; Glm not yet implemented)
+ * @param d_background_hist Device histogram, num_reflections * NUM_BG_BINS bins
+ * @param d_background_overflow Device per-reflection high-tail counts
+ * @param num_reflections Number of reflections
+ * @param d_background_mean Output: per-reflection background level (per pixel)
+ * @param d_background_sum_value Output: per-reflection inlier weighted sum (background.sum.value)
+ * @param d_background_count Output: per-reflection total background pixel count
+ * @param d_background_success Output: per-reflection success flag (1 = estimate valid)
+ * @param stream CUDA stream for async execution
+ */
+void compute_background(BackgroundModel model,
+                        const uint32_t *d_background_hist,
+                        const uint32_t *d_background_overflow,
+                        size_t num_reflections,
+                        double *d_background_mean,
+                        double *d_background_sum_value,
+                        uint32_t *d_background_count,
+                        uint8_t *d_background_success,
+                        cudaStream_t stream);

--- a/include/integrator/background.hpp
+++ b/include/integrator/background.hpp
@@ -37,6 +37,19 @@
  */
 enum class BackgroundModel : uint8_t { Constant, Glm };
 
+/**
+ * @brief Selects which implementation of the constant (Tukey/IQR) background
+ *        model the host baseline uses.
+ *
+ * DialsIndependent is the original self-contained baseline: an unbounded
+ * histogram (small array plus a sparse map for large/outlier values) that
+ * counts every pixel, including negative sentinels, with no overflow rejection.
+ * This is the true-to-dials reference. SharedCore delegates to the same
+ * tukey_constant_background() the GPU runs, over a bounded NUM_BG_BINS
+ * histogram, so the baseline can be compared directly against the shared core.
+ */
+enum class ConstantBackgroundImpl : uint8_t { DialsIndependent, SharedCore };
+
 // Number of integer-valued bins in each per-reflection background histogram.
 // Single source of truth, shared by the GPU device histogram stride and the
 // host baseline adapter, so both paths bin identical pixel values and produce
@@ -248,7 +261,10 @@ class BackgroundAggregator {
  * using a Tukey (IQR-based) outlier rejection.
  *
  * @param data Aggregated background pixel histogram for one reflection.
+ * @param impl Which implementation to run: the independent dials-like baseline
+ *        (default) or the shared core the GPU uses.
  * @return {mean background, weighted sum of included pixel values}
  */
 std::tuple<double, double> compute_background_constant_3d(
-  const BackgroundAggregator &data);
+  const BackgroundAggregator &data,
+  ConstantBackgroundImpl impl = ConstantBackgroundImpl::DialsIndependent);

--- a/include/integrator/background.hpp
+++ b/include/integrator/background.hpp
@@ -127,9 +127,11 @@ FFS_HD inline BackgroundResult tukey_constant_background(
     const uint64_t p50 = (N + 1) / 2;
     const uint64_t p75 = (3 * N + 1) / 4;
 
-    // Ascending scan over bins to locate q1, median, q3. If a quartile falls in
-    // the overflow tail, num_bins is too small for this reflection; clamp it to
-    // num_bins (a lower bound) so the estimate degrades instead of failing.
+    // Ascending scan over bins to locate q1, median, q3. If a quartile
+    // falls in the overflow tail, num_bins is too small for this
+    // reflection; clamp it to num_bins (a lower bound). A clamped q1
+    // alone leaves the estimate usable, whereas a clamped q3 pushes the
+    // upper fence to num_bins, which the bound check below rejects.
     uint64_t cumulative = 0;
     long q1 = -1, median = -1, q3 = -1;
     for (int v = 0; v < hist.num_bins; ++v) {
@@ -148,9 +150,16 @@ FFS_HD inline BackgroundResult tukey_constant_background(
     const double lower_bound = q1 - iqr_multiplier * iqr;
     const double upper_bound = q3 + iqr_multiplier * iqr;
 
-    // Accumulate inliers. Overflow values are >= num_bins, so they count only
-    // if num_bins itself falls within the rejection bounds, matching the
-    // baseline's treatment of the high tail as outliers.
+    // The upper fence reaching past the bins into the overflow tail
+    // means the range is too small to separate the inliers from the
+    // high tail, so reject the estimate (valid stays false).
+    if (upper_bound >= static_cast<double>(hist.num_bins)) {
+        return result;
+    }
+
+    // Accumulate inliers. The fence check above guarantees
+    // upper_bound < num_bins, so overflow values (>= num_bins)
+    // always sit above the upper bound and are rejected
     uint64_t included_count = 0;
     double weighted_sum = 0.0;
     for (int v = 0; v < hist.num_bins; ++v) {

--- a/include/integrator/background.hpp
+++ b/include/integrator/background.hpp
@@ -1,14 +1,147 @@
 /**
  * @file background.hpp
- * @brief Background estimation for baseline CPU integration.
+ * @brief Per-reflection background estimation, shared by the baseline CPU
+ *        integrator and the GPU integrator.
+ *
+ * The constant (Tukey/IQR) background model is implemented once, as a
+ * device-safe function over a uniform integer-histogram view
+ * (::ConstHistogramView). The same code compiles for the host (baseline) and
+ * for CUDA device code (GPU reduction kernel), so both paths produce identical
+ * results. Background pixel values are integer counts, so a histogram with one
+ * bin per integer value makes the quartile/IQR logic exact.
  */
 
 #pragma once
 
 #include <array>
 #include <cstddef>
+#include <cstdint>
 #include <tuple>
 #include <unordered_map>
+
+// __host__ __device__ under nvcc, nothing under a plain C++ compiler, so this
+// header compiles in the baseline's CXX translation unit as well as in CUDA.
+#if defined(__CUDACC__)
+#define FFS_HD __host__ __device__
+#else
+#define FFS_HD
+#endif
+
+/**
+ * @brief Selects which background model is used to estimate the per-reflection
+ *        background level from its pixel histogram.
+ *
+ * Constant is the Tukey/IQR outlier-rejecting constant background (matches the
+ * DIALS "constant 3d" model). Glm is the full DIALS robust-Poisson GLM model,
+ * not yet implemented; it will read the same histogram.
+ */
+enum class BackgroundModel : uint8_t { Constant, Glm };
+
+/**
+ * @brief Read-only view of a per-reflection background histogram.
+ *
+ * bins[v] holds the number of background pixels with integer value v, for
+ * v in [0, num_bins). overflow_count holds the number of pixels with value
+ * >= num_bins (the high tail). For a constant background, num_bins is chosen
+ * above the realistic inlier range, so the overflow only ever contains high
+ * outliers, which Tukey rejects; this keeps the bounded histogram exact.
+ */
+struct ConstHistogramView {
+    const uint32_t *bins = nullptr;
+    int num_bins = 0;
+    uint32_t overflow_count = 0;
+};
+
+/**
+ * @brief Result of a constant background estimate.
+ *
+ * mean is the background level per pixel; weighted_sum is the sum of the
+ * inlier pixel values used to form it (DIALS background.sum.value). valid is
+ * false when there are no pixels or no inliers survive outlier rejection.
+ */
+struct BackgroundResult {
+    double mean = 0.0;
+    double weighted_sum = 0.0;
+    bool valid = false;
+};
+
+/**
+ * @brief Tukey (IQR-based) outlier-rejecting constant background.
+ *
+ * Single-source implementation shared by host and device. Computes the
+ * quartiles of the histogram, rejects values outside
+ * [q1 - 1.5*IQR, q3 + 1.5*IQR], and returns the mean and weighted sum of the
+ * surviving inliers. Device-safe: no allocation, no exceptions; failure is
+ * reported via BackgroundResult::valid.
+ *
+ * The high tail (overflow_count) is counted towards the quartile positions but
+ * never contributes inliers, since for a sensible num_bins it lies above the
+ * upper rejection bound.
+ */
+FFS_HD inline BackgroundResult tukey_constant_background(
+  const ConstHistogramView &hist) {
+    constexpr double iqr_multiplier = 1.5;
+
+    // Defaults to valid=false; set true only once a mean has been computed from
+    // real inliers at the end.
+    BackgroundResult result;
+
+    // Total pixel count across the histogram and the high-tail overflow.
+    uint64_t N = hist.overflow_count;
+    for (int v = 0; v < hist.num_bins; ++v) {
+        N += hist.bins[v];
+    }
+    if (N == 0) {
+        return result;  // no background pixels, so no estimate (valid stays false)
+    }
+
+    // Quantile positions (1-based counting convention, matching the baseline).
+    const uint64_t p25 = (N + 3) / 4;
+    const uint64_t p50 = (N + 1) / 2;
+    const uint64_t p75 = (3 * N + 1) / 4;
+
+    // Ascending scan over bins to locate q1, median, q3. If a quartile falls in
+    // the overflow tail, num_bins is too small for this reflection; clamp it to
+    // num_bins (a lower bound) so the estimate degrades instead of failing.
+    uint64_t cumulative = 0;
+    long q1 = -1, median = -1, q3 = -1;
+    for (int v = 0; v < hist.num_bins; ++v) {
+        cumulative += hist.bins[v];
+        if (q1 < 0 && cumulative >= p25) q1 = v;
+        if (median < 0 && cumulative >= p50) median = v;
+        if (q3 < 0 && cumulative >= p75) {
+            q3 = v;
+            break;
+        }
+    }
+    if (q1 < 0) q1 = hist.num_bins;
+    if (q3 < 0) q3 = hist.num_bins;
+
+    const double iqr = static_cast<double>(q3 - q1);
+    const double lower_bound = q1 - iqr_multiplier * iqr;
+    const double upper_bound = q3 + iqr_multiplier * iqr;
+
+    // Accumulate inliers. Overflow values are >= num_bins, so they count only
+    // if num_bins itself falls within the rejection bounds, matching the
+    // baseline's treatment of the high tail as outliers.
+    uint64_t included_count = 0;
+    double weighted_sum = 0.0;
+    for (int v = 0; v < hist.num_bins; ++v) {
+        if (v < lower_bound || v > upper_bound) continue;
+        const uint64_t count = hist.bins[v];
+        included_count += count;
+        weighted_sum += static_cast<double>(v) * static_cast<double>(count);
+    }
+
+    if (included_count == 0) {
+        return result;  // every pixel rejected as an outlier (valid stays false)
+    }
+
+    result.mean = weighted_sum / static_cast<double>(included_count);
+    result.weighted_sum = weighted_sum;
+    result.valid = true;
+    return result;
+}
 
 /**
  * @brief Accumulates a histogram of background pixel values for a single

--- a/include/integrator/background.hpp
+++ b/include/integrator/background.hpp
@@ -216,7 +216,12 @@ class BackgroundAggregator {
     }
 
     void add(int x) {
-        if (x >= 0 && x < VECTOR_LIMIT) {
+        // Negatives are garbage pixels that slipped past the mask, not real
+        // background measurements, so they are dropped entirely.
+        if (x < 0) {
+            return;
+        }
+        if (x < VECTOR_LIMIT) {
             ++_small_hist[x];
         } else {
             if (!_large_hist) {

--- a/include/integrator/background.hpp
+++ b/include/integrator/background.hpp
@@ -9,6 +9,12 @@
  * for CUDA device code (GPU reduction kernel), so both paths produce identical
  * results. Background pixel values are integer counts, so a histogram with one
  * bin per integer value makes the quartile/IQR logic exact.
+ *
+ * This assumes a photon-counting detector, where raw pixel values are
+ * non-negative integer photon counts. The integer histogram and the dropping
+ * of negative values both depend on that assumption. Charge-integrating
+ * detectors (e.g. Jungfrau) produce non-integer pixel values that will 
+ * need a different background approach.
  */
 
 #pragma once

--- a/include/integrator/background.hpp
+++ b/include/integrator/background.hpp
@@ -37,6 +37,23 @@
  */
 enum class BackgroundModel : uint8_t { Constant, Glm };
 
+// Number of integer-valued bins in each per-reflection background histogram.
+// Single source of truth, shared by the GPU device histogram stride and the
+// host baseline adapter, so both paths bin identical pixel values and produce
+// identical estimates. bins cover pixel values [0, NUM_BG_BINS); values at or
+// above NUM_BG_BINS land in the per-reflection overflow tail. Chosen above the
+// realistic constant-background inlier range; device-memory cost is
+// num_reflections * NUM_BG_BINS * 4 bytes. If a reflection puts more than
+// kBackgroundMaxOverflowFraction of its background pixels in the overflow, the
+// range is too small to characterise that background and the estimate is
+// rejected (see tukey_constant_background), which the callers surface as an
+// error rather than silently degrading.
+constexpr int NUM_BG_BINS = 256;
+
+// Fraction of a reflection's background pixels allowed in the high-tail
+// overflow before the constant background estimate is rejected as untrustworthy.
+constexpr double kBackgroundMaxOverflowFraction = 0.25;
+
 /**
  * @brief Read-only view of a per-reflection background histogram.
  *
@@ -93,6 +110,16 @@ FFS_HD inline BackgroundResult tukey_constant_background(
     }
     if (N == 0) {
         return result;  // no background pixels, so no estimate (valid stays false)
+    }
+
+    // Too much of the background in the high-tail overflow means the histogram
+    // range (num_bins) is too small to characterise this reflection. The
+    // quartile and inlier estimate would silently diverge from a full-range
+    // computation, so reject it (valid stays false) and let the caller report
+    // the insufficient range.
+    if (static_cast<double>(hist.overflow_count)
+        > kBackgroundMaxOverflowFraction * static_cast<double>(N)) {
+        return result;
     }
 
     // Quantile positions (1-based counting convention, matching the baseline).

--- a/integrator/CMakeLists.txt
+++ b/integrator/CMakeLists.txt
@@ -8,6 +8,7 @@ add_executable(integrator
     integrator.cc
     integrator.cu
     kabsch.cu
+    background.cu
     ${CMAKE_SOURCE_DIR}/src/integrator/extent.cc
     ${CMAKE_SOURCE_DIR}/src/integrator/lp_correction.cc
     ${CMAKE_SOURCE_DIR}/src/integrator/coordinate_system.cc

--- a/integrator/background.cu
+++ b/integrator/background.cu
@@ -1,0 +1,99 @@
+/**
+ * @file background.cu
+ * @brief GPU per-reflection background reduction kernel.
+ *
+ * Reduces the per-reflection background histograms accumulated by the Kabsch
+ * kernel into background estimates, using the single-source model code in
+ * integrator/background.hpp so the result matches the baseline CPU path.
+ */
+
+#include <cuda_runtime.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <stdexcept>
+
+#include "cuda_common.hpp"
+#include "integrator.cuh"
+#include "integrator/background.cuh"
+#include "integrator/background.hpp"
+
+namespace {
+constexpr int BACKGROUND_REDUCE_THREADS = 128;
+}
+
+/**
+ * @brief One thread per reflection: evaluate the background model over that
+ *        reflection's histogram slice.
+ */
+__global__ void background_reduce_kernel(BackgroundModel model,
+                                         const uint32_t *d_background_hist,
+                                         const uint32_t *d_background_overflow,
+                                         size_t num_reflections,
+                                         double *d_background_mean,
+                                         double *d_background_sum_value,
+                                         uint32_t *d_background_count,
+                                         uint8_t *d_background_success) {
+    const size_t r = static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    if (r >= num_reflections) return;
+
+    ConstHistogramView view;
+    view.bins = d_background_hist + r * NUM_BG_BINS;
+    view.num_bins = NUM_BG_BINS;
+    view.overflow_count = d_background_overflow[r];
+
+    // Total background pixel count for this reflection (num_pixels.background).
+    uint32_t total = view.overflow_count;
+    for (int v = 0; v < NUM_BG_BINS; ++v) {
+        total += view.bins[v];
+    }
+    d_background_count[r] = total;
+
+    BackgroundResult res;
+    switch (model) {
+    case BackgroundModel::Constant:
+        res = tukey_constant_background(view);
+        break;
+    case BackgroundModel::Glm:
+        // Not yet implemented; fall back to the constant model so the pipeline
+        // still produces a usable estimate. GLM (robust Poisson IRLS) will read
+        // the same histogram view.
+        res = tukey_constant_background(view);
+        break;
+    }
+
+    d_background_mean[r] = res.mean;
+    d_background_sum_value[r] = res.weighted_sum;
+    d_background_success[r] = res.valid ? 1u : 0u;
+}
+
+void compute_background(BackgroundModel model,
+                        const uint32_t *d_background_hist,
+                        const uint32_t *d_background_overflow,
+                        size_t num_reflections,
+                        double *d_background_mean,
+                        double *d_background_sum_value,
+                        uint32_t *d_background_count,
+                        uint8_t *d_background_success,
+                        cudaStream_t stream) {
+    if (num_reflections == 0) return;
+
+    const unsigned int blocks = static_cast<unsigned int>(
+      (num_reflections + BACKGROUND_REDUCE_THREADS - 1) / BACKGROUND_REDUCE_THREADS);
+
+    background_reduce_kernel<<<blocks, BACKGROUND_REDUCE_THREADS, 0, stream>>>(
+      model,
+      d_background_hist,
+      d_background_overflow,
+      num_reflections,
+      d_background_mean,
+      d_background_sum_value,
+      d_background_count,
+      d_background_success);
+
+    cudaError_t err = cudaGetLastError();
+    if (err != cudaSuccess) {
+        throw std::runtime_error(fmt::format("Background reduction launch failed: {}",
+                                             cudaGetErrorString(err)));
+    }
+}

--- a/integrator/integrator.cc
+++ b/integrator/integrator.cc
@@ -1037,6 +1037,7 @@ int main(int argc, char **argv) {
     std::vector<double> backgrounds(num_reflections);  // b̄  (background mean per pixel)
     std::vector<double> background_sigmas(num_reflections);  // σ(b̄)
     size_t valid_reflections = 0;
+    size_t background_failures = 0;  // fg present but Tukey estimate rejected
 
     for (size_t i = 0; i < num_reflections; ++i) {
         uint32_t fg_count = h_foreground_count[i];
@@ -1054,8 +1055,15 @@ int main(int argc, char **argv) {
 
         double fg_sum = h_foreground_sum[i];
 
+        // Tally rejected estimates (no inlier pixels, or the IQR fence ran past
+        // the histogram range) purely for error reporting and logging; the
+        // reflection is marked unintegrated below regardless.
+        if (!h_background_success[i]) {
+            ++background_failures;
+        }
+
         // Background mean b̄ from the device-side Tukey/IQR reduction. When the
-        // estimate failed (no inlier pixels) the model contributes nothing.
+        // estimate failed the model contributes nothing.
         double bg_mean = h_background_success[i] ? h_background_mean[i] : 0.0;
 
         // Subtract background:  I = Σcᵢ(fg) − n_fg · b̄
@@ -1090,6 +1098,15 @@ int main(int argc, char **argv) {
     logger.info("Summation integration complete: {} valid reflections out of {}",
                 valid_reflections,
                 num_reflections);
+
+    if (background_failures > 0) {
+        logger.warn(
+          "Background estimate rejected for {} of {} reflections with "
+          "foreground pixels; NUM_BG_BINS may be too small for their "
+          "background level",
+          background_failures,
+          num_reflections);
+    }
 
     // Log some statistics
     if (valid_reflections > 0) {

--- a/integrator/integrator.cc
+++ b/integrator/integrator.cc
@@ -39,6 +39,8 @@
 #include "ffs_logger.hpp"
 #include "h5read.h"
 #include "integrator.cuh"
+#include "integrator/background.cuh"
+#include "integrator/background.hpp"
 #include "integrator/coordinate_system.hpp"
 #include "integrator/extent.hpp"
 #include "integrator/lp_correction.hpp"
@@ -58,6 +60,14 @@ static FGAlgorithm parse_fg_algorithm(const std::string &name) {
     if (name == "ellipsoid") return FGAlgorithm::Ellipsoid;
     if (name == "dials") return FGAlgorithm::Dials;
     throw std::runtime_error("Unknown foreground algorithm: " + name);
+}
+
+static BackgroundModel parse_background_model(const std::string &name) {
+    if (name == "constant" || name == "tukey") return BackgroundModel::Constant;
+    if (name == "glm") {
+        throw std::runtime_error("GLM background model not yet implemented");
+    }
+    throw std::runtime_error("Unknown background model: " + name);
 }
 
 using namespace std::chrono_literals;
@@ -177,6 +187,12 @@ class IntegratorArgumentParser : public CUDAArgumentParser {
           .help("Foreground algorithm choice - dials or ellipsoid.")
           .default_value<std::string>("ellipsoid");
 
+        add_argument("--background")
+          .help(
+            "Background model - constant (Tukey/IQR outlier rejection). "
+            "glm is not yet implemented.")
+          .default_value<std::string>("constant");
+
         add_argument("--min_zeta")
           .help(
             "Reflections close to the rotation axis, with a zeta below this threshold "
@@ -270,6 +286,10 @@ int main(int argc, char **argv) {
     std::string output_file = parser.get<std::string>("output");
     logger.info("Foreground algorithm: {}",
                 fg_algorithm == FGAlgorithm::Ellipsoid ? "ellipsoid" : "dials");
+
+    BackgroundModel background_model =
+      parse_background_model(parser.get<std::string>("background"));
+    logger.info("Background model: {}", parser.get<std::string>("background"));
 
 #pragma endregion Data preparation
 
@@ -641,8 +661,21 @@ int main(int argc, char **argv) {
     // These persist across all images and accumulate atomically
     DeviceBuffer<accumulator_t> d_foreground_sum(num_reflections);
     DeviceBuffer<uint32_t> d_foreground_count(num_reflections);
-    DeviceBuffer<accumulator_t> d_background_sum(num_reflections);
+    // Per-reflection background histogram: one bin per integer pixel value over
+    // [0, NUM_BG_BINS), plus an overflow counter for the high tail. The Kabsch
+    // kernel fills these; compute_background() reduces them into an estimate
+    // after the image loop.
+    DeviceBuffer<uint32_t> d_background_hist(num_reflections * NUM_BG_BINS);
+    DeviceBuffer<uint32_t> d_background_overflow(num_reflections);
+    logger.info("Background histograms: {} reflections x {} bins = {:.1f} MiB",
+                num_reflections,
+                NUM_BG_BINS,
+                (num_reflections * NUM_BG_BINS * sizeof(uint32_t)) / (1024.0 * 1024.0));
+    // Reduced background estimates (written by compute_background()).
+    DeviceBuffer<double> d_background_mean(num_reflections);
+    DeviceBuffer<double> d_background_sum_value(num_reflections);
     DeviceBuffer<uint32_t> d_background_count(num_reflections);
+    DeviceBuffer<uint8_t> d_background_success(num_reflections);
     // COM (intensity * coord) accumulators. Baseline uses Vector3d (double) for
     // these, but we use unsigned long long so we can use the hardware-fast
     // integer atomicAdd; double atomicAdd is slower and requires sm_60+. To
@@ -660,8 +693,9 @@ int main(int argc, char **argv) {
 
     cudaMemset(d_foreground_sum.data(), 0, num_reflections * sizeof(accumulator_t));
     cudaMemset(d_foreground_count.data(), 0, num_reflections * sizeof(uint32_t));
-    cudaMemset(d_background_sum.data(), 0, num_reflections * sizeof(accumulator_t));
-    cudaMemset(d_background_count.data(), 0, num_reflections * sizeof(uint32_t));
+    cudaMemset(
+      d_background_hist.data(), 0, num_reflections * NUM_BG_BINS * sizeof(uint32_t));
+    cudaMemset(d_background_overflow.data(), 0, num_reflections * sizeof(uint32_t));
     cudaMemset(
       d_intensity_times_x.data(), 0, num_reflections * sizeof(unsigned long long));
     cudaMemset(
@@ -834,8 +868,8 @@ int main(int argc, char **argv) {
                                          fg_algorithm,
                                          d_foreground_sum.data(),
                                          d_foreground_count.data(),
-                                         d_background_sum.data(),
-                                         d_background_count.data(),
+                                         d_background_hist.data(),
+                                         d_background_overflow.data(),
                                          d_intensity_times_x.data(),
                                          d_intensity_times_y.data(),
                                          d_intensity_times_z.data(),
@@ -870,6 +904,32 @@ int main(int argc, char **argv) {
         logger.info("Total time waiting for images: {:.2f} s", time_waiting_for_images);
     }
 
+#pragma region Background Reduction
+    // The reader threads have joined, which destroyed their per-thread streams,
+    // but cudaStreamDestroy does not wait for queued work, so the accumulation
+    // kernels may still be in flight. Synchronise the whole device before the
+    // reduction reads the histograms those kernels filled.
+    // Perhaps better to have each thread synchronize its stream before joining,
+    // this is simper for now, but worth testing during profiling.
+    cudaDeviceSynchronize();
+    cuda_throw_error();
+
+    // Reduce each reflection's background histogram into an estimate on the
+    // device (Tukey/IQR constant model), then copy the small results back.
+    logger.info("Reducing background histograms for {} reflections", num_reflections);
+    compute_background(background_model,
+                       d_background_hist.data(),
+                       d_background_overflow.data(),
+                       num_reflections,
+                       d_background_mean.data(),
+                       d_background_sum_value.data(),
+                       d_background_count.data(),
+                       d_background_success.data(),
+                       0);
+    cudaDeviceSynchronize();
+    cuda_throw_error();
+#pragma endregion Background Reduction
+
 #pragma region Summation Integration Finalization
     // Host-side reduction and finalization
     // Copy accumulator buffers back from GPU and compute final intensities
@@ -878,8 +938,10 @@ int main(int argc, char **argv) {
     // Allocate host buffers for results
     std::vector<accumulator_t> h_foreground_sum(num_reflections);
     std::vector<uint32_t> h_foreground_count(num_reflections);
-    std::vector<accumulator_t> h_background_sum(num_reflections);
+    std::vector<double> h_background_mean(num_reflections);
+    std::vector<double> h_background_sum_value(num_reflections);
     std::vector<uint32_t> h_background_count(num_reflections);
+    std::vector<uint8_t> h_background_success(num_reflections);
     std::vector<unsigned long long> h_intensity_times_x(num_reflections);
     std::vector<unsigned long long> h_intensity_times_y(num_reflections);
     std::vector<unsigned long long> h_intensity_times_z(num_reflections);
@@ -888,8 +950,10 @@ int main(int argc, char **argv) {
     // Copy results from device to host
     d_foreground_sum.extract(h_foreground_sum.data());
     d_foreground_count.extract(h_foreground_count.data());
-    d_background_sum.extract(h_background_sum.data());
+    d_background_mean.extract(h_background_mean.data());
+    d_background_sum_value.extract(h_background_sum_value.data());
     d_background_count.extract(h_background_count.data());
+    d_background_success.extract(h_background_success.data());
     d_intensity_times_x.extract(h_intensity_times_x.data());
     d_intensity_times_y.extract(h_intensity_times_y.data());
     d_intensity_times_z.extract(h_intensity_times_z.data());
@@ -919,8 +983,9 @@ int main(int argc, char **argv) {
 
         double fg_sum = h_foreground_sum[i];
 
-        // Background mean b̄ (simple mean for now
-        double bg_mean = (bg_count > 0) ? h_background_sum[i] / bg_count : 0.0;
+        // Background mean b̄ from the device-side Tukey/IQR reduction. When the
+        // estimate failed (no inlier pixels) the model contributes nothing.
+        double bg_mean = h_background_success[i] ? h_background_mean[i] : 0.0;
 
         // Subtract background:  I = Σcᵢ(fg) − n_fg · b̄
         double background_total = bg_mean * fg_count;
@@ -1015,14 +1080,15 @@ int main(int argc, char **argv) {
     for (size_t i = 0; i < num_reflections; ++i) {
         nfg_out[i] = static_cast<int>(h_foreground_count[i]);
         nbg_out[i] = static_cast<int>(h_background_count[i]);
-        bg_sum_out[i] = static_cast<double>(h_background_sum[i]);
-        bg_mean_out[i] = (h_background_count[i] > 0)
-                           ? static_cast<double>(h_background_sum[i])
-                               / static_cast<double>(h_background_count[i])
-                           : 0.0;
+        // background.sum.value is the Tukey inlier weighted sum; background.mean
+        // is the inlier mean. Both come from the device reduction.
+        bg_sum_out[i] = h_background_success[i] ? h_background_sum_value[i] : 0.0;
+        bg_mean_out[i] = h_background_success[i] ? h_background_mean[i] : 0.0;
 
-        // Success: kernel-flagged AND fg_count > 0 AND not dont_integrated.
-        bool ok = h_success[i] && (h_foreground_count[i] > 0) && !dont_integrate[i];
+        // Success: kernel-flagged AND fg_count > 0 AND a valid background
+        // estimate AND not dont_integrated.
+        bool ok = h_success[i] && (h_foreground_count[i] > 0) && h_background_success[i]
+                  && !dont_integrate[i];
         success_final[i] = ok ? 1 : 0;
 
         // Centre-of-mass: kernel accumulated intensity·(2k+1), so divide by 2·I.

--- a/integrator/integrator.cc
+++ b/integrator/integrator.cc
@@ -971,6 +971,7 @@ int main(int argc, char **argv) {
     std::vector<double> h_background_mean(num_reflections);
     std::vector<double> h_background_sum_value(num_reflections);
     std::vector<uint32_t> h_background_count(num_reflections);
+    std::vector<uint32_t> h_background_overflow(num_reflections);
     std::vector<uint8_t> h_background_success(num_reflections);
     std::vector<unsigned long long> h_intensity_times_x(num_reflections);
     std::vector<unsigned long long> h_intensity_times_y(num_reflections);
@@ -983,11 +984,43 @@ int main(int argc, char **argv) {
     d_background_mean.extract(h_background_mean.data());
     d_background_sum_value.extract(h_background_sum_value.data());
     d_background_count.extract(h_background_count.data());
+    d_background_overflow.extract(h_background_overflow.data());
     d_background_success.extract(h_background_success.data());
     d_intensity_times_x.extract(h_intensity_times_x.data());
     d_intensity_times_y.extract(h_intensity_times_y.data());
     d_intensity_times_z.extract(h_intensity_times_z.data());
     d_success.extract(h_success.data());
+
+    // The background histogram only covers pixel values [0, NUM_BG_BINS). If a
+    // reflection pushes more than kBackgroundMaxOverflowFraction of its
+    // background pixels into the overflow tail, that range is too small to
+    // characterise its background and the device Tukey estimate diverges from a
+    // full-range computation. Fail loudly so the histogram range is raised
+    // rather than silently producing a degraded intensity.
+    {
+        size_t overflowing = 0;
+        double worst_fraction = 0.0;
+        for (size_t i = 0; i < num_reflections; ++i) {
+            const uint32_t total = h_background_count[i];
+            if (total == 0) continue;
+            const double fraction = static_cast<double>(h_background_overflow[i])
+                                    / static_cast<double>(total);
+            if (fraction > kBackgroundMaxOverflowFraction) {
+                overflowing++;
+                worst_fraction = std::max(worst_fraction, fraction);
+            }
+        }
+        if (overflowing > 0) {
+            throw std::runtime_error(fmt::format(
+              "{} reflection(s) put more than {:.0f}% of their background pixels "
+              "above NUM_BG_BINS={} (worst {:.1f}%); the background histogram "
+              "range is too small. Increase NUM_BG_BINS.",
+              overflowing,
+              kBackgroundMaxOverflowFraction * 100.0,
+              NUM_BG_BINS,
+              worst_fraction * 100.0));
+        }
+    }
 
     // Compute final intensities for each reflection
     std::vector<double> intensities(num_reflections);

--- a/integrator/integrator.cc
+++ b/integrator/integrator.cc
@@ -563,8 +563,16 @@ int main(int argc, char **argv) {
     }
     logger.info("Running with {} CPU threads", num_cpu_threads);
 
-    // Set up image reader
-    const auto images_file = parser.images();
+    // Set up image reader. When no images are given, fall back to the
+    // image file recorded in the experiment
+    auto images_file = parser.images();
+    if (images_file.empty()) {
+        images_file = expt.imagesequence().filename();
+        if (!images_file.empty()) {
+            logger.info("No --images given; using image file from the experiment: {}",
+                        images_file);
+        }
+    }
     std::unique_ptr<Reader> reader_ptr;
 
     if (std::filesystem::is_directory(images_file)) {

--- a/integrator/integrator.cuh
+++ b/integrator/integrator.cuh
@@ -12,6 +12,13 @@
 
 enum class FGAlgorithm : uint8_t { Ellipsoid, Dials };
 
+// Number of integer-valued bins in each per-reflection background histogram.
+// bins cover pixel values [0, NUM_BG_BINS); values >= NUM_BG_BINS land in a
+// per-reflection overflow counter (the high tail). Chosen above the realistic
+// inlier range so the constant (Tukey) model rejects everything in the
+// overflow. Device-memory cost is num_reflections * NUM_BG_BINS * 4 bytes.
+constexpr int NUM_BG_BINS = 256;
+
 struct DetectorParameters {
     scalar_t pixel_size[2];       // pixel pitch [fast, slow] in mm
     bool parallax_correction;     // whether to apply parallax correction

--- a/integrator/integrator.cuh
+++ b/integrator/integrator.cuh
@@ -7,17 +7,11 @@
 #include <cstdint>
 #include <dx2/detector.hpp>
 
+#include "integrator/background.hpp"  // NUM_BG_BINS (shared host/device constant)
 #include "math/device_precision.cuh"
 #include "math/vector3d.cuh"
 
 enum class FGAlgorithm : uint8_t { Ellipsoid, Dials };
-
-// Number of integer-valued bins in each per-reflection background histogram.
-// bins cover pixel values [0, NUM_BG_BINS); values >= NUM_BG_BINS land in a
-// per-reflection overflow counter (the high tail). Chosen above the realistic
-// inlier range so the constant (Tukey) model rejects everything in the
-// overflow. Device-memory cost is num_reflections * NUM_BG_BINS * 4 bytes.
-constexpr int NUM_BG_BINS = 256;
 
 struct DetectorParameters {
     scalar_t pixel_size[2];       // pixel pitch [fast, slow] in mm

--- a/integrator/kabsch.cu
+++ b/integrator/kabsch.cu
@@ -561,15 +561,17 @@ __global__ void kabsch_transform(pixel_t *d_image,
                 // image; masked or out-of-image background is dropped. Each
                 // pixel value increments one bin of this reflection's
                 // histogram (one bin per integer count). Values at or above
-                // NUM_BG_BINS go to the overflow tail; rare negatives (sentinel
-                // values not caught by the mask) are clamped into bin 0.
+                // NUM_BG_BINS go to the overflow tail. A negative value is a
+                // sentinel/garbage pixel that slipped past the mask (reachable
+                // only when pixel_t is 32-bit and the value exceeds INT_MAX);
+                // it is not a real background measurement, so it is dropped
+                // rather than counted.
                 if (pixel_in_image
                     && d_mask[static_cast<size_t>(gy) * width + gx] != 0) {
-                    int bin = static_cast<int>(image(gx, gy));
-                    if (bin < 0) bin = 0;
-                    if (bin < NUM_BG_BINS) {
+                    const int bin = static_cast<int>(image(gx, gy));
+                    if (bin >= 0 && bin < NUM_BG_BINS) {
                         atomicAdd(&d_background_hist[refl_idx * NUM_BG_BINS + bin], 1u);
-                    } else {
+                    } else if (bin >= NUM_BG_BINS) {
                         atomicAdd(&d_background_overflow[refl_idx], 1u);
                     }
                 }

--- a/integrator/kabsch.cu
+++ b/integrator/kabsch.cu
@@ -290,8 +290,8 @@ __device__ __forceinline__ void px_to_mm(int gx,
  * @param delta_m Foreground extent in e₃ direction (n_sigma × σ_M)
  * @param d_foreground_sum Output: accumulated foreground intensities per reflection
  * @param d_foreground_count Output: foreground pixel counts per reflection
- * @param d_background_sum Output: accumulated background intensities per reflection
- * @param d_background_count Output: background pixel counts per reflection
+ * @param d_background_hist Output: per-reflection background histogram (num_reflections*NUM_BG_BINS bins, one per integer value)
+ * @param d_background_overflow Output: per-reflection count of background pixels with value >= NUM_BG_BINS
  * @param d_intensity_times_x Output: intensity·(2gx+1) per reflection (centre-of-mass)
  * @param d_intensity_times_y Output: intensity·(2gy+1) per reflection (centre-of-mass)
  * @param d_intensity_times_z Output: intensity·(2z+1) per reflection (centre-of-mass)
@@ -325,8 +325,8 @@ __global__ void kabsch_transform(pixel_t *d_image,
                                  // Output accumulators (atomically updated)
                                  accumulator_t *d_foreground_sum,
                                  uint32_t *d_foreground_count,
-                                 accumulator_t *d_background_sum,
-                                 uint32_t *d_background_count,
+                                 uint32_t *d_background_hist,
+                                 uint32_t *d_background_overflow,
                                  unsigned long long *d_intensity_times_x,
                                  unsigned long long *d_intensity_times_y,
                                  unsigned long long *d_intensity_times_z,
@@ -558,13 +558,20 @@ __global__ void kabsch_transform(pixel_t *d_image,
                 }
             } else {
                 // Background is counted only for unmasked pixels inside the
-                // image; masked or out-of-image background is dropped.
+                // image; masked or out-of-image background is dropped. Each
+                // pixel value increments one bin of this reflection's
+                // histogram (one bin per integer count). Values at or above
+                // NUM_BG_BINS go to the overflow tail; rare negatives (sentinel
+                // values not caught by the mask) are clamped into bin 0.
                 if (pixel_in_image
                     && d_mask[static_cast<size_t>(gy) * width + gx] != 0) {
-                    const accumulator_t pixel_value =
-                      static_cast<accumulator_t>(image(gx, gy));
-                    atomicAdd(&d_background_sum[refl_idx], pixel_value);
-                    atomicAdd(&d_background_count[refl_idx], 1u);
+                    int bin = static_cast<int>(image(gx, gy));
+                    if (bin < 0) bin = 0;
+                    if (bin < NUM_BG_BINS) {
+                        atomicAdd(&d_background_hist[refl_idx * NUM_BG_BINS + bin], 1u);
+                    } else {
+                        atomicAdd(&d_background_overflow[refl_idx], 1u);
+                    }
                 }
             }
         }
@@ -609,8 +616,8 @@ void compute_kabsch_transform(pixel_t *d_image,
                               FGAlgorithm algorithm,
                               accumulator_t *d_foreground_sum,
                               uint32_t *d_foreground_count,
-                              accumulator_t *d_background_sum,
-                              uint32_t *d_background_count,
+                              uint32_t *d_background_hist,
+                              uint32_t *d_background_overflow,
                               unsigned long long *d_intensity_times_x,
                               unsigned long long *d_intensity_times_y,
                               unsigned long long *d_intensity_times_z,
@@ -675,8 +682,8 @@ void compute_kabsch_transform(pixel_t *d_image,
                                              delta_m,
                                              d_foreground_sum,
                                              d_foreground_count,
-                                             d_background_sum,
-                                             d_background_count,
+                                             d_background_hist,
+                                             d_background_overflow,
                                              d_intensity_times_x,
                                              d_intensity_times_y,
                                              d_intensity_times_z,

--- a/integrator/kabsch.cuh
+++ b/integrator/kabsch.cuh
@@ -66,8 +66,8 @@
  * @param delta_m Foreground extent in e₃ direction (n_sigma × σ_M), radians
  * @param d_foreground_sum Device array to accumulate foreground intensities per reflection
  * @param d_foreground_count Device array to count foreground pixels per reflection
- * @param d_background_sum Device array to accumulate background intensities per reflection
- * @param d_background_count Device array to count background pixels per reflection
+ * @param d_background_hist Device per-reflection background histogram, num_reflections*NUM_BG_BINS bins (one per integer pixel value)
+ * @param d_background_overflow Device per-reflection count of background pixels with value >= NUM_BG_BINS (high tail)
  * @param d_intensity_times_x Device array accumulating intensity·(2gx+1) per reflection (centre-of-mass)
  * @param d_intensity_times_y Device array accumulating intensity·(2gy+1) per reflection (centre-of-mass)
  * @param d_intensity_times_z Device array accumulating intensity·(2z+1) per reflection (centre-of-mass)
@@ -102,8 +102,8 @@ void compute_kabsch_transform(pixel_t *d_image,
                               FGAlgorithm algorithm,
                               accumulator_t *d_foreground_sum,
                               uint32_t *d_foreground_count,
-                              accumulator_t *d_background_sum,
-                              uint32_t *d_background_count,
+                              uint32_t *d_background_hist,
+                              uint32_t *d_background_overflow,
                               unsigned long long *d_intensity_times_x,
                               unsigned long long *d_intensity_times_y,
                               unsigned long long *d_intensity_times_z,

--- a/integrator/tests/CMakeLists.txt
+++ b/integrator/tests/CMakeLists.txt
@@ -11,7 +11,7 @@ target_link_libraries(test_extent PRIVATE
     nlohmann_json::nlohmann_json
 )
 
-add_executable(test_background test_background.cc)
+add_executable(test_background test_background.cc ${CMAKE_SOURCE_DIR}/src/integrator/background.cc)
 target_include_directories(test_background PRIVATE ${CMAKE_SOURCE_DIR}/include)
 target_link_libraries(test_background PRIVATE
     GTest::gtest_main

--- a/integrator/tests/CMakeLists.txt
+++ b/integrator/tests/CMakeLists.txt
@@ -11,8 +11,14 @@ target_link_libraries(test_extent PRIVATE
     nlohmann_json::nlohmann_json
 )
 
-add_executable(test_kabsch test_kabsch.cc ../kabsch.cu ${CMAKE_SOURCE_DIR}/src/integrator/extent.cc)
-set_source_files_properties(../kabsch.cu PROPERTIES LANGUAGE CUDA)
+add_executable(test_background test_background.cc)
+target_include_directories(test_background PRIVATE ${CMAKE_SOURCE_DIR}/include)
+target_link_libraries(test_background PRIVATE
+    GTest::gtest_main
+)
+
+add_executable(test_kabsch test_kabsch.cc ../kabsch.cu ../background.cu ${CMAKE_SOURCE_DIR}/src/integrator/extent.cc)
+set_source_files_properties(../kabsch.cu ../background.cu PROPERTIES LANGUAGE CUDA)
 target_include_directories(test_kabsch PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/..
 )
@@ -30,4 +36,5 @@ target_link_libraries(test_kabsch PRIVATE
 set_property(TARGET test_kabsch PROPERTY CUDA_SEPARABLE_COMPILATION ON)
 
 gtest_discover_tests(test_extent PROPERTIES LABELS "integrator-tests")
+gtest_discover_tests(test_background PROPERTIES LABELS "integrator-tests")
 gtest_discover_tests(test_kabsch PROPERTIES LABELS "integrator-tests")

--- a/integrator/tests/baseline_references.md
+++ b/integrator/tests/baseline_references.md
@@ -13,7 +13,7 @@ The test is skipped if the directory is missing.
 |------|----------|
 | `integrated_1_10.refl` | predictions: `s1`, `xyzcal.mm`, `bbox`, `miller_index` |
 | `indexed_1_10.expt` | beam, detector panel, goniometer, scan |
-| `baseline_<algo>_1_10.refl` | reference `num_pixels.foreground` / `.background` |
+| `baseline_<algo>_1_10.refl` | reference `num_pixels.foreground` / `.background`, `intensity.sum.value`, `background.mean` / `.sum.value` |
 
 The baseline references are generated. Regenerate them whenever the baseline algorithm, its parameters, or the input data change. `$FFS_KABSCH_BASELINE_REFERENCE` overrides the reference path.
 

--- a/integrator/tests/test_background.cc
+++ b/integrator/tests/test_background.cc
@@ -1,0 +1,82 @@
+/**
+ * @file test_background.cc
+ * @brief Host unit tests for the single-source constant (Tukey/IQR) background
+ *        model in integrator/background.hpp.
+ *
+ * These exercise tukey_constant_background() directly over hand-built
+ * histograms with known quartiles and outliers, independent of CUDA. The same
+ * function is compiled for the device, so locking its behaviour here also pins
+ * the GPU reduction's result.
+ */
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <vector>
+
+#include "integrator/background.hpp"
+
+namespace {
+
+// Build a ConstHistogramView over a caller-owned bins vector.
+ConstHistogramView view_of(const std::vector<uint32_t> &bins, uint32_t overflow = 0) {
+    return ConstHistogramView{bins.data(), static_cast<int>(bins.size()), overflow};
+}
+
+}  // namespace
+
+// Empty histogram -> no estimate.
+TEST(TukeyConstantBackground, EmptyHistogramFails) {
+    std::vector<uint32_t> bins(16, 0);
+    BackgroundResult r = tukey_constant_background(view_of(bins));
+    EXPECT_FALSE(r.valid);
+}
+
+// Uniform spread 0..9 (one pixel each). No outliers: mean is the plain mean.
+TEST(TukeyConstantBackground, UniformNoOutliers) {
+    std::vector<uint32_t> bins(64, 0);
+    for (int v = 0; v <= 9; ++v) bins[v] = 1;  // N = 10
+
+    BackgroundResult r = tukey_constant_background(view_of(bins));
+    ASSERT_TRUE(r.valid);
+    // q1=2, q3=6, IQR=4 -> bounds [-4, 12]; all of 0..9 survive.
+    EXPECT_DOUBLE_EQ(r.weighted_sum, 45.0);
+    EXPECT_DOUBLE_EQ(r.mean, 4.5);
+}
+
+// A single extreme value in the overflow tail must be rejected and must not
+// perturb the mean of the inliers.
+TEST(TukeyConstantBackground, HighOutlierInOverflowRejected) {
+    std::vector<uint32_t> bins(64, 0);
+    for (int v = 0; v <= 9; ++v) bins[v] = 1;
+    const uint32_t overflow = 1;  // one pixel with value >= num_bins (e.g. 5000)
+
+    BackgroundResult r = tukey_constant_background(view_of(bins, overflow));
+    ASSERT_TRUE(r.valid);
+    // Inliers remain 0..9; the overflow pixel is above the upper bound.
+    EXPECT_DOUBLE_EQ(r.weighted_sum, 45.0);
+    EXPECT_DOUBLE_EQ(r.mean, 4.5);
+}
+
+// A high outlier inside the binned range (not overflow) is also rejected.
+TEST(TukeyConstantBackground, HighOutlierInBinsRejected) {
+    std::vector<uint32_t> bins(64, 0);
+    for (int v = 0; v <= 9; ++v) bins[v] = 1;
+    bins[60] = 1;  // clear outlier well above q3 + 1.5*IQR
+
+    BackgroundResult r = tukey_constant_background(view_of(bins));
+    ASSERT_TRUE(r.valid);
+    EXPECT_DOUBLE_EQ(r.weighted_sum, 45.0);
+    EXPECT_DOUBLE_EQ(r.mean, 4.5);
+}
+
+// Degenerate: every pixel has the same value -> IQR 0, mean equals that value.
+TEST(TukeyConstantBackground, ConstantValue) {
+    std::vector<uint32_t> bins(64, 0);
+    bins[5] = 20;  // N = 20, all value 5
+
+    BackgroundResult r = tukey_constant_background(view_of(bins));
+    ASSERT_TRUE(r.valid);
+    EXPECT_DOUBLE_EQ(r.mean, 5.0);
+    EXPECT_DOUBLE_EQ(r.weighted_sum, 100.0);
+}

--- a/integrator/tests/test_background.cc
+++ b/integrator/tests/test_background.cc
@@ -70,6 +70,17 @@ TEST(TukeyConstantBackground, HighOutlierInBinsRejected) {
     EXPECT_DOUBLE_EQ(r.mean, 4.5);
 }
 
+// A spread wide enough that the upper fence q3 + 1.5*IQR reaches num_bins is
+// rejected, even with an empty overflow tail: the range is too small to apply
+// Tukey rejection, so the estimate is untrustworthy.
+TEST(TukeyConstantBackground, UpperFenceReachingOverflowRejected) {
+    std::vector<uint32_t> bins(16, 1);  // N = 16, uniform 0..15, no overflow
+
+    BackgroundResult r = tukey_constant_background(view_of(bins));
+    // q1=3, q3=11, IQR=8 -> upper_bound = 23 >= num_bins (16).
+    EXPECT_FALSE(r.valid);
+}
+
 // Degenerate: every pixel has the same value -> IQR 0, mean equals that value.
 TEST(TukeyConstantBackground, ConstantValue) {
     std::vector<uint32_t> bins(64, 0);

--- a/integrator/tests/test_background.cc
+++ b/integrator/tests/test_background.cc
@@ -120,25 +120,27 @@ TEST(ConstantBackgroundImplComparison, AgreeOnCleanLowValues) {
     EXPECT_DOUBLE_EQ(shared_sum, dials_sum);
 }
 
-// Negative sentinel pixels are counted by the dials-like baseline (and pulled
-// into the inlier mean here) but dropped by the shared core, so the two
-// diverge. This is exactly the true-to-dials behaviour the baseline keeps.
-TEST(ConstantBackgroundImplComparison, NegativesCountedByDialsDroppedByShared) {
+// Negative values are garbage pixels that slipped past the mask, not real
+// background measurements. The aggregator drops them at the source, so both the
+// dials-like baseline and the shared core see only the 100 clean pixels and
+// agree on the estimate.
+TEST(ConstantBackgroundImplComparison, NegativesDroppedBeforeEstimation) {
     BackgroundAggregator agg;
     for (int v = 0; v <= 9; ++v) add_n(agg, v, 10);  // 100 low pixels
-    add_n(agg, -1, 4);                               // 4 negative sentinels
+    add_n(agg, -1, 4);                               // 4 negatives, dropped
+
+    EXPECT_EQ(agg.num_pixels(), 100);
 
     auto [dials_mean, dials_sum] =
       compute_background_constant_3d(agg, ConstantBackgroundImpl::DialsIndependent);
     auto [shared_mean, shared_sum] =
       compute_background_constant_3d(agg, ConstantBackgroundImpl::SharedCore);
 
-    // Dials counts the four -1 pixels as inliers: sum 450 - 4 over 104 pixels.
-    EXPECT_DOUBLE_EQ(dials_sum, 446.0);
-    EXPECT_DOUBLE_EQ(dials_mean, 446.0 / 104.0);
-    // Shared drops the sentinels: sum 450 over 100 pixels.
-    EXPECT_DOUBLE_EQ(shared_sum, 450.0);
-    EXPECT_DOUBLE_EQ(shared_mean, 4.5);
+    // Both see sum 450 over the 100 retained pixels.
+    EXPECT_DOUBLE_EQ(dials_sum, 450.0);
+    EXPECT_DOUBLE_EQ(dials_mean, 4.5);
+    EXPECT_DOUBLE_EQ(shared_sum, dials_sum);
+    EXPECT_DOUBLE_EQ(shared_mean, dials_mean);
 }
 
 // A large fraction of pixels above NUM_BG_BINS overflows the shared core's

--- a/integrator/tests/test_background.cc
+++ b/integrator/tests/test_background.cc
@@ -11,7 +11,9 @@
 
 #include <gtest/gtest.h>
 
+#include <cmath>
 #include <cstdint>
+#include <stdexcept>
 #include <vector>
 
 #include "integrator/background.hpp"
@@ -90,4 +92,85 @@ TEST(TukeyConstantBackground, ConstantValue) {
     ASSERT_TRUE(r.valid);
     EXPECT_DOUBLE_EQ(r.mean, 5.0);
     EXPECT_DOUBLE_EQ(r.weighted_sum, 100.0);
+}
+
+namespace {
+
+// Add a value to a BackgroundAggregator a given number of times.
+void add_n(BackgroundAggregator &agg, int value, int times) {
+    for (int i = 0; i < times; ++i) agg.add(value);
+}
+
+}  // namespace
+
+// With only low, outlier-free values, the independent dials-like baseline and
+// the shared core agree exactly.
+TEST(ConstantBackgroundImplComparison, AgreeOnCleanLowValues) {
+    BackgroundAggregator agg;
+    for (int v = 0; v <= 9; ++v) agg.add(v);  // N = 10, one pixel each
+
+    auto [dials_mean, dials_sum] =
+      compute_background_constant_3d(agg, ConstantBackgroundImpl::DialsIndependent);
+    auto [shared_mean, shared_sum] =
+      compute_background_constant_3d(agg, ConstantBackgroundImpl::SharedCore);
+
+    EXPECT_DOUBLE_EQ(dials_mean, 4.5);
+    EXPECT_DOUBLE_EQ(dials_sum, 45.0);
+    EXPECT_DOUBLE_EQ(shared_mean, dials_mean);
+    EXPECT_DOUBLE_EQ(shared_sum, dials_sum);
+}
+
+// Negative sentinel pixels are counted by the dials-like baseline (and pulled
+// into the inlier mean here) but dropped by the shared core, so the two
+// diverge. This is exactly the true-to-dials behaviour the baseline keeps.
+TEST(ConstantBackgroundImplComparison, NegativesCountedByDialsDroppedByShared) {
+    BackgroundAggregator agg;
+    for (int v = 0; v <= 9; ++v) add_n(agg, v, 10);  // 100 low pixels
+    add_n(agg, -1, 4);                               // 4 negative sentinels
+
+    auto [dials_mean, dials_sum] =
+      compute_background_constant_3d(agg, ConstantBackgroundImpl::DialsIndependent);
+    auto [shared_mean, shared_sum] =
+      compute_background_constant_3d(agg, ConstantBackgroundImpl::SharedCore);
+
+    // Dials counts the four -1 pixels as inliers: sum 450 - 4 over 104 pixels.
+    EXPECT_DOUBLE_EQ(dials_sum, 446.0);
+    EXPECT_DOUBLE_EQ(dials_mean, 446.0 / 104.0);
+    // Shared drops the sentinels: sum 450 over 100 pixels.
+    EXPECT_DOUBLE_EQ(shared_sum, 450.0);
+    EXPECT_DOUBLE_EQ(shared_mean, 4.5);
+}
+
+// A large fraction of pixels above NUM_BG_BINS overflows the shared core's
+// bounded histogram, which it rejects; the unbounded dials-like baseline still
+// produces an estimate from the full range.
+TEST(ConstantBackgroundImplComparison, HighOverflowRejectedOnlyByShared) {
+    BackgroundAggregator agg;
+    for (int v = 0; v <= 9; ++v) agg.add(v);  // 10 low pixels
+    add_n(agg, 5000, 10);                     // 10 pixels above NUM_BG_BINS
+
+    // Shared core: overflow fraction (50%) exceeds the permitted limit.
+    EXPECT_THROW(
+      compute_background_constant_3d(agg, ConstantBackgroundImpl::SharedCore),
+      std::runtime_error);
+
+    // Dials-like baseline: unbounded, so it still returns an estimate.
+    auto [dials_mean, dials_sum] =
+      compute_background_constant_3d(agg, ConstantBackgroundImpl::DialsIndependent);
+    EXPECT_GT(dials_sum, 0.0);
+    EXPECT_TRUE(std::isfinite(dials_mean));
+}
+
+// The default implementation is the independent dials-like baseline.
+TEST(ConstantBackgroundImplComparison, DefaultIsDialsIndependent) {
+    BackgroundAggregator agg;
+    for (int v = 0; v <= 9; ++v) add_n(agg, v, 10);
+    add_n(agg, -1, 4);
+
+    auto [default_mean, default_sum] = compute_background_constant_3d(agg);
+    auto [dials_mean, dials_sum] =
+      compute_background_constant_3d(agg, ConstantBackgroundImpl::DialsIndependent);
+
+    EXPECT_DOUBLE_EQ(default_mean, dials_mean);
+    EXPECT_DOUBLE_EQ(default_sum, dials_sum);
 }

--- a/integrator/tests/test_kabsch.cc
+++ b/integrator/tests/test_kabsch.cc
@@ -57,6 +57,8 @@
 #include "cuda_common.hpp"
 #include "h5read.h"
 #include "integrator.cuh"
+#include "integrator/background.cuh"
+#include "integrator/background.hpp"
 #include "integrator/extent.hpp"
 #include "kabsch.cuh"
 #include "math/math_utils.cuh"
@@ -97,6 +99,27 @@ struct KabschInputs {
     std::vector<scalar_t> phi_vals;
     std::vector<BoundingBoxExtents> bboxes;
 };
+
+/// Recover per-reflection background pixel counts from the device histogram +
+/// overflow buffers (sum of all bins plus the high-tail overflow). The kernel
+/// no longer keeps a running background count; it is derived here.
+static std::vector<uint32_t> background_counts(const DeviceBuffer<uint32_t> &d_hist,
+                                               const DeviceBuffer<uint32_t> &d_overflow,
+                                               size_t num_reflections) {
+    std::vector<uint32_t> hist(num_reflections * NUM_BG_BINS);
+    std::vector<uint32_t> overflow(num_reflections);
+    d_hist.extract(hist.data());
+    d_overflow.extract(overflow.data());
+    std::vector<uint32_t> counts(num_reflections);
+    for (size_t r = 0; r < num_reflections; ++r) {
+        uint32_t total = overflow[r];
+        for (int v = 0; v < NUM_BG_BINS; ++v) {
+            total += hist[r * NUM_BG_BINS + v];
+        }
+        counts[r] = total;
+    }
+    return counts;
+}
 
 /// Parse indexed_1_10.expt + integrated_1_10.refl into kernel-facing inputs.
 static KabschInputs loadKabschInputs(const fs::path &data_dir) {
@@ -265,8 +288,10 @@ void KabschTransformTest::RunPixelCountComparison(FGAlgorithm algo) {
     // Per-reflection accumulators (sums are unchecked; image is zero)
     DeviceBuffer<accumulator_t> d_fg_sum(num_reflections);
     DeviceBuffer<uint32_t> d_fg_count(num_reflections);
-    DeviceBuffer<accumulator_t> d_bg_sum(num_reflections);
-    DeviceBuffer<uint32_t> d_bg_count(num_reflections);
+    // Background histogram (one bin per integer value) + overflow tail. The
+    // background pixel count is recovered by summing these on the host.
+    DeviceBuffer<uint32_t> d_bg_hist(num_reflections * NUM_BG_BINS);
+    DeviceBuffer<uint32_t> d_bg_overflow(num_reflections);
     // Centre-of-mass accumulators: kernel writes unconditionally when any
     // foreground pixel is found, so valid device memory is required even
     // though this test only inspects the fg/bg pixel counts.
@@ -275,8 +300,8 @@ void KabschTransformTest::RunPixelCountComparison(FGAlgorithm algo) {
     DeviceBuffer<unsigned long long> d_intensity_times_z(num_reflections);
     cudaMemset(d_fg_sum.data(), 0, num_reflections * sizeof(accumulator_t));
     cudaMemset(d_fg_count.data(), 0, num_reflections * sizeof(uint32_t));
-    cudaMemset(d_bg_sum.data(), 0, num_reflections * sizeof(accumulator_t));
-    cudaMemset(d_bg_count.data(), 0, num_reflections * sizeof(uint32_t));
+    cudaMemset(d_bg_hist.data(), 0, num_reflections * NUM_BG_BINS * sizeof(uint32_t));
+    cudaMemset(d_bg_overflow.data(), 0, num_reflections * sizeof(uint32_t));
     cudaMemset(
       d_intensity_times_x.data(), 0, num_reflections * sizeof(unsigned long long));
     cudaMemset(
@@ -343,8 +368,8 @@ void KabschTransformTest::RunPixelCountComparison(FGAlgorithm algo) {
                                  algo,
                                  d_fg_sum.data(),
                                  d_fg_count.data(),
-                                 d_bg_sum.data(),
-                                 d_bg_count.data(),
+                                 d_bg_hist.data(),
+                                 d_bg_overflow.data(),
                                  d_intensity_times_x.data(),
                                  d_intensity_times_y.data(),
                                  d_intensity_times_z.data(),
@@ -355,9 +380,9 @@ void KabschTransformTest::RunPixelCountComparison(FGAlgorithm algo) {
     cuda_throw_error();
 
     std::vector<uint32_t> h_fg_count(num_reflections);
-    std::vector<uint32_t> h_bg_count(num_reflections);
+    std::vector<uint32_t> h_bg_count =
+      background_counts(d_bg_hist, d_bg_overflow, num_reflections);
     d_fg_count.extract(h_fg_count.data());
-    d_bg_count.extract(h_bg_count.data());
 
     // Load baseline foreground/background pixel counts. The baseline writes
     // rows in the SAME order as its input (integrated_1_10.refl), which is
@@ -529,15 +554,15 @@ void KabschTransformTest::RunIntensitySumComparison(FGAlgorithm algo) {
     // Per-reflection accumulators (zeroed; the kernel atomically adds into them).
     DeviceBuffer<accumulator_t> d_fg_sum(num_reflections);
     DeviceBuffer<uint32_t> d_fg_count(num_reflections);
-    DeviceBuffer<accumulator_t> d_bg_sum(num_reflections);
-    DeviceBuffer<uint32_t> d_bg_count(num_reflections);
+    DeviceBuffer<uint32_t> d_bg_hist(num_reflections * NUM_BG_BINS);
+    DeviceBuffer<uint32_t> d_bg_overflow(num_reflections);
     DeviceBuffer<unsigned long long> d_itx(num_reflections);
     DeviceBuffer<unsigned long long> d_ity(num_reflections);
     DeviceBuffer<unsigned long long> d_itz(num_reflections);
     cudaMemset(d_fg_sum.data(), 0, num_reflections * sizeof(accumulator_t));
     cudaMemset(d_fg_count.data(), 0, num_reflections * sizeof(uint32_t));
-    cudaMemset(d_bg_sum.data(), 0, num_reflections * sizeof(accumulator_t));
-    cudaMemset(d_bg_count.data(), 0, num_reflections * sizeof(uint32_t));
+    cudaMemset(d_bg_hist.data(), 0, num_reflections * NUM_BG_BINS * sizeof(uint32_t));
+    cudaMemset(d_bg_overflow.data(), 0, num_reflections * sizeof(uint32_t));
     cudaMemset(d_itx.data(), 0, num_reflections * sizeof(unsigned long long));
     cudaMemset(d_ity.data(), 0, num_reflections * sizeof(unsigned long long));
     cudaMemset(d_itz.data(), 0, num_reflections * sizeof(unsigned long long));
@@ -634,8 +659,8 @@ void KabschTransformTest::RunIntensitySumComparison(FGAlgorithm algo) {
                                  algo,
                                  d_fg_sum.data(),
                                  d_fg_count.data(),
-                                 d_bg_sum.data(),
-                                 d_bg_count.data(),
+                                 d_bg_hist.data(),
+                                 d_bg_overflow.data(),
                                  d_itx.data(),
                                  d_ity.data(),
                                  d_itz.data(),
@@ -647,10 +672,35 @@ void KabschTransformTest::RunIntensitySumComparison(FGAlgorithm algo) {
 
     std::vector<accumulator_t> h_fg_sum(num_reflections);
     std::vector<uint32_t> h_fg_count(num_reflections);
-    std::vector<uint32_t> h_bg_count(num_reflections);
+    std::vector<uint32_t> h_bg_count =
+      background_counts(d_bg_hist, d_bg_overflow, num_reflections);
     d_fg_sum.extract(h_fg_sum.data());
     d_fg_count.extract(h_fg_count.data());
-    d_bg_count.extract(h_bg_count.data());
+
+    // Reduce the per-reflection background histograms on the device (the same
+    // Tukey/IQR path the integrator uses) to compare the GPU background estimate
+    // against the baseline.
+    DeviceBuffer<double> d_bg_mean(num_reflections);
+    DeviceBuffer<double> d_bg_sum_value(num_reflections);
+    DeviceBuffer<uint32_t> d_bg_count_r(num_reflections);
+    DeviceBuffer<uint8_t> d_bg_success(num_reflections);
+    compute_background(BackgroundModel::Constant,
+                       d_bg_hist.data(),
+                       d_bg_overflow.data(),
+                       num_reflections,
+                       d_bg_mean.data(),
+                       d_bg_sum_value.data(),
+                       d_bg_count_r.data(),
+                       d_bg_success.data(),
+                       nullptr);
+    cudaDeviceSynchronize();
+    cuda_throw_error();
+    std::vector<double> h_bg_mean(num_reflections);
+    std::vector<double> h_bg_sum_value(num_reflections);
+    std::vector<uint8_t> h_bg_success(num_reflections);
+    d_bg_mean.extract(h_bg_mean.data());
+    d_bg_sum_value.extract(h_bg_sum_value.data());
+    d_bg_success.extract(h_bg_success.data());
 
     // Baseline columns (row-aligned with the prediction table).
     auto reference_path = reference_file.string();
@@ -662,10 +712,13 @@ void KabschTransformTest::RunIntensitySumComparison(FGAlgorithm algo) {
       read_array_from_h5_file<double>(reference_path, G + "intensity.sum.value");
     auto expected_bg_mean =
       read_array_from_h5_file<double>(reference_path, G + "background.mean");
+    auto expected_bg_sum =
+      read_array_from_h5_file<double>(reference_path, G + "background.sum.value");
     ASSERT_EQ(expected_fg_int.size(), num_reflections);
     ASSERT_EQ(expected_bg_int.size(), num_reflections);
     ASSERT_EQ(expected_intensity.size(), num_reflections);
     ASSERT_EQ(expected_bg_mean.size(), num_reflections);
+    ASSERT_EQ(expected_bg_sum.size(), num_reflections);
 
     // A reflection is comparable only when the kernel and baseline selected the
     // identical foreground pixel set, which is guaranteed when both the fg and
@@ -676,6 +729,9 @@ void KabschTransformTest::RunIntensitySumComparison(FGAlgorithm algo) {
     size_t excluded = 0;
     double sum_abs_err = 0.0;
     double max_abs_err = 0.0;
+    // Background estimate parity (device Tukey reduction vs baseline).
+    size_t bg_mismatches = 0;
+    double bg_max_abs_err = 0.0;
 
     for (size_t i = 0; i < num_reflections; ++i) {
         if (static_cast<int64_t>(h_fg_count[i]) != expected_fg_int[i]
@@ -684,6 +740,26 @@ void KabschTransformTest::RunIntensitySumComparison(FGAlgorithm algo) {
             continue;
         }
         compared++;
+
+        // Same background pixel population (bg counts match) => the device
+        // Tukey reduction must reproduce the baseline background.mean and
+        // background.sum.value.
+        double bg_mean_err = std::abs(h_bg_mean[i] - expected_bg_mean[i]);
+        double bg_sum_err = std::abs(h_bg_sum_value[i] - expected_bg_sum[i]);
+        double bg_mean_tol = 1e-5 * std::abs(expected_bg_mean[i]) + 1e-4;
+        double bg_sum_tol = 1e-5 * std::abs(expected_bg_sum[i]) + 1e-3;
+        bg_max_abs_err = std::max(bg_max_abs_err, bg_mean_err);
+        if (!h_bg_success[i] || bg_mean_err > bg_mean_tol || bg_sum_err > bg_sum_tol) {
+            bg_mismatches++;
+            if (bg_mismatches <= 10) {
+                std::cout << "  background mismatch refl " << i
+                          << ": gpu_mean=" << h_bg_mean[i]
+                          << " baseline_mean=" << expected_bg_mean[i]
+                          << " gpu_sum=" << h_bg_sum_value[i]
+                          << " baseline_sum=" << expected_bg_sum[i]
+                          << " success=" << static_cast<int>(h_bg_success[i]) << "\n";
+            }
+        }
         // Undo the baseline's background subtraction to get its raw foreground
         // sum. background.mean is the mean background per pixel, and the
         // baseline stored intensity.sum.value = fg_sum - n_fg * background.mean,
@@ -722,12 +798,19 @@ void KabschTransformTest::RunIntensitySumComparison(FGAlgorithm algo) {
         std::cout << "  Mean |err|           : " << (sum_abs_err / compared) << "\n";
         std::cout << "  Max  |err|           : " << max_abs_err << "\n";
     }
+    std::cout << "  Background mismatches : " << bg_mismatches << " (max |mean err| "
+              << bg_max_abs_err << ")\n";
     std::cout << "=============================================\n";
 
     EXPECT_GT(compared, 0u) << "No comparable reflections (counts never matched)";
     EXPECT_EQ(mismatches, 0u)
       << mismatches << " of " << compared
       << " comparable reflections had a foreground sum differing from the baseline "
+      << algo_name << " reference";
+    EXPECT_EQ(bg_mismatches, 0u)
+      << bg_mismatches << " of " << compared
+      << " comparable reflections had a device Tukey background differing from the "
+         "baseline "
       << algo_name << " reference";
 }
 

--- a/integrator/tests/test_kabsch.cc
+++ b/integrator/tests/test_kabsch.cc
@@ -234,6 +234,7 @@ class KabschTransformTest : public ::testing::Test {
 };
 
 void KabschTransformTest::RunPixelCountComparison(FGAlgorithm algo) {
+#pragma region Load inputs
     auto refl_file = data_dir / "integrated_1_10.refl";
     auto expt_file = data_dir / "indexed_1_10.expt";
     // Reference is the CPU baseline integrator run with the SAME algorithm,
@@ -269,7 +270,9 @@ void KabschTransformTest::RunPixelCountComparison(FGAlgorithm algo) {
     const std::vector<fastvec::Vector3D> &s1_vecs = in.s1_vecs;
     const std::vector<scalar_t> &phi_vals = in.phi_vals;
     const std::vector<BoundingBoxExtents> &bboxes = in.bboxes;
+#pragma endregion Load inputs
 
+#pragma region Allocate buffers
     // Allocate a blank (all-zero) detector image on the GPU, reused per image
     auto d_image = PitchedMalloc<pixel_t>(width, height);
     cudaMemset2D(
@@ -317,7 +320,9 @@ void KabschTransformTest::RunPixelCountComparison(FGAlgorithm algo) {
     DeviceBuffer<uint8_t> d_success(num_reflections);
     cudaMemset(d_success.data(), 1, num_reflections * sizeof(uint8_t));
     cuda_throw_error();
+#pragma endregion Allocate buffers
 
+#pragma region Dispatch
     // For each image in the scan, gather reflections whose bbox covers it
     // (z_min <= image_num < z_max) and dispatch one kernel call. Counts
     // accumulate across images via atomic adds inside the kernel.
@@ -378,7 +383,9 @@ void KabschTransformTest::RunPixelCountComparison(FGAlgorithm algo) {
     }
     cudaDeviceSynchronize();
     cuda_throw_error();
+#pragma endregion Dispatch
 
+#pragma region Compare counts
     std::vector<uint32_t> h_fg_count(num_reflections);
     std::vector<uint32_t> h_bg_count =
       background_counts(d_bg_hist, d_bg_overflow, num_reflections);
@@ -496,6 +503,7 @@ void KabschTransformTest::RunPixelCountComparison(FGAlgorithm algo) {
                              << " comparable reflections diverged from the "
                                 "baseline "
                              << algo_name << " reference";
+#pragma endregion Compare counts
 }
 
 TEST_F(KabschTransformTest, ForegroundBackgroundPixelCountsDials) {
@@ -519,6 +527,7 @@ TEST_F(KabschTransformTest, ForegroundBackgroundPixelCountsEllipsoid) {
  * needed here.
  */
 void KabschTransformTest::RunIntensitySumComparison(FGAlgorithm algo) {
+#pragma region Load inputs
     auto refl_file = data_dir / "integrated_1_10.refl";
     auto expt_file = data_dir / "indexed_1_10.expt";
     fs::path reference_file = baselineReference(algo);
@@ -539,7 +548,9 @@ void KabschTransformTest::RunIntensitySumComparison(FGAlgorithm algo) {
     auto shape = reader.image_shape();  // {slow, fast}
     ASSERT_EQ(shape[1], width) << "Image fast dimension disagrees with detector";
     ASSERT_EQ(shape[0], height) << "Image slow dimension disagrees with detector";
+#pragma endregion Load inputs
 
+#pragma region Allocate buffers
     // Static per-reflection inputs.
     auto d_image = PitchedMalloc<pixel_t>(width, height);
     DeviceBuffer<scalar_t> d_d_matrix(9);
@@ -577,7 +588,9 @@ void KabschTransformTest::RunIntensitySumComparison(FGAlgorithm algo) {
     DeviceBuffer<uint8_t> d_success(num_reflections);
     cudaMemset(d_success.data(), 1, num_reflections * sizeof(uint8_t));
     cuda_throw_error();
+#pragma endregion Allocate buffers
 
+#pragma region Dispatch
     // Pad the launch grid to cover bboxes overflowing the detector edge, exactly
     // as the production integrator does, so masked / out-of-image foreground
     // fails reflections the same way the baseline does.
@@ -669,7 +682,9 @@ void KabschTransformTest::RunIntensitySumComparison(FGAlgorithm algo) {
     }
     cudaDeviceSynchronize();
     cuda_throw_error();
+#pragma endregion Dispatch
 
+#pragma region Reduce background
     std::vector<accumulator_t> h_fg_sum(num_reflections);
     std::vector<uint32_t> h_fg_count(num_reflections);
     std::vector<uint32_t> h_bg_count =
@@ -701,7 +716,9 @@ void KabschTransformTest::RunIntensitySumComparison(FGAlgorithm algo) {
     d_bg_mean.extract(h_bg_mean.data());
     d_bg_sum_value.extract(h_bg_sum_value.data());
     d_bg_success.extract(h_bg_success.data());
+#pragma endregion Reduce background
 
+#pragma region Load baseline
     // Baseline columns (row-aligned with the prediction table).
     auto reference_path = reference_file.string();
     auto expected_fg_int =
@@ -719,7 +736,9 @@ void KabschTransformTest::RunIntensitySumComparison(FGAlgorithm algo) {
     ASSERT_EQ(expected_intensity.size(), num_reflections);
     ASSERT_EQ(expected_bg_mean.size(), num_reflections);
     ASSERT_EQ(expected_bg_sum.size(), num_reflections);
+#pragma endregion Load baseline
 
+#pragma region Compare results
     // A reflection is comparable only when the kernel and baseline selected the
     // identical foreground pixel set, which is guaranteed when both the fg and
     // bg counts match. For those, the raw foreground sums must be equal:
@@ -787,6 +806,9 @@ void KabschTransformTest::RunIntensitySumComparison(FGAlgorithm algo) {
         }
     }
 
+#pragma endregion Compare results
+
+#pragma region Assertions
     const char *algo_name = (algo == FGAlgorithm::Ellipsoid) ? "Ellipsoid" : "Dials";
     std::cout << "\n=== Kabsch Foreground Intensity Sum Comparison (" << algo_name
               << ") ===\n";
@@ -812,6 +834,7 @@ void KabschTransformTest::RunIntensitySumComparison(FGAlgorithm algo) {
       << " comparable reflections had a device Tukey background differing from the "
          "baseline "
       << algo_name << " reference";
+#pragma endregion Assertions
 }
 
 TEST_F(KabschTransformTest, IntensitySumDials) {

--- a/integrator/tests/test_kabsch.cc
+++ b/integrator/tests/test_kabsch.cc
@@ -739,20 +739,51 @@ void KabschTransformTest::RunIntensitySumComparison(FGAlgorithm algo) {
 #pragma endregion Load baseline
 
 #pragma region Compare results
-    // A reflection is comparable only when the kernel and baseline selected the
-    // identical foreground pixel set, which is guaranteed when both the fg and
-    // bg counts match. For those, the raw foreground sums must be equal:
+    // Foreground sum parity requires the kernel and baseline to have selected the
+    // identical foreground pixel set, which holds when both the fg and bg counts
+    // match. For those, the raw foreground sums must be equal:
     //   kernel fg_sum == intensity.sum.value + background.mean.
+    // Background parity depends only on the background population, so it is gated
+    // on the bg count alone: a reflection whose foreground was clipped by the
+    // mask can still have an identical background worth verifying.
     size_t compared = 0;
     size_t mismatches = 0;
     size_t excluded = 0;
     double sum_abs_err = 0.0;
     double max_abs_err = 0.0;
     // Background estimate parity (device Tukey reduction vs baseline).
+    size_t bg_compared = 0;
     size_t bg_mismatches = 0;
     double bg_max_abs_err = 0.0;
 
     for (size_t i = 0; i < num_reflections; ++i) {
+        // Background parity: same background pixel population (bg counts match)
+        // => the device Tukey reduction must reproduce the baseline
+        // background.mean and background.sum.value.
+        if (static_cast<int64_t>(h_bg_count[i]) == expected_bg_int[i]) {
+            bg_compared++;
+            double bg_mean_err = std::abs(h_bg_mean[i] - expected_bg_mean[i]);
+            double bg_sum_err = std::abs(h_bg_sum_value[i] - expected_bg_sum[i]);
+            double bg_mean_tol = 1e-5 * std::abs(expected_bg_mean[i]) + 1e-4;
+            double bg_sum_tol = 1e-5 * std::abs(expected_bg_sum[i]) + 1e-3;
+            bg_max_abs_err = std::max(bg_max_abs_err, bg_mean_err);
+            if (!h_bg_success[i] || bg_mean_err > bg_mean_tol
+                || bg_sum_err > bg_sum_tol) {
+                bg_mismatches++;
+                if (bg_mismatches <= 10) {
+                    std::cout << "  background mismatch refl " << i
+                              << ": gpu_mean=" << h_bg_mean[i]
+                              << " baseline_mean=" << expected_bg_mean[i]
+                              << " gpu_sum=" << h_bg_sum_value[i]
+                              << " baseline_sum=" << expected_bg_sum[i]
+                              << " success=" << static_cast<int>(h_bg_success[i])
+                              << "\n";
+                }
+            }
+        }
+
+        // Foreground sum parity needs the identical foreground pixel set, which
+        // requires both the fg and bg counts to match.
         if (static_cast<int64_t>(h_fg_count[i]) != expected_fg_int[i]
             || static_cast<int64_t>(h_bg_count[i]) != expected_bg_int[i]) {
             excluded++;
@@ -760,25 +791,6 @@ void KabschTransformTest::RunIntensitySumComparison(FGAlgorithm algo) {
         }
         compared++;
 
-        // Same background pixel population (bg counts match) => the device
-        // Tukey reduction must reproduce the baseline background.mean and
-        // background.sum.value.
-        double bg_mean_err = std::abs(h_bg_mean[i] - expected_bg_mean[i]);
-        double bg_sum_err = std::abs(h_bg_sum_value[i] - expected_bg_sum[i]);
-        double bg_mean_tol = 1e-5 * std::abs(expected_bg_mean[i]) + 1e-4;
-        double bg_sum_tol = 1e-5 * std::abs(expected_bg_sum[i]) + 1e-3;
-        bg_max_abs_err = std::max(bg_max_abs_err, bg_mean_err);
-        if (!h_bg_success[i] || bg_mean_err > bg_mean_tol || bg_sum_err > bg_sum_tol) {
-            bg_mismatches++;
-            if (bg_mismatches <= 10) {
-                std::cout << "  background mismatch refl " << i
-                          << ": gpu_mean=" << h_bg_mean[i]
-                          << " baseline_mean=" << expected_bg_mean[i]
-                          << " gpu_sum=" << h_bg_sum_value[i]
-                          << " baseline_sum=" << expected_bg_sum[i]
-                          << " success=" << static_cast<int>(h_bg_success[i]) << "\n";
-            }
-        }
         // Undo the baseline's background subtraction to get its raw foreground
         // sum. background.mean is the mean background per pixel, and the
         // baseline stored intensity.sum.value = fg_sum - n_fg * background.mean,
@@ -820,6 +832,8 @@ void KabschTransformTest::RunIntensitySumComparison(FGAlgorithm algo) {
         std::cout << "  Mean |err|           : " << (sum_abs_err / compared) << "\n";
         std::cout << "  Max  |err|           : " << max_abs_err << "\n";
     }
+    std::cout << "  Background compared  : " << bg_compared << " (of "
+              << num_reflections << ")\n";
     std::cout << "  Background mismatches : " << bg_mismatches << " (max |mean err| "
               << bg_max_abs_err << ")\n";
     std::cout << "=============================================\n";
@@ -829,10 +843,12 @@ void KabschTransformTest::RunIntensitySumComparison(FGAlgorithm algo) {
       << mismatches << " of " << compared
       << " comparable reflections had a foreground sum differing from the baseline "
       << algo_name << " reference";
+    EXPECT_GT(bg_compared, 0u)
+      << "No reflections with matching background counts to compare";
     EXPECT_EQ(bg_mismatches, 0u)
-      << bg_mismatches << " of " << compared
-      << " comparable reflections had a device Tukey background differing from the "
-         "baseline "
+      << bg_mismatches << " of " << bg_compared
+      << " reflections with matching background counts had a device Tukey background "
+         "differing from the baseline "
       << algo_name << " reference";
 #pragma endregion Assertions
 }

--- a/src/integrator/background.cc
+++ b/src/integrator/background.cc
@@ -10,18 +10,10 @@
 #include <stdexcept>
 #include <vector>
 
-// Upper bound on the contiguous histogram from the aggregator.
-// Background pixel values above this are folded into the overflow tail; for a
-// constant background these are extreme outliers that Tukey rejects, so the
-// estimate is unaffected and large hot-pixel-sized values need no allocation.
-namespace {
-constexpr int kMaxBins = 4096;
-}
-
 // Tukey outlier-rejecting constant background. Delegates to the single-source
 // tukey_constant_background() so the baseline and the GPU run identical math;
 // this function only flattens the aggregator's array and overflow map into a
-// contiguous ConstHistogramView.
+// contiguous ConstHistogramView over the shared NUM_BG_BINS range.
 std::tuple<double, double> compute_background_constant_3d(
   const BackgroundAggregator &data) {
     if (data.num_pixels() == 0) {
@@ -31,34 +23,39 @@ std::tuple<double, double> compute_background_constant_3d(
     const auto &small_hist = data.small_hist();
     const auto *large_hist = data.large_hist();  // may be nullptr
 
-    // Determine how many contiguous integer bins to allocate: enough to
-    // cover the small array and any in-range map keys, capped at kMaxBins.
-    int num_bins = static_cast<int>(small_hist.size());
-    if (large_hist != nullptr) {
-        for (const auto &[value, count] : *large_hist) {
-            if (value >= num_bins && value < kMaxBins) {
-                num_bins = value + 1;
-            }
-        }
-    }
-
-    std::vector<uint32_t> bins(static_cast<size_t>(num_bins), 0);
+    // Bin into the shared [0, NUM_BG_BINS) range exactly as the GPU kernel does,
+    // so the host baseline and the device reduction see identical histograms:
+    // negatives clamp into bin 0, values at or above NUM_BG_BINS go to the
+    // overflow tail.
+    std::vector<uint32_t> bins(static_cast<size_t>(NUM_BG_BINS), 0);
     uint32_t overflow_count = 0;
 
-    for (std::size_t v = 0; v < small_hist.size(); ++v) {
+    for (std::size_t v = 0; v < small_hist.size() && v < NUM_BG_BINS; ++v) {
         bins[v] = static_cast<uint32_t>(small_hist[v]);
     }
     if (large_hist != nullptr) {
         for (const auto &[value, count] : *large_hist) {
-            if (value >= 0 && value < num_bins) {
-                bins[static_cast<size_t>(value)] += static_cast<uint32_t>(count);
+            const int bin = value < 0 ? 0 : value;
+            if (bin < NUM_BG_BINS) {
+                bins[static_cast<size_t>(bin)] += static_cast<uint32_t>(count);
             } else {
                 overflow_count += static_cast<uint32_t>(count);
             }
         }
     }
 
-    ConstHistogramView view{bins.data(), num_bins, overflow_count};
+    ConstHistogramView view{bins.data(), NUM_BG_BINS, overflow_count};
+
+    // Too many pixels in the overflow tail means NUM_BG_BINS is too small to
+    // represent this reflection's background, so the estimate would diverge
+    // from a full-range computation. Fail loudly rather than degrade silently.
+    if (static_cast<double>(overflow_count)
+        > kBackgroundMaxOverflowFraction * static_cast<double>(data.num_pixels())) {
+        throw std::runtime_error(
+          "Background histogram overflow exceeded the permitted fraction; "
+          "NUM_BG_BINS is too small for this reflection's background level");
+    }
+
     BackgroundResult result = tukey_constant_background(view);
     if (!result.valid) {
         throw std::runtime_error(

--- a/src/integrator/background.cc
+++ b/src/integrator/background.cc
@@ -1,110 +1,69 @@
 /**
  * @file background.cc
- * @brief Background estimation for baseline CPU integration.
+ * @brief Host adapter from the baseline BackgroundAggregator histogram to the
+ *        shared, device-safe constant background model.
  */
 
 #include "integrator/background.hpp"
 
-#include <algorithm>
-#include <cstddef>
+#include <cstdint>
 #include <stdexcept>
 #include <vector>
 
-// Simple background with tukey outlier for now.
+// Upper bound on the contiguous histogram from the aggregator.
+// Background pixel values above this are folded into the overflow tail; for a
+// constant background these are extreme outliers that Tukey rejects, so the
+// estimate is unaffected and large hot-pixel-sized values need no allocation.
+namespace {
+constexpr int kMaxBins = 4096;
+}
+
+// Tukey outlier-rejecting constant background. Delegates to the single-source
+// tukey_constant_background() so the baseline and the GPU run identical math;
+// this function only flattens the aggregator's array and overflow map into a
+// contiguous ConstHistogramView.
 std::tuple<double, double> compute_background_constant_3d(
   const BackgroundAggregator &data) {
-    constexpr double iqr_multiplier = 1.5;
-
-    const int N = data.num_pixels();
-    if (N == 0) {
+    if (data.num_pixels() == 0) {
         throw std::runtime_error("No background pixels available");
     }
-
-    // Quantile positions (1-based counting convention)
-    const std::size_t p25 = (N + 3) / 4;
-    const std::size_t p50 = (N + 1) / 2;
-    const std::size_t p75 = (3 * N + 1) / 4;
 
     const auto &small_hist = data.small_hist();
     const auto *large_hist = data.large_hist();  // may be nullptr
 
-    std::size_t cumulative = 0;
-    int q1 = -1, median = -1, q3 = -1;
-
-    // ---- Scan small histogram (fixed array) ----
-    for (std::size_t value = 0; value < small_hist.size(); ++value) {
-        cumulative += small_hist[value];
-
-        if (q1 < 0 && cumulative >= p25) q1 = static_cast<int>(value);
-        if (median < 0 && cumulative >= p50) median = static_cast<int>(value);
-        if (q3 < 0 && cumulative >= p75) {
-            q3 = static_cast<int>(value);
-            break;
-        }
-    }
-
-    // ---- Scan large histogram only if needed ----
-    if (q3 < 0 && large_hist != nullptr) {
-        std::vector<int> keys;
-        keys.reserve(large_hist->size());
-        for (const auto &[k, _] : *large_hist) {
-            keys.push_back(k);
-        }
-        std::sort(keys.begin(), keys.end());
-
-        for (int value : keys) {
-            cumulative += large_hist->at(value);
-
-            if (q1 < 0 && cumulative >= p25) q1 = value;
-            if (median < 0 && cumulative >= p50) median = value;
-            if (q3 < 0 && cumulative >= p75) {
-                q3 = value;
-                break;
-            }
-        }
-    }
-
-    // Sanity check (should not happen unless input is inconsistent)
-    if (q1 < 0 || q3 < 0) {
-        throw std::runtime_error("Failed to compute quartiles for background");
-    }
-
-    const int iqr = q3 - q1;
-    const double lower_bound = q1 - iqr_multiplier * iqr;
-    const double upper_bound = q3 + iqr_multiplier * iqr;
-
-    // ---- Accumulate inliers ----
-    std::size_t included_count = 0;
-    double weighted_sum = 0.0;
-
-    // Small histogram
-    for (std::size_t value = 0; value < small_hist.size(); ++value) {
-        if (value < lower_bound || value > upper_bound) {
-            continue;
-        }
-
-        const std::size_t count = small_hist[value];
-        included_count += count;
-        weighted_sum += static_cast<double>(value) * count;
-    }
-
-    // Large histogram (if present)
+    // Determine how many contiguous integer bins to allocate: enough to
+    // cover the small array and any in-range map keys, capped at kMaxBins.
+    int num_bins = static_cast<int>(small_hist.size());
     if (large_hist != nullptr) {
         for (const auto &[value, count] : *large_hist) {
-            if (value < lower_bound || value > upper_bound) {
-                continue;
+            if (value >= num_bins && value < kMaxBins) {
+                num_bins = value + 1;
             }
-
-            included_count += count;
-            weighted_sum += static_cast<double>(value) * count;
         }
     }
 
-    if (included_count == 0) {
+    std::vector<uint32_t> bins(static_cast<size_t>(num_bins), 0);
+    uint32_t overflow_count = 0;
+
+    for (std::size_t v = 0; v < small_hist.size(); ++v) {
+        bins[v] = static_cast<uint32_t>(small_hist[v]);
+    }
+    if (large_hist != nullptr) {
+        for (const auto &[value, count] : *large_hist) {
+            if (value >= 0 && value < num_bins) {
+                bins[static_cast<size_t>(value)] += static_cast<uint32_t>(count);
+            } else {
+                overflow_count += static_cast<uint32_t>(count);
+            }
+        }
+    }
+
+    ConstHistogramView view{bins.data(), num_bins, overflow_count};
+    BackgroundResult result = tukey_constant_background(view);
+    if (!result.valid) {
         throw std::runtime_error(
           "No background data remaining after outlier rejection");
     }
 
-    const double mean = weighted_sum / static_cast<double>(included_count);
-    return {mean, weighted_sum};
+    return {result.mean, result.weighted_sum};
 }

--- a/src/integrator/background.cc
+++ b/src/integrator/background.cc
@@ -28,10 +28,12 @@ std::tuple<double, double> compute_background_constant_3d(
     // negative sentinel values are dropped, values at or above NUM_BG_BINS go to
     // the overflow tail.
     std::vector<uint32_t> bins(static_cast<size_t>(NUM_BG_BINS), 0);
+    uint32_t in_range_count = 0;
     uint32_t overflow_count = 0;
 
     for (std::size_t v = 0; v < small_hist.size() && v < NUM_BG_BINS; ++v) {
         bins[v] = static_cast<uint32_t>(small_hist[v]);
+        in_range_count += static_cast<uint32_t>(small_hist[v]);
     }
     if (large_hist != nullptr) {
         for (const auto &[value, count] : *large_hist) {
@@ -40,6 +42,7 @@ std::tuple<double, double> compute_background_constant_3d(
             // matching the GPU kernel.
             if (value >= 0 && value < NUM_BG_BINS) {
                 bins[static_cast<size_t>(value)] += static_cast<uint32_t>(count);
+                in_range_count += static_cast<uint32_t>(count);
             } else if (value >= NUM_BG_BINS) {
                 overflow_count += static_cast<uint32_t>(count);
             }
@@ -51,8 +54,11 @@ std::tuple<double, double> compute_background_constant_3d(
     // Too many pixels in the overflow tail means NUM_BG_BINS is too small to
     // represent this reflection's background, so the estimate would diverge
     // from a full-range computation. Fail loudly rather than degrade silently.
+    // The denominator is the histogram population (in-range + overflow), which
+    // matches the GPU reduction's count and excludes dropped sentinels.
     if (static_cast<double>(overflow_count)
-        > kBackgroundMaxOverflowFraction * static_cast<double>(data.num_pixels())) {
+        > kBackgroundMaxOverflowFraction
+            * static_cast<double>(in_range_count + overflow_count)) {
         throw std::runtime_error(
           "Background histogram overflow exceeded the permitted fraction; "
           "NUM_BG_BINS is too small for this reflection's background level");

--- a/src/integrator/background.cc
+++ b/src/integrator/background.cc
@@ -146,14 +146,12 @@ std::tuple<double, double> compute_background_constant_3d_shared(
     }
     if (large_hist != nullptr) {
         for (const auto &[value, count] : *large_hist) {
-            // A negative value is a sentinel/garbage pixel, not a real
-            // background measurement, so it is dropped rather than counted,
-            // matching the GPU kernel.
-            if (value >= 0 && value < NUM_BG_BINS) {
+            // Values at or above NUM_BG_BINS go to the overflow tail
+            if (value >= NUM_BG_BINS) {
+                overflow_count += static_cast<uint32_t>(count);
+            } else {
                 bins[static_cast<size_t>(value)] += static_cast<uint32_t>(count);
                 in_range_count += static_cast<uint32_t>(count);
-            } else if (value >= NUM_BG_BINS) {
-                overflow_count += static_cast<uint32_t>(count);
             }
         }
     }

--- a/src/integrator/background.cc
+++ b/src/integrator/background.cc
@@ -1,20 +1,129 @@
 /**
  * @file background.cc
- * @brief Host adapter from the baseline BackgroundAggregator histogram to the
- *        shared, device-safe constant background model.
+ * @brief Host constant (Tukey/IQR) background estimation for the baseline
+ *        integrator, available as either the independent dials-like algorithm
+ *        or an adapter onto the shared, device-safe constant background model.
  */
 
 #include "integrator/background.hpp"
 
+#include <algorithm>
+#include <cstddef>
 #include <cstdint>
 #include <stdexcept>
 #include <vector>
 
-// Tukey outlier-rejecting constant background. Delegates to the single-source
+namespace {
+
+// Independent dials-like constant background. Self-contained baseline that
+// scans the aggregator's unbounded histogram directly: the small fixed array
+// for low values and, only if a quartile is not yet found, the sparse map of
+// large/outlier values. Every pixel is counted (including negative sentinels
+// in the large map) and there is no overflow rejection, so this stays the
+// true-to-dials reference independent of the shared core's bounded range.
+std::tuple<double, double> compute_background_constant_3d_dials(
+  const BackgroundAggregator &data) {
+    constexpr double iqr_multiplier = 1.5;
+
+    const int N = data.num_pixels();
+    if (N == 0) {
+        throw std::runtime_error("No background pixels available");
+    }
+
+    // Quantile positions (1-based counting convention)
+    const std::size_t p25 = (N + 3) / 4;
+    const std::size_t p50 = (N + 1) / 2;
+    const std::size_t p75 = (3 * N + 1) / 4;
+
+    const auto &small_hist = data.small_hist();
+    const auto *large_hist = data.large_hist();  // may be nullptr
+
+    std::size_t cumulative = 0;
+    int q1 = -1, median = -1, q3 = -1;
+
+    // ---- Scan small histogram (fixed array) ----
+    for (std::size_t value = 0; value < small_hist.size(); ++value) {
+        cumulative += small_hist[value];
+
+        if (q1 < 0 && cumulative >= p25) q1 = static_cast<int>(value);
+        if (median < 0 && cumulative >= p50) median = static_cast<int>(value);
+        if (q3 < 0 && cumulative >= p75) {
+            q3 = static_cast<int>(value);
+            break;
+        }
+    }
+
+    // ---- Scan large histogram only if needed ----
+    if (q3 < 0 && large_hist != nullptr) {
+        std::vector<int> keys;
+        keys.reserve(large_hist->size());
+        for (const auto &[k, _] : *large_hist) {
+            keys.push_back(k);
+        }
+        std::sort(keys.begin(), keys.end());
+
+        for (int value : keys) {
+            cumulative += large_hist->at(value);
+
+            if (q1 < 0 && cumulative >= p25) q1 = value;
+            if (median < 0 && cumulative >= p50) median = value;
+            if (q3 < 0 && cumulative >= p75) {
+                q3 = value;
+                break;
+            }
+        }
+    }
+
+    // Sanity check (should not happen unless input is inconsistent)
+    if (q1 < 0 || q3 < 0) {
+        throw std::runtime_error("Failed to compute quartiles for background");
+    }
+
+    const int iqr = q3 - q1;
+    const double lower_bound = q1 - iqr_multiplier * iqr;
+    const double upper_bound = q3 + iqr_multiplier * iqr;
+
+    // ---- Accumulate inliers ----
+    std::size_t included_count = 0;
+    double weighted_sum = 0.0;
+
+    // Small histogram
+    for (std::size_t value = 0; value < small_hist.size(); ++value) {
+        if (value < lower_bound || value > upper_bound) {
+            continue;
+        }
+
+        const std::size_t count = small_hist[value];
+        included_count += count;
+        weighted_sum += static_cast<double>(value) * count;
+    }
+
+    // Large histogram (if present)
+    if (large_hist != nullptr) {
+        for (const auto &[value, count] : *large_hist) {
+            if (value < lower_bound || value > upper_bound) {
+                continue;
+            }
+
+            included_count += count;
+            weighted_sum += static_cast<double>(value) * count;
+        }
+    }
+
+    if (included_count == 0) {
+        throw std::runtime_error(
+          "No background data remaining after outlier rejection");
+    }
+
+    const double mean = weighted_sum / static_cast<double>(included_count);
+    return {mean, weighted_sum};
+}
+
+// Shared-core constant background. Delegates to the single-source
 // tukey_constant_background() so the baseline and the GPU run identical math;
 // this function only flattens the aggregator's array and overflow map into a
 // contiguous ConstHistogramView over the shared NUM_BG_BINS range.
-std::tuple<double, double> compute_background_constant_3d(
+std::tuple<double, double> compute_background_constant_3d_shared(
   const BackgroundAggregator &data) {
     if (data.num_pixels() == 0) {
         throw std::runtime_error("No background pixels available");
@@ -71,4 +180,18 @@ std::tuple<double, double> compute_background_constant_3d(
     }
 
     return {result.mean, result.weighted_sum};
+}
+
+}  // namespace
+
+std::tuple<double, double> compute_background_constant_3d(
+  const BackgroundAggregator &data,
+  ConstantBackgroundImpl impl) {
+    switch (impl) {
+    case ConstantBackgroundImpl::SharedCore:
+        return compute_background_constant_3d_shared(data);
+    case ConstantBackgroundImpl::DialsIndependent:
+    default:
+        return compute_background_constant_3d_dials(data);
+    }
 }

--- a/src/integrator/background.cc
+++ b/src/integrator/background.cc
@@ -25,8 +25,8 @@ std::tuple<double, double> compute_background_constant_3d(
 
     // Bin into the shared [0, NUM_BG_BINS) range exactly as the GPU kernel does,
     // so the host baseline and the device reduction see identical histograms:
-    // negatives clamp into bin 0, values at or above NUM_BG_BINS go to the
-    // overflow tail.
+    // negative sentinel values are dropped, values at or above NUM_BG_BINS go to
+    // the overflow tail.
     std::vector<uint32_t> bins(static_cast<size_t>(NUM_BG_BINS), 0);
     uint32_t overflow_count = 0;
 
@@ -35,10 +35,12 @@ std::tuple<double, double> compute_background_constant_3d(
     }
     if (large_hist != nullptr) {
         for (const auto &[value, count] : *large_hist) {
-            const int bin = value < 0 ? 0 : value;
-            if (bin < NUM_BG_BINS) {
-                bins[static_cast<size_t>(bin)] += static_cast<uint32_t>(count);
-            } else {
+            // A negative value is a sentinel/garbage pixel, not a real
+            // background measurement, so it is dropped rather than counted,
+            // matching the GPU kernel.
+            if (value >= 0 && value < NUM_BG_BINS) {
+                bins[static_cast<size_t>(value)] += static_cast<uint32_t>(count);
+            } else if (value >= NUM_BG_BINS) {
                 overflow_count += static_cast<uint32_t>(count);
             }
         }


### PR DESCRIPTION
This PR replaces the GPU integrator's plain-mean background with the
same Tukey/IQR outlier-rejecting constant background the CPU baseline
already runs, so the two paths produce matching estimates. The Tukey
core is written once as a `__host__ __device__` function over a uniform
integer-histogram view and compiled into both the baseline and the
device.

The histogram aggregation here is also the foundation the future GLM
background will read from.

### Changes:

- Adds the single-source Tukey core in
  `include/integrator/background.hpp`: `tukey_constant_background()`
  over a `ConstHistogramView` (contiguous integer bins plus an overflow
  tail), device-safe with no allocation or exceptions. A
  `BackgroundModel` enum (`Constant`/`Tukey`, `Glm` reserved) selects
  the model. `NUM_BG_BINS` and the overflow-rejection fraction live here
  as the one source of truth shared by host and device.

- Accumulates a per-reflection histogram on the existing pixel pass in
  `kabsch.cu` instead of a running sum/count: a background pixel
  increments its bin, values at or above `NUM_BG_BINS` go to a
  per-reflection overflow counter, and negative sentinel pixels are
  dropped rather than counted as zero. Same atomic traffic as before.

- Reduces the histograms device-side in `integrator/background.cu`
  (`include/integrator/background.cuh`), one reflection per block in
  double precision, dispatching on `BackgroundModel` and writing back
  per-reflection mean, inlier weighted sum, and a success flag. Only a
  few doubles per reflection return rather than the full histogram.

- Rewires `src/integrator/background.cc` to flatten the baseline's
  aggregator into the same `ConstHistogramView` and delegate to the
  shared core, so the baseline and GPU run identical math. The host
  overflow guard divides by the histogram population so its rejection
  threshold matches the device exactly.

- Fails loudly when a reflection puts more than 25% of its background
  pixels above `NUM_BG_BINS`, rather than silently degrading the
  estimate against a too-small range.

- Adds a `--background` flag (`constant`/`tukey`, default `constant`;
  `glm` rejected at parse) alongside the existing algorithm parsing, and
  resolves the image file from the experiment when `--images` is
  omitted.

- Adds `test_background.cc` locking the core's median/IQR math against a
  hand-built histogram, and extends `test_kabsch.cc` to verify
  per-reflection `background.mean` and `background.sum.value` against
  the baseline independently of the foreground match.