### PR TITLE
Add robust-Poisson GLM constant background to the GPU integrator

### DIFF
--- a/baseline/integrator/integrator.cc
+++ b/baseline/integrator/integrator.cc
@@ -109,6 +109,12 @@ class BaselineIntegratorArgumentParser : public FFSArgumentParser {
           .help("Foreground algorithm choice - dials or ellipsoid.")
           .default_value<std::string>("ellipsoid");
 
+        add_argument("--background")
+          .help(
+            "Background model - constant (Tukey/IQR outlier rejection) or "
+            "glm (robust-Poisson GLM constant background).")
+          .default_value<std::string>("constant");
+
         add_argument("--min_zeta")
           .help(
             "Reflections close to the rotation axis, with a zeta below this threshold "
@@ -492,6 +498,12 @@ FGAlgorithm parse_fg_algorithm(const std::string &name) {
     throw std::runtime_error("Unknown foreground algorithm: " + name);
 }
 
+BackgroundModel parse_background_model(const std::string &name) {
+    if (name == "constant" || name == "tukey") return BackgroundModel::Constant;
+    if (name == "glm") return BackgroundModel::Glm;
+    throw std::runtime_error("Unknown background model: " + name);
+}
+
 #pragma region Application Entry
 int main(int argc, char **argv) {
     logger.info("Baseline Integrator Version: {}", FFS_VERSION);
@@ -506,6 +518,9 @@ int main(int argc, char **argv) {
     std::string output_file = parser.get<std::string>("output");
 
     FGAlgorithm fg_algorithm = parse_fg_algorithm(parser.get<std::string>("algorithm"));
+    BackgroundModel background_model =
+      parse_background_model(parser.get<std::string>("background"));
+    logger.info("Background model: {}", parser.get<std::string>("background"));
 
     // Guard against missing files
     if (!std::filesystem::exists(reflection_file)) {
@@ -966,11 +981,18 @@ int main(int argc, char **argv) {
     std::vector<double> d_values(num_reflections);
     std::vector<double> mean_bg(num_reflections);
     std::vector<double> bg_sum_value(num_reflections);
-    // FIXME need to include robust outlier rejection in background calculation (glm, constant3dmodel)
     for (int i = 0; i < num_reflections; i++) {
         if (nbg_accumulators[i]) {
-            auto [bg, total_bg_counts] =
-              compute_background_constant_3d(bg_accumulators[i]);
+            BackgroundResult bg_result =
+              compute_background_constant_3d(bg_accumulators[i], background_model);
+            if (!bg_result.valid) {
+                // Estimate rejected (no inliers, too few pixels, too much
+                // overflow, or non-convergence); skip like the GPU path.
+                success[i] = false;
+                continue;
+            }
+            double bg = bg_result.mean;
+            double total_bg_counts = bg_result.weighted_sum;
             mean_bg[i] = bg;
             bg_sum_value[i] = total_bg_counts;
             double I = intensity_accumulators[i] - bg;

--- a/baseline/integrator/integrator.cc
+++ b/baseline/integrator/integrator.cc
@@ -111,9 +111,8 @@ class BaselineIntegratorArgumentParser : public FFSArgumentParser {
 
         add_argument("--background")
           .help(
-            "Background model - dials for the independent dials-like Tukey/IQR "
-            "baseline, constant/tukey for the shared-core Tukey/IQR model, or "
-            "glm for the shared-core robust-Poisson GLM constant background.")
+            "Background model: dials (dials-like Tukey), constant (shared-core "
+            "Tukey), or glm (shared-core robust-Poisson GLM).")
           .default_value<std::string>("constant");
 
         add_argument("--min_zeta")

--- a/include/integrator/background.cuh
+++ b/include/integrator/background.cuh
@@ -23,7 +23,7 @@
  * One thread handles one reflection: it views its slice of the histogram
  * (NUM_BG_BINS bins plus the overflow tail) and evaluates the chosen model.
  *
- * @param model Background model to apply (Constant = Tukey; Glm not yet implemented)
+ * @param model Background model to apply (Constant = Tukey; Glm = robust-Poisson GLM)
  * @param d_background_hist Device histogram, num_reflections * NUM_BG_BINS bins
  * @param d_background_overflow Device per-reflection high-tail counts
  * @param num_reflections Number of reflections

--- a/include/integrator/background.hpp
+++ b/include/integrator/background.hpp
@@ -514,11 +514,19 @@ class BackgroundAggregator {
 };
 
 /**
- * @brief Estimate a constant background level from an aggregated histogram
- * using a Tukey (IQR-based) outlier rejection.
+ * @brief Estimate a constant background level from an aggregated histogram.
+ *
+ * Flattens the aggregator into the shared ConstHistogramView and dispatches to
+ * the selected single-source model: tukey_constant_background (Constant) or
+ * glm_constant_background (Glm), so the baseline runs the same math as the GPU.
  *
  * @param data Aggregated background pixel histogram for one reflection.
- * @return {mean background, weighted sum of included pixel values}
+ * @param model Background model to apply (Constant = Tukey; Glm = robust GLM).
+ * @return BackgroundResult with mean and weighted_sum; valid is false when the
+ *         estimate is rejected (no inliers, too few pixels, too much overflow,
+ *         or non-convergence), in which case the caller marks the reflection
+ *         unintegrated. Mirrors the BackgroundResult::valid channel the GPU
+ *         reduction uses.
  */
-std::tuple<double, double> compute_background_constant_3d(
-  const BackgroundAggregator &data);
+BackgroundResult compute_background_constant_3d(const BackgroundAggregator &data,
+                                                BackgroundModel model);

--- a/include/integrator/background.hpp
+++ b/include/integrator/background.hpp
@@ -14,6 +14,7 @@
 #pragma once
 
 #include <array>
+#include <cmath>
 #include <cstddef>
 #include <cstdint>
 #include <tuple>
@@ -32,8 +33,9 @@
  *        background level from its pixel histogram.
  *
  * Constant is the Tukey/IQR outlier-rejecting constant background (matches the
- * DIALS "constant 3d" model). Glm is the full DIALS robust-Poisson GLM model,
- * not yet implemented; it will read the same histogram.
+ * DIALS "constant 3d" model). Glm is the DIALS robust-Poisson GLM constant
+ * background (matches the DIALS "glm constant3d" model); it reads the same
+ * histogram.
  */
 enum class BackgroundModel : uint8_t { Constant, Glm };
 
@@ -53,6 +55,15 @@ constexpr int NUM_BG_BINS = 256;
 // Fraction of a reflection's background pixels allowed in the high-tail
 // overflow before the constant background estimate is rejected as untrustworthy.
 constexpr double kBackgroundMaxOverflowFraction = 0.25;
+
+// Parameters for the robust-Poisson GLM constant background, matching the DIALS
+// defaults (dials.algorithms.background.glm: tuning_constant 1.345,
+// max_iter 100, tolerance 1e-3, min_pixels 10). Held here as the single source
+// of truth so the host baseline and the device reduction iterate identically.
+constexpr double kGlmTuningConstant = 1.345;
+constexpr double kGlmTolerance = 1e-3;
+constexpr int kGlmMaxIter = 100;
+constexpr uint32_t kGlmMinPixels = 10;
 
 /**
  * @brief Read-only view of a per-reflection background histogram.
@@ -175,6 +186,233 @@ FFS_HD inline BackgroundResult tukey_constant_background(
 
     result.mean = weighted_sum / static_cast<double>(included_count);
     result.weighted_sum = weighted_sum;
+    result.valid = true;
+    return result;
+}
+
+/**
+ * @brief Poisson probability mass P(Y = value).
+ *
+ * Used to form the GLM expectation values. value is integer-valued.
+ *
+ * Source: scitbx::glmtbx::poisson::pdf in scitbx/glmtbx/family.h.
+ */
+FFS_HD inline double glm_poisson_pdf(double mean, double value) {
+    if (mean == 0.0) return 0.0;
+    if (value == 0.0) return std::exp(-mean);
+    if (value < 0.0) return 0.0;
+    return std::exp(value * std::log(mean) - mean - std::lgamma(value + 1.0));
+}
+
+/**
+ * @brief Poisson cumulative probability P(Y <= value) for integer value.
+ *
+ * The DIALS routine uses boost::math::gamma_q(floor(value+1), mean). For an
+ * integer first argument that regularised upper incomplete gamma equals the
+ * finite Poisson sum e^-mean * sum_{k=0..value} mean^k / k!, which avoids a
+ * special-function dependency on the device. mean stays below NUM_BG_BINS for
+ * accepted reflections, so the sum is short.
+ *
+ * Source: scitbx::glmtbx::poisson::cdf in scitbx/glmtbx/family.h.
+ */
+FFS_HD inline double glm_poisson_cdf(double mean, double value) {
+    if (mean == 0.0) return 0.0;
+    if (value < 0.0) return 0.0;
+    const long v = static_cast<long>(std::floor(value));
+    double term = std::exp(-mean);  // k = 0
+    double sum = term;
+    for (long k = 1; k <= v; ++k) {
+        term *= mean / static_cast<double>(k);
+        sum += term;
+    }
+    return sum;
+}
+
+/**
+ * @brief Huber psi function: identity inside [-c, c], clipped to +/-c outside.
+ *
+ * Source: scitbx::glmtbx::huber in scitbx/glmtbx/robust_glm.h.
+ */
+FFS_HD inline double glm_huber(double r, double c) {
+    if (std::fabs(r) < c) return r;
+    return (r > 0.0) ? c : ((r < 0.0) ? -c : 0.0);
+}
+
+/**
+ * @brief Expectation values E[psi] (epsi1) and E[psi'] (epsi2) under the
+ *        Poisson model, used to centre and weight the robust score.
+ *
+ * Source: the epsi1/epsi2 members of scitbx::glmtbx::expectation<poisson> in
+ * scitbx/glmtbx/robust_glm.h.
+ */
+struct GlmExpectation {
+    double epsi1 = 0.0;
+    double epsi2 = 0.0;
+};
+
+/**
+ * @brief Compute the Poisson expectation values epsi1 and epsi2 for a given
+ *        mean, sqrt-variance and Huber tuning constant.
+ *
+ * The p1..p10 Poisson probabilities and the epsi1/epsi2 closed forms reproduce
+ * the DIALS algebra.
+ *
+ * Source: the constructor of scitbx::glmtbx::expectation<poisson> in
+ * scitbx/glmtbx/robust_glm.h.
+ */
+FFS_HD inline GlmExpectation glm_expectation(double mu, double svar, double c) {
+    const double j1 = std::floor(mu - c * svar);
+    const double j2 = std::floor(mu + c * svar);
+    const double p1 = glm_poisson_pdf(mu, j1);        // P(Y  = j1)
+    const double p2 = glm_poisson_pdf(mu, j2);        // P(Y  = j2)
+    const double p3 = glm_poisson_cdf(mu, j1);        // P(Y <= j1)
+    const double p4 = glm_poisson_pdf(mu, j2 + 1.0);  // P(Y  = j2 + 1)
+    const double p5 = glm_poisson_cdf(mu, j2 + 1.0);  // P(Y <= j2 + 1)
+    const double p6 = 1.0 - p5 + p4;                  // P(Y >= j2 + 1)
+    const double p7 = glm_poisson_pdf(mu, j1 - 1.0);  // P(Y  = j1 - 1)
+    const double p8 = glm_poisson_pdf(mu, j2 - 1.0);  // P(Y  = j2 - 1)
+    const double p9 = glm_poisson_cdf(mu, j2 - 1.0);  // P(Y <= j2 - 1)
+    const double p10 = p9 - p3 + p1;                  // P(j1 <= Y <= j2)
+
+    GlmExpectation e;
+    e.epsi1 = c * (p6 - p3) + (mu / svar) * (p1 - p2);
+    e.epsi2 =
+      c * (p1 + p2) + (mu * mu / (svar * svar * svar)) * (p10 / mu + p7 - p1 - p8 + p2);
+    return e;
+}
+
+/**
+ * @brief Robust-Poisson GLM constant background (DIALS "glm constant3d").
+ *
+ * Single-source implementation shared by host and device. Fits a constant
+ * Poisson mean with a log link by iteratively reweighted least squares with
+ * Huber weighting, reproducing dials::algorithms::RobustPoissonMean over the
+ * same per-reflection histogram. Because every background pixel shares one
+ * design row, the fit depends only on the value counts, so the histogram is an
+ * exact representation. High-tail overflow pixels always sit far above the
+ * upper Huber bound, so their psi clips to +c regardless of their exact value,
+ * which is why the overflow count alone suffices.
+ *
+ * Iterating bins times their count and folding the overflow tail in at the
+ * saturated Huber value are exact restatements of the DIALS per-pixel loop. The
+ * sole numerical divergence is the Hessian: DIALS sums H += b per pixel while
+ * this uses N * b directly, equal in exact arithmetic but differing in
+ * floating-point rounding, so parity with DIALS holds to 1e-6 rather than
+ * bit-for-bit (see the IRLS loop below).
+ *
+ * The seed is the histogram median (matching DIALS), the tuning constant,
+ * tolerance, iteration cap and minimum pixel count match the DIALS defaults.
+ * Device-safe: no allocation, no exceptions; failure (too few pixels, range too
+ * small, non-convergence, or a degenerate parameter) is reported via
+ * BackgroundResult::valid. weighted_sum is the modelled background summed over
+ * the background pixels (mean * N), since the GLM models every pixel at mean.
+ *
+ * Source: dials::algorithms::RobustPoissonMean in
+ * dials/algorithms/background/glm/robust_poisson_mean.h (the constant-model
+ * specialisation of scitbx::glmtbx::robust_glm in scitbx/glmtbx/robust_glm.h).
+ */
+FFS_HD inline BackgroundResult glm_constant_background(const ConstHistogramView &hist) {
+    BackgroundResult result;
+
+    // Total pixel count across the histogram and the high-tail overflow.
+    uint64_t N = hist.overflow_count;
+    for (int v = 0; v < hist.num_bins; ++v) {
+        N += hist.bins[v];
+    }
+    // DIALS requires at least min_pixels background pixels to attempt a fit.
+    if (N < kGlmMinPixels) {
+        return result;
+    }
+
+    // Too much of the background in the high-tail overflow means the histogram
+    // range is too small to characterise this reflection (see
+    // tukey_constant_background); reject rather than fit a truncated histogram.
+    if (static_cast<double>(hist.overflow_count)
+        > kBackgroundMaxOverflowFraction * static_cast<double>(N)) {
+        return result;
+    }
+
+    // Median seed, matching DIALS detail::median (the element at sorted
+    // position N/2). The overflow tail counts towards the position but, for an
+    // accepted reflection, the median itself lies within the binned range.
+    const uint64_t mid = N / 2;  // 0-based target index
+    uint64_t cumulative = 0;
+    long median = -1;
+    for (int v = 0; v < hist.num_bins; ++v) {
+        cumulative += hist.bins[v];
+        if (cumulative >= mid + 1) {
+            median = v;
+            break;
+        }
+    }
+    double mean0 = (median < 0) ? 1.0 : static_cast<double>(median);
+    if (mean0 == 0.0) mean0 = 1.0;  // DIALS: a zero median seeds at 1
+
+    // IRLS for the single coefficient beta = log(mu) (constant model, log link).
+    const double c = kGlmTuningConstant;
+    double beta = std::log(mean0);
+    std::size_t niter = 0;
+    for (niter = 0; niter < static_cast<std::size_t>(kGlmMaxIter); ++niter) {
+        const double eta = beta;
+        const double mu = std::exp(eta);    // linkinv
+        const double dmu = std::exp(eta);   // dmu/deta
+        const double svar = std::sqrt(mu);  // sqrt(phi * variance), phi = 1
+        if (!(mu > 0.0) || !(svar > 0.0)) {
+            return result;  // degenerate, cannot continue (valid stays false)
+        }
+
+        const GlmExpectation epsi = glm_expectation(mu, svar, c);
+        const double b = epsi.epsi2 * dmu * dmu / svar;  // per-observation, w = 1
+
+        // U = sum over observations of (huber(res, c) - epsi1) * dmu / svar.
+        // Each bin contributes its count times the per-value term; the overflow
+        // pixels are extreme high outliers whose Huber psi clips to +c, so they
+        // contribute the same term regardless of their exact (unrecorded) value.
+        double U = 0.0;
+        for (int v = 0; v < hist.num_bins; ++v) {
+            const uint32_t count = hist.bins[v];
+            if (count == 0) {
+                continue;
+            }
+            const double res = (static_cast<double>(v) - mu) / svar;
+            const double q = (glm_huber(res, c) - epsi.epsi1) * dmu / svar;
+            U += static_cast<double>(count) * q;
+        }
+        if (hist.overflow_count > 0) {
+            const double q = (c - epsi.epsi1) * dmu / svar;
+            U += static_cast<double>(hist.overflow_count) * q;
+        }
+
+        // DIALS accumulates H += b once per observation, so H = n_obs * b. Since
+        // b is constant across observations for the constant model, this folds to
+        // N * b directly. The result is identical in exact arithmetic; the only
+        // divergence from DIALS is floating-point rounding (N * b versus summing
+        // b N times), which holds the histogram path to 1e-6 parity rather than
+        // bit-for-bit equality.
+        const double delta = U / (static_cast<double>(N) * b);
+        const double sum_delta_sq = delta * delta;
+        const double sum_beta_sq = beta * beta;
+        beta += delta;
+
+        const double error =
+          std::sqrt(sum_delta_sq / (sum_beta_sq > 1e-10 ? sum_beta_sq : 1e-10));
+        if (error < kGlmTolerance) {
+            break;
+        }
+    }
+
+    // DIALS treats a run that exhausts max_iter as non-converged and fails the
+    // reflection; mirror that, and the mean()'s bound on beta.
+    if (niter >= static_cast<std::size_t>(kGlmMaxIter)) {
+        return result;
+    }
+    if (!(beta > -300.0 && beta < 300.0)) {
+        return result;
+    }
+
+    const double mean = std::exp(beta);
+    result.mean = mean;
+    result.weighted_sum = mean * static_cast<double>(N);
     result.valid = true;
     return result;
 }

--- a/include/integrator/background.hpp
+++ b/include/integrator/background.hpp
@@ -126,8 +126,7 @@ struct BackgroundResult {
  * Single-source implementation shared by host and device. Computes the
  * quartiles of the histogram, rejects values outside
  * [q1 - 1.5*IQR, q3 + 1.5*IQR], and returns the mean and weighted sum of the
- * surviving inliers. Device-safe: no allocation, no exceptions; failure is
- * reported via BackgroundResult::valid.
+ * surviving inliers. Failure is reported via BackgroundResult::valid.
  *
  * The high tail (overflow_count) is counted towards the quartile positions but
  * never contributes inliers, since for a sensible num_bins it lies above the
@@ -322,9 +321,9 @@ FFS_HD inline GlmExpectation glm_expectation(double mu, double svar, double c) {
  * Single-source implementation shared by host and device. Fits a constant
  * Poisson mean with a log link by iteratively reweighted least squares with
  * Huber weighting, reproducing dials::algorithms::RobustPoissonMean over the
- * same per-reflection histogram. Because every background pixel shares one
- * design row, the fit depends only on the value counts, so the histogram is an
- * exact representation. High-tail overflow pixels always sit far above the
+ * same per-reflection histogram. The model treats every pixel the same, so the
+ * fit only needs the count of pixels at each value, which makes the histogram
+ * an exact representation. High-tail overflow pixels always sit far above the
  * upper Huber bound, so their psi clips to +c regardless of their exact value,
  * which is why the overflow count alone suffices.
  *
@@ -335,18 +334,15 @@ FFS_HD inline GlmExpectation glm_expectation(double mu, double svar, double c) {
  * floating-point rounding, so parity with DIALS holds to 1e-6 rather than
  * bit-for-bit (see the IRLS loop below).
  *
- * Paper symbols (constant model, design row xᵢ = (1)): coefficient β, linear
+ * Paper symbols (constant model, per-pixel term xᵢ = 1): coefficient β, linear
  * predictor η = β, mean μ = exp(η) (log link), link derivative μ′ = dμ/dη,
  * dispersion φ = 1 and variance function v_μ = μ, so √(φ*v_μ) = √μ. The IRLS
  * loop below forms the robust score U [Eq 2] and the Fisher information I [Eq 9]
  * and applies the update β ← β + I⁻¹U [Eq 5].
  *
- * The seed is the histogram median (matching DIALS), the tuning constant,
- * tolerance, iteration cap and minimum pixel count match the DIALS defaults.
- * Device-safe: no allocation, no exceptions; failure (too few pixels, range too
- * small, non-convergence, or a degenerate parameter) is reported via
- * BackgroundResult::valid. weighted_sum is the modelled background summed over
- * the background pixels (mean * N), since the GLM models every pixel at mean.
+ * Failure (too few pixels, range too small, non-convergence, or a degenerate
+ * parameter) is reported via BackgroundResult::valid. weighted_sum is mean * N,
+ * since the GLM models every background pixel at the fitted mean.
  *
  * Source: dials::algorithms::RobustPoissonMean in
  * dials/algorithms/background/glm/robust_poisson_mean.h (the constant-model

--- a/include/integrator/background.hpp
+++ b/include/integrator/background.hpp
@@ -9,6 +9,12 @@
  * for CUDA device code (GPU reduction kernel), so both paths produce identical
  * results. Background pixel values are integer counts, so a histogram with one
  * bin per integer value makes the quartile/IQR logic exact.
+ *
+ * The robust-Poisson GLM model and its symbols (η, μ, β, ψ_c, the score U and
+ * the Fisher information I) follow Parkhurst, Winter, Waterman, Fuentes-Montero,
+ * Gildea, Murshudov & Evans (2016), "Robust background modelling in DIALS",
+ * J. Appl. Cryst. 49, 1912-1921, DOI 10.1107/S1600576716013595. Equation numbers
+ * in the GLM comments below refer to that paper.
  */
 
 #pragma once
@@ -60,6 +66,8 @@ constexpr double kBackgroundMaxOverflowFraction = 0.25;
 // defaults (dials.algorithms.background.glm: tuning_constant 1.345,
 // max_iter 100, tolerance 1e-3, min_pixels 10). Held here as the single source
 // of truth so the host baseline and the device reduction iterate identically.
+// kGlmTuningConstant is the Huber tuning constant c of ψ_c [Eq 3]; 1.345 gives
+// 95% efficiency under a normal model.
 constexpr double kGlmTuningConstant = 1.345;
 constexpr double kGlmTolerance = 1e-3;
 constexpr int kGlmMaxIter = 100;
@@ -229,7 +237,8 @@ FFS_HD inline double glm_poisson_cdf(double mean, double value) {
 }
 
 /**
- * @brief Huber psi function: identity inside [-c, c], clipped to +/-c outside.
+ * @brief Huber psi function ψ_c(r) [Eq 3]: identity for |r| < c, clipped to
+ *        ±c outside.
  *
  * Source: scitbx::glmtbx::huber in scitbx/glmtbx/robust_glm.h.
  */
@@ -239,8 +248,14 @@ FFS_HD inline double glm_huber(double r, double c) {
 }
 
 /**
- * @brief Expectation values E[psi] (epsi1) and E[psi'] (epsi2) under the
- *        Poisson model, used to centre and weight the robust score.
+ * @brief Poisson expectation values used to centre and weight the robust score.
+ *
+ * epsi1 = E[ψ_c(rᵢ)], the per-observation expectation subtracted from ψ_c in
+ * the score U [Eq 2]; weighted by μ′/√(φ*v_μ) it forms the consistency
+ * correction a(β) [Eq 4]. epsi2 = E[ψ_c(rᵢ)*∂lnP(yᵢ|μ)/∂μ] (for Poisson
+ * ∂lnP/∂μ = (yᵢ - μ)/v_μ), the expectation in the diagonal bᵢ of B [Eq 10,
+ * Poisson form Eq 11]; B is the weight matrix of the Fisher information
+ * I = XᵀBX [Eq 9].
  *
  * Source: the epsi1/epsi2 members of scitbx::glmtbx::expectation<poisson> in
  * scitbx/glmtbx/robust_glm.h.
@@ -251,8 +266,9 @@ struct GlmExpectation {
 };
 
 /**
- * @brief Compute the Poisson expectation values epsi1 and epsi2 for a given
- *        mean, sqrt-variance and Huber tuning constant.
+ * @brief Compute the Poisson expectation values E[ψ_c] (epsi1) and
+ *        E[ψ_c*∂lnP/∂μ] (epsi2) for a given mean μ, sqrt-variance √(φ*v_μ) and
+ *        Huber tuning constant c.
  *
  * The p1..p10 Poisson probabilities and the epsi1/epsi2 closed forms reproduce
  * the DIALS algebra.
@@ -299,6 +315,12 @@ FFS_HD inline GlmExpectation glm_expectation(double mu, double svar, double c) {
  * this uses N * b directly, equal in exact arithmetic but differing in
  * floating-point rounding, so parity with DIALS holds to 1e-6 rather than
  * bit-for-bit (see the IRLS loop below).
+ *
+ * Paper symbols (constant model, design row xᵢ = (1)): coefficient β, linear
+ * predictor η = β, mean μ = exp(η) (log link), link derivative μ′ = dμ/dη,
+ * dispersion φ = 1 and variance function v_μ = μ, so √(φ*v_μ) = √μ. The IRLS
+ * loop below forms the robust score U [Eq 2] and the Fisher information I [Eq 9]
+ * and applies the update β ← β + I⁻¹U [Eq 5].
  *
  * The seed is the histogram median (matching DIALS), the tuning constant,
  * tolerance, iteration cap and minimum pixel count match the DIALS defaults.
@@ -348,33 +370,42 @@ FFS_HD inline BackgroundResult glm_constant_background(const ConstHistogramView 
     double mean0 = (median < 0) ? 1.0 : static_cast<double>(median);
     if (mean0 == 0.0) mean0 = 1.0;  // DIALS: a zero median seeds at 1
 
-    // IRLS for the single coefficient beta = log(mu) (constant model, log link).
+    // IRLS for the single coefficient β = log(μ) (constant model, log link).
     const double c = kGlmTuningConstant;
     double beta = std::log(mean0);
     std::size_t niter = 0;
     for (niter = 0; niter < static_cast<std::size_t>(kGlmMaxIter); ++niter) {
-        const double eta = beta;
-        const double mu = std::exp(eta);    // linkinv
-        const double dmu = std::exp(eta);   // dmu/deta
-        const double svar = std::sqrt(mu);  // sqrt(phi * variance), phi = 1
+        const double eta = beta;           // η = β
+        const double mu = std::exp(eta);   // μ = exp(η), linkinv
+        const double dmu = std::exp(eta);  // μ′ = dμ/dη, dmu/deta
+        const double svar =
+          std::sqrt(mu);  // √(φ*v_μ), φ = 1, v_μ = μ, sqrt(phi * variance), phi = 1
         if (!(mu > 0.0) || !(svar > 0.0)) {
             return result;  // degenerate, cannot continue (valid stays false)
         }
 
         const GlmExpectation epsi = glm_expectation(mu, svar, c);
-        const double b = epsi.epsi2 * dmu * dmu / svar;  // per-observation, w = 1
+        // bᵢ = epsi2*μ′²/√(φ*v_μ), the diagonal of B [Eq 10], where the
+        // expectation factor epsi2 = E[ψ_c*∂lnP/∂μ] (Poisson form, Eq 11);
+        // constant across observations here (w = 1).
+        const double b = epsi.epsi2 * dmu * dmu / svar;
 
-        // U = sum over observations of (huber(res, c) - epsi1) * dmu / svar.
-        // Each bin contributes its count times the per-value term; the overflow
-        // pixels are extreme high outliers whose Huber psi clips to +c, so they
-        // contribute the same term regardless of their exact (unrecorded) value.
+        // Robust score U = Σ (ψ_c(rᵢ) - E[ψ_c])*μ′/√(φ*v_μ) [Eq 2], with the
+        // Pearson residual rᵢ = (yᵢ - μ)/√v_μ and E[ψ_c] = epsi1. Expanding the
+        // subtraction recovers the paper's per-term form
+        // Σ (ψ_c(rᵢ)*μ′/√(φ*v_μ) - a(β)), where the consistency correction
+        // a(β) = E[ψ_c]*μ′/√(φ*v_μ) [Eq 4] (μ′ and √(φ*v_μ) are constant across
+        // observations). Each bin
+        // contributes its count times the per-value term; the overflow pixels
+        // are extreme high outliers whose ψ_c clips to +c, so they contribute
+        // the same term regardless of their exact (unrecorded) value.
         double U = 0.0;
         for (int v = 0; v < hist.num_bins; ++v) {
             const uint32_t count = hist.bins[v];
             if (count == 0) {
                 continue;
             }
-            const double res = (static_cast<double>(v) - mu) / svar;
+            const double res = (static_cast<double>(v) - mu) / svar;  // rᵢ
             const double q = (glm_huber(res, c) - epsi.epsi1) * dmu / svar;
             U += static_cast<double>(count) * q;
         }
@@ -383,12 +414,13 @@ FFS_HD inline BackgroundResult glm_constant_background(const ConstHistogramView 
             U += static_cast<double>(hist.overflow_count) * q;
         }
 
-        // DIALS accumulates H += b once per observation, so H = n_obs * b. Since
-        // b is constant across observations for the constant model, this folds to
-        // N * b directly. The result is identical in exact arithmetic; the only
-        // divergence from DIALS is floating-point rounding (N * b versus summing
-        // b N times), which holds the histogram path to 1e-6 parity rather than
-        // bit-for-bit equality.
+        // Fisher information I = XᵀBX [Eq 9], a scalar N*b for the constant
+        // model. DIALS accumulates H += b once per observation, so H = n_obs*b;
+        // since b is constant here this folds to N*b directly. The result is
+        // identical in exact arithmetic; the only divergence from DIALS is
+        // floating-point rounding (N*b versus summing b N times), which holds
+        // the histogram path to 1e-6 parity rather than bit-for-bit equality.
+        // delta = I⁻¹U, and beta += delta is the IRLS update β <- β + I⁻¹U [Eq 5].
         const double delta = U / (static_cast<double>(N) * b);
         const double sum_delta_sq = delta * delta;
         const double sum_beta_sq = beta * beta;
@@ -410,7 +442,7 @@ FFS_HD inline BackgroundResult glm_constant_background(const ConstHistogramView 
         return result;
     }
 
-    const double mean = std::exp(beta);
+    const double mean = std::exp(beta);  // μ = exp(β)
     result.mean = mean;
     result.weighted_sum = mean * static_cast<double>(N);
     result.valid = true;

--- a/integrator/background.cu
+++ b/integrator/background.cu
@@ -55,10 +55,10 @@ __global__ void background_reduce_kernel(BackgroundModel model,
         res = tukey_constant_background(view);
         break;
     case BackgroundModel::Glm:
-        // Not yet implemented; fall back to the constant model so the pipeline
-        // still produces a usable estimate. GLM (robust Poisson IRLS) will read
-        // the same histogram view.
-        res = tukey_constant_background(view);
+        // Robust-Poisson GLM constant background (DIALS "glm constant3d"),
+        // evaluated over the same histogram view by the shared single-source
+        // core so the device matches the baseline.
+        res = glm_constant_background(view);
         break;
     }
 

--- a/integrator/integrator.cc
+++ b/integrator/integrator.cc
@@ -68,9 +68,7 @@ static FGAlgorithm parse_fg_algorithm(const std::string &name) {
 
 static BackgroundModel parse_background_model(const std::string &name) {
     if (name == "constant" || name == "tukey") return BackgroundModel::Constant;
-    if (name == "glm") {
-        throw std::runtime_error("GLM background model not yet implemented");
-    }
+    if (name == "glm") return BackgroundModel::Glm;
     throw std::runtime_error("Unknown background model: " + name);
 }
 
@@ -219,8 +217,8 @@ class IntegratorArgumentParser : public CUDAArgumentParser {
 
         add_argument("--background")
           .help(
-            "Background model - constant (Tukey/IQR outlier rejection). "
-            "glm is not yet implemented.")
+            "Background model - constant (Tukey/IQR outlier rejection) or "
+            "glm (robust-Poisson GLM constant background).")
           .default_value<std::string>("constant");
 
         add_argument("--min_zeta")
@@ -1062,8 +1060,8 @@ int main(int argc, char **argv) {
             ++background_failures;
         }
 
-        // Background mean b̄ from the device-side Tukey/IQR reduction. When the
-        // estimate failed the model contributes nothing.
+        // Background mean b̄ from the device-side background reduction (the
+        // selected model). When the estimate failed the model contributes nothing.
         double bg_mean = h_background_success[i] ? h_background_mean[i] : 0.0;
 
         // Subtract background:  I = Σcᵢ(fg) − n_fg · b̄
@@ -1168,8 +1166,11 @@ int main(int argc, char **argv) {
     for (size_t i = 0; i < num_reflections; ++i) {
         nfg_out[i] = static_cast<int>(h_foreground_count[i]);
         nbg_out[i] = static_cast<int>(h_background_count[i]);
-        // background.sum.value is the Tukey inlier weighted sum; background.mean
-        // is the inlier mean. Both come from the device reduction.
+        // background.sum.value is the modelled background summed over the
+        // background pixels; background.mean is the per-pixel level. For the
+        // constant model these are the Tukey inlier sum and mean; for the GLM
+        // model the robust-Poisson sum (mean*N) and mean. Both come from the
+        // device reduction.
         bg_sum_out[i] = h_background_success[i] ? h_background_sum_value[i] : 0.0;
         bg_mean_out[i] = h_background_success[i] ? h_background_mean[i] : 0.0;
 

--- a/integrator/tests/CMakeLists.txt
+++ b/integrator/tests/CMakeLists.txt
@@ -11,7 +11,8 @@ target_link_libraries(test_extent PRIVATE
     nlohmann_json::nlohmann_json
 )
 
-add_executable(test_background test_background.cc)
+add_executable(test_background test_background.cc
+    ${CMAKE_SOURCE_DIR}/src/integrator/background.cc)
 target_include_directories(test_background PRIVATE ${CMAKE_SOURCE_DIR}/include)
 target_link_libraries(test_background PRIVATE
     GTest::gtest_main

--- a/integrator/tests/test_background.cc
+++ b/integrator/tests/test_background.cc
@@ -120,11 +120,11 @@ TEST(TukeyConstantBackground, ConstantValue) {
 // This parity tolerance is distinct from the GLM's own convergence
 // tolerance (kGlmTolerance = 1e-3, the DIALS default at which the IRLS
 // loop stops). That 1e-3 is matched to DIALS so both fits halt at the
-// same iteration. Because our core and DIALS run the same algorithm
-// with the same stopping rule, their results agree far more tightly
-// than 1e-3 (~1e-11 in practice). 1e-6 sits between that real agreement
-// and 1e-3: loose enough to absorb the documented H = N*b vs H += b
-// divergence and FP error
+// same iteration. Because the shared core and DIALS run the same
+// algorithm with the same stopping rule, their results agree far more
+// tightly than 1e-3 (~1e-11 in practice). 1e-6 sits between that real
+// agreement and 1e-3: loose enough to absorb the documented H = N*b vs
+// H += b divergence and FP error.
 namespace {
 constexpr double kDialsParityTol = 1e-6;
 }  // namespace
@@ -217,7 +217,7 @@ TEST(GlmConstantBackground, ExcessiveOverflowRejected) {
 
 // The tests above feed a ConstHistogramView straight into the model
 // functions, which bypasses the baseline host adapter. The cases below
-// tests compute_background_constant_3d, which flattens a
+// test compute_background_constant_3d, which flattens a
 // BackgroundAggregator into the same view before dispatching. They pin
 // the adapter's binning (the small/large split versus the NUM_BG_BINS
 // range, negative-sentinel drop, overflow tail) by asserting it

--- a/integrator/tests/test_background.cc
+++ b/integrator/tests/test_background.cc
@@ -14,6 +14,7 @@
 #include <gtest/gtest.h>
 
 #include <cstdint>
+#include <utility>
 #include <vector>
 
 #include "integrator/background.hpp"
@@ -97,6 +98,32 @@ TEST(TukeyConstantBackground, ConstantValue) {
 // Reference means below were produced by DIALS RobustPoissonMean (tuning
 // constant 1.345, tolerance 1e-3, max_iter 100) on the expanded histograms.
 // Matching them confirms the single-source GLM core reproduces DIALS.
+//
+// To regenerate (using DIALS): expand each histogram back into a flat
+// list of pixel values, since RobustPoissonMean takes the raw values,
+// not bin counts. For TightLowNoOutliers the list is [2,2,2, 3x5, 4x8,
+// 5x6, 6,6] (24 values). The constructor is RobustPoissonMean(Y, mean0,
+// c=1.345, tolerance=1e-3, max_iter=100), where mean0 is the median
+// seed (the sorted element at index N/2, matching the seed in
+// glm_constant_background) and overflow pixels become any value past
+// the bin range (the Huber clip makes their exact value irrelevant).
+// Run:
+//   from dials.algorithms.background.glm import RobustPoissonMean
+//   from scitbx.array_family import flex
+//   m = RobustPoissonMean(flex.double(values), 4.0, 1.345, 1e-3, 100)
+//   print(m.mean())
+// and paste the result. The values are frozen constants, so any change
+// to the tuning constant, tolerance, or max_iter above invalidates them
+// and they must be regenerated this way.
+
+// This parity tolerance is distinct from the GLM's own convergence
+// tolerance (kGlmTolerance = 1e-3, the DIALS default at which the IRLS
+// loop stops). That 1e-3 is matched to DIALS so both fits halt at the
+// same iteration. Because our core and DIALS run the same algorithm
+// with the same stopping rule, their results agree far more tightly
+// than 1e-3 (~1e-11 in practice). 1e-6 sits between that real agreement
+// and 1e-3: loose enough to absorb the documented H = N*b vs H += b
+// divergence and FP error
 namespace {
 constexpr double kDialsParityTol = 1e-6;
 }  // namespace
@@ -131,10 +158,13 @@ TEST(GlmConstantBackground, HighOutlierDownweighted) {
     BackgroundResult r = glm_constant_background(view_of(bins));
     ASSERT_TRUE(r.valid);
     EXPECT_NEAR(r.mean, 4.1427022177, kDialsParityTol);
+    // Sum is mean over all N background pixels, the outlier included.
+    EXPECT_DOUBLE_EQ(r.weighted_sum, r.mean * 25.0);
 }
 
-// Overflow-tail pixels clip to the Huber bound regardless of their exact value,
-// so the overflow count alone reproduces the DIALS result. N = 89 (4 overflow).
+// Overflow-tail pixels clip to the Huber bound regardless of their
+// exact value, so the overflow count alone reproduces the DIALS result.
+// N = 89 (4 overflow).
 TEST(GlmConstantBackground, OverflowTailClips) {
     std::vector<uint32_t> bins(NUM_BG_BINS, 0);
     bins[2] = 10;
@@ -145,6 +175,8 @@ TEST(GlmConstantBackground, OverflowTailClips) {
     BackgroundResult r = glm_constant_background(view_of(bins, 4));
     ASSERT_TRUE(r.valid);
     EXPECT_NEAR(r.mean, 4.0257619071, kDialsParityTol);
+    // N counts the 4 overflow pixels too, so the sum is mean over all 89.
+    EXPECT_DOUBLE_EQ(r.weighted_sum, r.mean * 89.0);
 }
 
 // Higher background level. N = 27, median seed 50.
@@ -159,6 +191,7 @@ TEST(GlmConstantBackground, ModerateLevel) {
     BackgroundResult r = glm_constant_background(view_of(bins));
     ASSERT_TRUE(r.valid);
     EXPECT_NEAR(r.mean, 51.6834964586, kDialsParityTol);
+    EXPECT_DOUBLE_EQ(r.weighted_sum, r.mean * 27.0);
 }
 
 // Fewer than kGlmMinPixels background pixels -> no estimate (matches DIALS,
@@ -179,4 +212,148 @@ TEST(GlmConstantBackground, ExcessiveOverflowRejected) {
 
     BackgroundResult r = glm_constant_background(view_of(bins, 20));  // 50% overflow
     EXPECT_FALSE(r.valid);
+}
+
+// The tests above feed a ConstHistogramView straight into the model
+// functions, which bypasses the baseline host adapter. The cases below
+// tests compute_background_constant_3d, which flattens a
+// BackgroundAggregator into the same view before dispatching. They pin
+// the adapter's binning (the small/large split versus the NUM_BG_BINS
+// range, negative-sentinel drop, overflow tail) by asserting it
+// reproduces the already-DIALS-pinned direct-view results.
+namespace {
+
+// Build an aggregator by adding each (value, count) pair count times, matching
+// how the Kabsch kernel feeds pixels in one at a time.
+BackgroundAggregator aggregator_of(
+  const std::vector<std::pair<int, int>> &value_counts) {
+    BackgroundAggregator agg;
+    for (const auto &[value, count] : value_counts) {
+        for (int n = 0; n < count; ++n) agg.add(value);
+    }
+    return agg;
+}
+
+// Assert two BackgroundResults are bit-for-bit identical (same bins in, so the
+// adapter and the direct view must agree exactly, not just to a tolerance).
+void expect_same_result(const BackgroundResult &a, const BackgroundResult &b) {
+    EXPECT_EQ(a.valid, b.valid);
+    if (a.valid && b.valid) {
+        EXPECT_DOUBLE_EQ(a.mean, b.mean);
+        EXPECT_DOUBLE_EQ(a.weighted_sum, b.weighted_sum);
+    }
+}
+
+}  // namespace
+
+// No background pixels -> no estimate, for either model.
+TEST(BackgroundAdapter, EmptyAggregatorFails) {
+    BackgroundAggregator agg;  // num_pixels() == 0
+    EXPECT_FALSE(compute_background_constant_3d(agg, BackgroundModel::Constant).valid);
+    EXPECT_FALSE(compute_background_constant_3d(agg, BackgroundModel::Glm).valid);
+}
+
+// The adapter's flattened histogram must reproduce the direct-view GLM result.
+// Same data as GlmConstantBackground.TightLowNoOutliers.
+TEST(BackgroundAdapter, MatchesDirectViewGlm) {
+    std::vector<uint32_t> bins(NUM_BG_BINS, 0);
+    bins[2] = 3;
+    bins[3] = 5;
+    bins[4] = 8;
+    bins[5] = 6;
+    bins[6] = 2;
+    BackgroundResult direct = glm_constant_background(view_of(bins));
+
+    BackgroundAggregator agg = aggregator_of({{2, 3}, {3, 5}, {4, 8}, {5, 6}, {6, 2}});
+    BackgroundResult adapted =
+      compute_background_constant_3d(agg, BackgroundModel::Glm);
+
+    ASSERT_TRUE(adapted.valid);
+    expect_same_result(adapted, direct);
+}
+
+// Same parity check for the Tukey/constant model.
+// Same data as TukeyConstantBackground.UniformNoOutliers.
+TEST(BackgroundAdapter, MatchesDirectViewTukey) {
+    std::vector<uint32_t> bins(64, 0);
+    for (int v = 0; v <= 9; ++v) bins[v] = 1;
+    BackgroundResult direct = tukey_constant_background(view_of(bins));
+
+    std::vector<std::pair<int, int>> value_counts;
+    for (int v = 0; v <= 9; ++v) value_counts.push_back({v, 1});
+    BackgroundAggregator agg = aggregator_of(value_counts);
+    BackgroundResult adapted =
+      compute_background_constant_3d(agg, BackgroundModel::Constant);
+
+    ASSERT_TRUE(adapted.valid);
+    expect_same_result(adapted, direct);
+}
+
+// A value in [VECTOR_LIMIT, NUM_BG_BINS) lands in the aggregator's large_hist
+// map but must be flattened to an in-range bin, not the overflow tail. 120 is
+// the outlier value from GlmConstantBackground.HighOutlierDownweighted.
+TEST(BackgroundAdapter, LargeHistValueBinnedInRange) {
+    std::vector<uint32_t> bins(NUM_BG_BINS, 0);
+    bins[2] = 3;
+    bins[3] = 5;
+    bins[4] = 8;
+    bins[5] = 6;
+    bins[6] = 2;
+    bins[120] = 1;  // in-range, not overflow
+    BackgroundResult direct = glm_constant_background(view_of(bins));
+
+    BackgroundAggregator agg =
+      aggregator_of({{2, 3}, {3, 5}, {4, 8}, {5, 6}, {6, 2}, {120, 1}});
+    BackgroundResult adapted =
+      compute_background_constant_3d(agg, BackgroundModel::Glm);
+
+    ASSERT_TRUE(adapted.valid);
+    expect_same_result(adapted, direct);
+}
+
+// Values at or above NUM_BG_BINS must be counted in the overflow tail, where
+// they clip to the Huber bound. Same data as GlmConstantBackground.OverflowTailClips
+// (4 overflow pixels), here fed as concrete out-of-range values.
+TEST(BackgroundAdapter, OverflowTailCounted) {
+    std::vector<uint32_t> bins(NUM_BG_BINS, 0);
+    bins[2] = 10;
+    bins[3] = 20;
+    bins[4] = 30;
+    bins[5] = 25;
+    BackgroundResult direct = glm_constant_background(view_of(bins, 4));
+
+    BackgroundAggregator agg =
+      aggregator_of({{2, 10}, {3, 20}, {4, 30}, {5, 25}, {5000, 4}});
+    BackgroundResult adapted =
+      compute_background_constant_3d(agg, BackgroundModel::Glm);
+
+    ASSERT_TRUE(adapted.valid);
+    expect_same_result(adapted, direct);
+}
+
+// Negative pixels are sentinels, dropped by the adapter rather than counted.
+// Adding them must not change the estimate.
+TEST(BackgroundAdapter, NegativeSentinelDropped) {
+    std::vector<std::pair<int, int>> base = {{2, 3}, {3, 5}, {4, 8}, {5, 6}, {6, 2}};
+    BackgroundAggregator clean = aggregator_of(base);
+    BackgroundResult without =
+      compute_background_constant_3d(clean, BackgroundModel::Glm);
+
+    std::vector<std::pair<int, int>> with_sentinels = base;
+    with_sentinels.push_back({-1, 3});
+    with_sentinels.push_back({-100, 2});
+    BackgroundAggregator dirty = aggregator_of(with_sentinels);
+    BackgroundResult with = compute_background_constant_3d(dirty, BackgroundModel::Glm);
+
+    ASSERT_TRUE(without.valid);
+    expect_same_result(with, without);
+}
+
+// Too much of the background in the overflow tail trips the adapter's
+// overflow-fraction guard before the model runs.
+TEST(BackgroundAdapter, ExcessiveOverflowRejected) {
+    // 20 in range, 20 overflow -> 50% overflow, above kBackgroundMaxOverflowFraction.
+    BackgroundAggregator agg = aggregator_of({{3, 10}, {4, 10}, {5000, 20}});
+    EXPECT_FALSE(compute_background_constant_3d(agg, BackgroundModel::Glm).valid);
+    EXPECT_FALSE(compute_background_constant_3d(agg, BackgroundModel::Constant).valid);
 }

--- a/integrator/tests/test_background.cc
+++ b/integrator/tests/test_background.cc
@@ -1,12 +1,14 @@
 /**
  * @file test_background.cc
- * @brief Host unit tests for the single-source constant (Tukey/IQR) background
- *        model in integrator/background.hpp.
+ * @brief Host unit tests for the single-source background models in
+ *        integrator/background.hpp.
  *
- * These exercise tukey_constant_background() directly over hand-built
- * histograms with known quartiles and outliers, independent of CUDA. The same
- * function is compiled for the device, so locking its behaviour here also pins
- * the GPU reduction's result.
+ * These exercise tukey_constant_background() and glm_constant_background()
+ * directly over hand-built histograms, independent of CUDA. The same functions
+ * are compiled for the device, so locking their behaviour here also pins the
+ * GPU reduction's result. The GLM expected values come from DIALS
+ * RobustPoissonMean run on the expanded histograms, so the tests assert parity
+ * with DIALS.
  */
 
 #include <gtest/gtest.h>
@@ -90,4 +92,91 @@ TEST(TukeyConstantBackground, ConstantValue) {
     ASSERT_TRUE(r.valid);
     EXPECT_DOUBLE_EQ(r.mean, 5.0);
     EXPECT_DOUBLE_EQ(r.weighted_sum, 100.0);
+}
+
+// Reference means below were produced by DIALS RobustPoissonMean (tuning
+// constant 1.345, tolerance 1e-3, max_iter 100) on the expanded histograms.
+// Matching them confirms the single-source GLM core reproduces DIALS.
+namespace {
+constexpr double kDialsParityTol = 1e-6;
+}  // namespace
+
+// Tight low background, no outliers. N = 24, median seed 4.
+TEST(GlmConstantBackground, TightLowNoOutliers) {
+    std::vector<uint32_t> bins(NUM_BG_BINS, 0);
+    bins[2] = 3;
+    bins[3] = 5;
+    bins[4] = 8;
+    bins[5] = 6;
+    bins[6] = 2;
+
+    BackgroundResult r = glm_constant_background(view_of(bins));
+    ASSERT_TRUE(r.valid);
+    EXPECT_NEAR(r.mean, 4.0304431542, kDialsParityTol);
+    // GLM models every background pixel at mean, so the reported sum is mean*N.
+    EXPECT_DOUBLE_EQ(r.weighted_sum, r.mean * 24.0);
+}
+
+// A single in-range high outlier is down-weighted, not rejected outright, so it
+// shifts the mean slightly. N = 25, median seed 4.
+TEST(GlmConstantBackground, HighOutlierDownweighted) {
+    std::vector<uint32_t> bins(NUM_BG_BINS, 0);
+    bins[2] = 3;
+    bins[3] = 5;
+    bins[4] = 8;
+    bins[5] = 6;
+    bins[6] = 2;
+    bins[120] = 1;
+
+    BackgroundResult r = glm_constant_background(view_of(bins));
+    ASSERT_TRUE(r.valid);
+    EXPECT_NEAR(r.mean, 4.1427022177, kDialsParityTol);
+}
+
+// Overflow-tail pixels clip to the Huber bound regardless of their exact value,
+// so the overflow count alone reproduces the DIALS result. N = 89 (4 overflow).
+TEST(GlmConstantBackground, OverflowTailClips) {
+    std::vector<uint32_t> bins(NUM_BG_BINS, 0);
+    bins[2] = 10;
+    bins[3] = 20;
+    bins[4] = 30;
+    bins[5] = 25;
+
+    BackgroundResult r = glm_constant_background(view_of(bins, 4));
+    ASSERT_TRUE(r.valid);
+    EXPECT_NEAR(r.mean, 4.0257619071, kDialsParityTol);
+}
+
+// Higher background level. N = 27, median seed 50.
+TEST(GlmConstantBackground, ModerateLevel) {
+    std::vector<uint32_t> bins(NUM_BG_BINS, 0);
+    bins[48] = 4;
+    bins[50] = 10;
+    bins[52] = 8;
+    bins[55] = 3;
+    bins[60] = 2;
+
+    BackgroundResult r = glm_constant_background(view_of(bins));
+    ASSERT_TRUE(r.valid);
+    EXPECT_NEAR(r.mean, 51.6834964586, kDialsParityTol);
+}
+
+// Fewer than kGlmMinPixels background pixels -> no estimate (matches DIALS,
+// which asserts num_background >= min_pixels).
+TEST(GlmConstantBackground, TooFewPixelsFails) {
+    std::vector<uint32_t> bins(NUM_BG_BINS, 0);
+    for (int v = 3; v < 8; ++v) bins[v] = 1;  // N = 5 < kGlmMinPixels
+
+    BackgroundResult r = glm_constant_background(view_of(bins));
+    EXPECT_FALSE(r.valid);
+}
+
+// Too much of the background in the overflow tail -> range too small, rejected.
+TEST(GlmConstantBackground, ExcessiveOverflowRejected) {
+    std::vector<uint32_t> bins(NUM_BG_BINS, 0);
+    bins[3] = 10;
+    bins[4] = 10;  // 20 in range
+
+    BackgroundResult r = glm_constant_background(view_of(bins, 20));  // 50% overflow
+    EXPECT_FALSE(r.valid);
 }

--- a/src/integrator/background.cc
+++ b/src/integrator/background.cc
@@ -7,17 +7,19 @@
 #include "integrator/background.hpp"
 
 #include <cstdint>
-#include <stdexcept>
 #include <vector>
 
-// Tukey outlier-rejecting constant background. Delegates to the single-source
-// tukey_constant_background() so the baseline and the GPU run identical math;
+// Constant background estimate for one reflection. Delegates to the
+// single-source model functions so the baseline and the GPU run identical math;
 // this function only flattens the aggregator's array and overflow map into a
-// contiguous ConstHistogramView over the shared NUM_BG_BINS range.
-std::tuple<double, double> compute_background_constant_3d(
-  const BackgroundAggregator &data) {
+// contiguous ConstHistogramView over the shared NUM_BG_BINS range, then
+// dispatches on the selected model. A rejected estimate returns a
+// BackgroundResult with valid=false (the same channel the GPU reduction uses)
+// so the caller can mark the reflection unintegrated rather than aborting.
+BackgroundResult compute_background_constant_3d(const BackgroundAggregator &data,
+                                                BackgroundModel model) {
     if (data.num_pixels() == 0) {
-        throw std::runtime_error("No background pixels available");
+        return BackgroundResult{};  // no background pixels, so no estimate
     }
 
     const auto &small_hist = data.small_hist();
@@ -53,22 +55,28 @@ std::tuple<double, double> compute_background_constant_3d(
 
     // Too many pixels in the overflow tail means NUM_BG_BINS is too small to
     // represent this reflection's background, so the estimate would diverge
-    // from a full-range computation. Fail loudly rather than degrade silently.
+    // from a full-range computation. Reject it (the model functions apply the
+    // same guard internally; this short-circuits with the explicit reason).
     // The denominator is the histogram population (in-range + overflow), which
     // matches the GPU reduction's count and excludes dropped sentinels.
     if (static_cast<double>(overflow_count)
         > kBackgroundMaxOverflowFraction
             * static_cast<double>(in_range_count + overflow_count)) {
-        throw std::runtime_error(
-          "Background histogram overflow exceeded the permitted fraction; "
-          "NUM_BG_BINS is too small for this reflection's background level");
+        return BackgroundResult{};
     }
 
-    BackgroundResult result = tukey_constant_background(view);
-    if (!result.valid) {
-        throw std::runtime_error(
-          "No background data remaining after outlier rejection");
+    // Dispatch to the selected single-source model, mirroring the GPU kernel.
+    // The model functions already report rejection via BackgroundResult::valid.
+    // No default case, so adding a BackgroundModel raises a -Wswitch warning here
+    // until it is handled.
+    switch (model) {
+    case BackgroundModel::Constant:
+        return tukey_constant_background(view);
+    case BackgroundModel::Glm:
+        return glm_constant_background(view);
     }
 
-    return {result.mean, result.weighted_sum};
+    // Unreachable: parse_background_model rejects unknown names. Keeps the
+    // function total for an out-of-range model value.
+    return BackgroundResult{};
 }

--- a/tests/test_baseline_integrator.py
+++ b/tests/test_baseline_integrator.py
@@ -28,6 +28,8 @@ def test_baseline_integrator_dials_equivalence(tmp_path, dials_data):
             "0.03",
             "--sigma_m",
             "0.1",
+            "--background",
+            "dials"
         ],
         capture_output=True,
         text=True,
@@ -122,6 +124,8 @@ def test_baseline_integrator_ellipsoid(tmp_path, dials_data):
             "0.03",
             "--sigma_m",
             "0.1",
+            "--background",
+            "dials"
         ],
         capture_output=True,
         text=True,

--- a/tests/test_baseline_integrator.py
+++ b/tests/test_baseline_integrator.py
@@ -29,7 +29,7 @@ def test_baseline_integrator_dials_equivalence(tmp_path, dials_data):
             "--sigma_m",
             "0.1",
             "--background",
-            "dials"
+            "dials",
         ],
         capture_output=True,
         text=True,
@@ -125,7 +125,7 @@ def test_baseline_integrator_ellipsoid(tmp_path, dials_data):
             "--sigma_m",
             "0.1",
             "--background",
-            "dials"
+            "dials",
         ],
         capture_output=True,
         text=True,


### PR DESCRIPTION
This PR fills in the `Glm` branch that #109 reserved, adding the DIALS
robust-Poisson GLM constant background to the GPU integrator. As with
the Tukey model, the GLM core is written once as a `__host__ __device__`
function over the same per-reflection integer-histogram view and
compiled into both the baseline and the device, so the two paths produce
matching estimates analagous to DIALS' `glm constant3d`.

It reads the same histogram the Tukey model already accumulates, so
there are no new device buffers or major changes to the reduction.

### Changes:

- Adds `glm_constant_background()` in
  `include/integrator/background.hpp`: an IRLS fit of a constant Poisson
  mean (log link) with Huber weighting, seeded from the histogram
  median, reproducing `dials::algorithms::RobustPoissonMean`. The tuning
  constant (1.345), tolerance (1e-3), iteration cap (100) and minimum
  pixel count (10) match the DIALS defaults and live alongside
  `NUM_BG_BINS` as shared constants. Failures (too few pixels, too much
  overflow, non-convergence, or a degenerate parameter) are reported
  through the `BackgroundResult::valid` channel the device reduction
  already uses.

- Evaluates the Poisson CDF as a finite sum rather than
  `boost::math::gamma_q`, which is exact for the integer argument here
  and removes the special-function dependency on the device. High-tail
  overflow pixels sit far above the upper Huber bound, so their weight
  clips to `+c` regardless of value, which is why the overflow count
  alone suffices.

- Reuses the same overflow gate Tukey applies (reject when more than 25%
  of a reflection's background pixels land above `NUM_BG_BINS`). The GLM
  has no analogue of Tukey's second, tuning-parameter-aware range guard
  (`q3 + 1.5*IQR >= num_bins`): the Huber weighting clips the high tail
  into the score rather than fencing it against the range, so the
  overflow-fraction test is its only range gate.

- Dispatches the `Glm` branch in the device reduction
  (`integrator/background.cu`) and accepts `glm` in
  `parse_background_model`, alongside the existing `constant`/`tukey`.
  `background.sum.value` is `mean * N`, since the GLM models every
  background pixel at the fitted mean.

- Adds GLM parity tests to `test_background.cc`, locking the core
  against DIALS fixture values (tight low background, a downweighted
  high outlier, a clipped overflow tail, a moderate level, and the
  too-few- pixels and excessive-overflow rejections). These assert to
  1e-6 rather than bit-equality: the Fisher information is taken as `N *
  b` directly where DIALS sums `b` per pixel, equal in exact arithmetic
  but differing in floating-point rounding.

Closes #96.