### PR TITLE
Optimise the GPU Kabsch kernel by making it shoebox-parallel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,7 @@ _build*/
 # Python build artifacts
 *.egg-info/
 .venv/
+
+# Profiling artifacts
+profiling/
+out/

--- a/integrator/integrator.cc
+++ b/integrator/integrator.cc
@@ -11,6 +11,8 @@
 #include <bitshuffle.h>
 
 #include <Eigen/Dense>
+#include <algorithm>
+#include <array>
 #include <atomic>
 #include <barrier>
 #include <chrono>
@@ -70,6 +72,85 @@ static BackgroundModel parse_background_model(const std::string &name) {
     if (name == "constant" || name == "tukey") return BackgroundModel::Constant;
     if (name == "glm") return BackgroundModel::Glm;
     throw std::runtime_error("Unknown background model: " + name);
+}
+
+/**
+ * @brief Build a per-block pass-count histogram for the Kabsch kernel as one
+ * multi-line string (a startup diagnostic; the caller logs it at debug level).
+ *
+ * Each reflection launches one GPU block per image it spans, and every block
+ * strides a block_threads-wide thread vector over the shoebox's w*h pixels, so
+ * it makes ceil(w*h / block_threads) passes. Every pass but the last fills all
+ * lanes; the tail pass is the only place lanes sit idle. Blocks are bucketed by
+ * pass count, weighted by z-depth (the real block population), and summarised
+ * with the overall lane utilisation. One pass over the reflections,
+ * O(bboxes.size()); returns an empty string when there are no blocks.
+ */
+static std::string format_shoebox_pass_histogram(
+  const std::vector<BoundingBoxExtents> &bboxes,
+  const std::vector<uint8_t> &dont_integrate,
+  int block_threads) {
+    struct Bucket {
+        int lo;  // inclusive pass count
+        int hi;  // inclusive pass count
+        const char *label;
+    };
+    static constexpr std::array<Bucket, 6> buckets = {{{1, 1, "    1x"},
+                                                       {2, 2, "    2x"},
+                                                       {3, 4, "  3-4x"},
+                                                       {5, 8, "  5-8x"},
+                                                       {9, 16, " 9-16x"},
+                                                       {17, 1 << 30, "  >16x"}}};
+    std::array<size_t, 6> block_counts{};
+    size_t total_blocks = 0;
+    size_t total_px = 0;
+    size_t total_slots = 0;  // passes * block_threads, i.e. lanes launched
+    for (size_t refl_id = 0; refl_id < bboxes.size(); ++refl_id) {
+        if (dont_integrate[refl_id]) continue;
+        const auto &bbox = bboxes[refl_id];
+        const int npix = (bbox.x_max - bbox.x_min) * (bbox.y_max - bbox.y_min);
+        const int depth = bbox.z_max - bbox.z_min;
+        if (npix <= 0 || depth <= 0) continue;
+        const size_t d = static_cast<size_t>(depth);
+        const int passes = (npix + block_threads - 1) / block_threads;
+        for (size_t b = 0; b < buckets.size(); ++b) {
+            if (passes >= buckets[b].lo && passes <= buckets[b].hi) {
+                block_counts[b] += d;
+                break;
+            }
+        }
+        total_blocks += d;
+        total_px += static_cast<size_t>(npix) * d;
+        total_slots += static_cast<size_t>(passes) * block_threads * d;
+    }
+    if (total_blocks == 0) return {};
+
+    const size_t max_count =
+      *std::max_element(block_counts.begin(), block_counts.end());
+    constexpr int kBarWidth = 24;
+    std::string out =
+      fmt::format("Shoebox passes per block over {} GPU blocks ({} threads/block):",
+                  total_blocks,
+                  block_threads);
+    for (size_t b = 0; b < buckets.size(); ++b) {
+        const int fill =
+          max_count ? static_cast<int>((block_counts[b] * kBarWidth + max_count - 1)
+                                       / max_count)
+                    : 0;
+        std::string bar;
+        for (int i = 0; i < kBarWidth; ++i) bar += (i < fill) ? "█" : "░";
+        out += fmt::format("\n  {}  {}  {:5.1f}%  ({})",
+                           buckets[b].label,
+                           bar,
+                           100.0 * block_counts[b] / total_blocks,
+                           block_counts[b]);
+    }
+    out += fmt::format(
+      "\n  avg {:.0f} px/block, {:.1f} passes/block, {:.0f}% lane utilisation",
+      static_cast<double>(total_px) / total_blocks,
+      static_cast<double>(total_slots) / total_blocks / block_threads,
+      100.0 * total_px / total_slots);
+    return out;
 }
 
 using namespace std::chrono_literals;
@@ -545,6 +626,14 @@ int main(int argc, char **argv) {
                     min_refls_per_image,
                     max_refls_per_image,
                     avg_refls_per_image);
+    }
+
+    // Per-block pass-count histogram for the Kabsch kernel. The guard
+    // skips the O(num_reflections) scan entirely at higher levels.
+    if (logger.should_log(spdlog::level::debug)) {
+        std::string hist = format_shoebox_pass_histogram(
+          computed_bboxes, dont_integrate, static_cast<int>(KABSCH_THREADS));
+        if (!hist.empty()) logger.debug("{}", hist);
     }
 
     // Get threading parameters (0 = auto-select)

--- a/integrator/integrator.cc
+++ b/integrator/integrator.cc
@@ -664,31 +664,6 @@ int main(int argc, char **argv) {
     DeviceBuffer<uint8_t> d_mask(static_cast<size_t>(width) * height);
     d_mask.assign(h_mask.data());
 
-    // Reflection bboxes are not clamped to the detector in x/y, so
-    // foreground pixels can fall outside the image. The launch grid is
-    // padded to span this overflow; its origin may be negative.
-    // Foreground pixels landing outside the image fail their reflection
-    // in the kernel.
-    int grid_origin_x = 0;
-    int grid_origin_y = 0;
-    int grid_max_x = static_cast<int>(width);
-    int grid_max_y = static_cast<int>(height);
-    for (size_t i = 0; i < num_reflections; ++i) {
-        if (dont_integrate[i]) continue;
-        const auto &bb = computed_bboxes[i];
-        grid_origin_x = std::min(grid_origin_x, bb.x_min);
-        grid_origin_y = std::min(grid_origin_y, bb.y_min);
-        grid_max_x = std::max(grid_max_x, bb.x_max + 1);
-        grid_max_y = std::max(grid_max_y, bb.y_max + 1);
-    }
-    uint32_t grid_w = static_cast<uint32_t>(grid_max_x - grid_origin_x);
-    uint32_t grid_h = static_cast<uint32_t>(grid_max_y - grid_origin_y);
-    logger.info("Kabsch launch grid: origin=({},{}), extent={}x{}",
-                grid_origin_x,
-                grid_origin_y,
-                grid_w,
-                grid_h);
-
     DetectorParameters det_params = make_detector_params(panel);
 
     // Convert beam parameters to Vector3D
@@ -910,10 +885,6 @@ int main(int argc, char **argv) {
                                          d_reflection_indices.data(),
                                          num_refls_this_image,
                                          d_mask.data(),
-                                         grid_origin_x,
-                                         grid_origin_y,
-                                         grid_w,
-                                         grid_h,
                                          delta_b,
                                          delta_m,
                                          fg_algorithm,

--- a/integrator/kabsch.cu
+++ b/integrator/kabsch.cu
@@ -437,9 +437,9 @@ __global__ void kabsch_transform(pixel_t *d_image,
     const scalar_t phi_c = d_phi_values[refl_idx];
     const BoundingBoxExtents bbox = d_bboxes[refl_idx];
 
-    // The host lists a reflection only under the images its bbox spans, so this
-    // z-test normally passes; kept for parity/safety with the old block filter.
-    if (!(image_num >= bbox.z_min && image_num < bbox.z_max)) return;
+    // The shoebox's z-range is half-open: [z_min, z_max). The current
+    // image_num must be within that range.
+    assert(image_num >= bbox.z_min && image_num < bbox.z_max);
 
     // The voxel's two z-faces, one image apart. slice converts the 0-based
     // image_num to the (z + 1 - image_range_start) frame used everywhere else.

--- a/integrator/kabsch.cu
+++ b/integrator/kabsch.cu
@@ -109,7 +109,6 @@ __device__ __forceinline__ bool is_foreground(const Vector3D &eps,
  * @param s_pixel Diffracted vector at the current pixel (S′), units of 1/Å
  * @param phi_pixel Rotation angle at the pixel (φ′), in radians
  * @param rot_axis Unit goniometer rotation axis vector (m₂)
- * @param s1_len_out Output parameter for magnitude of s₁ᶜ (|s₁|)
  * @return Transformed coordinates in Kabsch space (ε₁, ε₂, ε₃)
  */
 __device__ Vector3D pixel_to_kabsch(const Vector3D &s0,
@@ -117,8 +116,7 @@ __device__ Vector3D pixel_to_kabsch(const Vector3D &s0,
                                     scalar_t phi_c,
                                     const Vector3D &s_pixel,
                                     scalar_t phi_pixel,
-                                    const Vector3D &rot_axis,
-                                    scalar_t &s1_len_out) {
+                                    const Vector3D &rot_axis) {
     // Define the local Kabsch basis vectors:
 
     // e1 is perpendicular to the scattering plane
@@ -132,7 +130,6 @@ __device__ Vector3D pixel_to_kabsch(const Vector3D &s0,
 
     // Compute the length of the predicted diffracted vector (|s₁|)
     scalar_t s1_len = norm(s1_c);
-    s1_len_out = s1_len;
 
     // Rotation offset between the pixel and reflection centre
     scalar_t dphi = phi_pixel - phi_c;
@@ -314,7 +311,6 @@ __device__ __forceinline__ bool pixel_is_foreground(
         for (int dx = 0; dx <= 1; ++dx) {
             const Vector3D s_pixel =
               corner_s_pixel(px + dx, py + dy, d_matrix, wavelength, det_params);
-            scalar_t s1_len;  // unused here, required by pixel_to_kabsch
 
             // `if constexpr` resolves at compile time; only the chosen branch is
             // emitted into each kernel specialization, so the unused algorithm's
@@ -322,24 +318,24 @@ __device__ __forceinline__ bool pixel_is_foreground(
             if constexpr (Algo == FGAlgorithm::Ellipsoid) {
                 // Lower z-face (phi_low)
                 Vector3D eps_lo =
-                  pixel_to_kabsch(s0, s1_c, phi_c, s_pixel, phi_low, rot_axis, s1_len);
+                  pixel_to_kabsch(s0, s1_c, phi_c, s_pixel, phi_low, rot_axis);
                 if (is_foreground(eps_lo, delta_b, delta_m)) return true;
 
                 // Upper z-face (phi_high)
                 Vector3D eps_hi =
-                  pixel_to_kabsch(s0, s1_c, phi_c, s_pixel, phi_high, rot_axis, s1_len);
+                  pixel_to_kabsch(s0, s1_c, phi_c, s_pixel, phi_high, rot_axis);
                 if (is_foreground(eps_hi, delta_b, delta_m)) return true;
 
                 // Centre z-slice: evaluate at phi_c where ε₃ = 0
                 if (centre_in_z_slice) {
-                    Vector3D eps_c = pixel_to_kabsch(
-                      s0, s1_c, phi_c, s_pixel, phi_c, rot_axis, s1_len);
+                    Vector3D eps_c =
+                      pixel_to_kabsch(s0, s1_c, phi_c, s_pixel, phi_c, rot_axis);
                     if (is_foreground(eps_c, delta_b, delta_m)) return true;
                 }
             } else {
                 // DIALS: single 2D ellipse, evaluated at phi_low; ε₃ ignored
                 Vector3D eps =
-                  pixel_to_kabsch(s0, s1_c, phi_c, s_pixel, phi_low, rot_axis, s1_len);
+                  pixel_to_kabsch(s0, s1_c, phi_c, s_pixel, phi_low, rot_axis);
                 scalar_t inv_delta_b_sq = scalar_t(1.0) / (delta_b * delta_b);
                 scalar_t ellipsoid_val =
                   (eps.x * eps.x + eps.y * eps.y) * inv_delta_b_sq;

--- a/integrator/kabsch.cu
+++ b/integrator/kabsch.cu
@@ -59,12 +59,6 @@
 
 using namespace fastvec;
 
-// Threads per block for the shoebox-parallel Kabsch kernel. One block handles
-// one reflection shoebox; its threads stride over the shoebox's w×h pixels, so
-// this is a scheduling knob, not a shoebox-size limit. 128 keeps register
-// pressure low enough for several blocks per SM; tune against the profiler.
-constexpr int KABSCH_THREADS = 128;
-
 /**
  * @brief Check if a pixel is in the foreground region of a reflection
  *

--- a/integrator/kabsch.cu
+++ b/integrator/kabsch.cu
@@ -59,26 +59,11 @@
 
 using namespace fastvec;
 
-// Block dimensions for the Kabsch transform kernel.
-// Used by both the kernel (shared memory sizing) and host wrapper (grid launch).
-//
-// Each block of KABSCH_BLOCK_X × KABSCH_BLOCK_Y threads maps 1:1 to corners.
-// A pixel's voxel has 4 xy-corners: (px,py), (px+1,py), (px,py+1), (px+1,py+1).
-// All 4 must be in the same block's shared memory so the pixel thread can read
-// them after __syncthreads(). This means a block of 32×16 corners can only
-// service (32-1)×(16-1) = 31×15 complete pixels. The rightmost column and
-// bottom row of threads are "helper" corners that exist solely so the last
-// interior pixel has a right/bottom neighbour to read.
-//
-// The grid is launched with a stride of (BLOCK-1) so adjacent blocks overlap
-// by one column/row of corners.  That single shared column/row is computed
-// by both blocks (redundantly), which costs ~3-6% extra work but keeps
-// everything in fast shared memory within a single kernel launch.
-constexpr int KABSCH_BLOCK_X = 32;
-constexpr int KABSCH_BLOCK_Y = 16;
-
-// Maximum number of reflections that can overlap a single block's footprint
-constexpr size_t MAX_BLOCK_REFLECTIONS = 64;
+// Threads per block for the shoebox-parallel Kabsch kernel. One block handles
+// one reflection shoebox; its threads stride over the shoebox's w×h pixels, so
+// this is a scheduling knob, not a shoebox-size limit. 128 keeps register
+// pressure low enough for several blocks per SM; tune against the profiler.
+constexpr int KABSCH_THREADS = 128;
 
 /**
  * @brief Check if a pixel is in the foreground region of a reflection
@@ -251,20 +236,141 @@ __device__ __forceinline__ void px_to_mm(int gx,
 }
 
 /**
- * @brief CUDA kernel with 8-corner voxel foreground classification
+ * @brief Scattered beam wavevector s1 (magnitude 1/λ) at a detector corner
+ *        (cx, cy).
  *
- * Each thread represents a corner in the (width+1)×(height+1) corner grid.
- * Blocks use overlapping tiles: KABSCH_BLOCK_X × KABSCH_BLOCK_Y threads
- * cover that many corners, yielding (KABSCH_BLOCK_X-1) × (KABSCH_BLOCK_Y-1)
- * complete pixels per block.  Adjacent blocks share one row/column of corners.
+ * The px -> reciprocal-space mapping is pure geometry, so it holds fine past
+ * the detector edge. Corners off the image still give real Kabsch coordinates
+ * and classify the same as any other, so we don't guard for them here.
  *
- * Algorithm:
- *   1. Every thread computes Kabsch coordinates for its corner at two φ values
- *      (lower and upper z-faces of the voxel) and writes foreground flags to
- *      shared memory.
- *   2. After sync, interior threads (representing complete pixels) check all
- *      8 voxel corners. If ANY corner is foreground, the pixel is foreground;
- *      otherwise it's background.
+ * @param wavelength Beam wavelength in Å.
+ * @return s1 in lab frame, units of 1/Å (lies on the Ewald sphere).
+ */
+__device__ __forceinline__ Vector3D
+corner_s_pixel(int cx,
+               int cy,
+               const scalar_t *d_matrix,
+               scalar_t wavelength,
+               const DetectorParameters &det_params) {
+    scalar_t cx_mm, cy_mm;
+    px_to_mm(cx, cy, det_params, cx_mm, cy_mm);
+
+    Vector3D lab_coord =
+      make_vector3d(d_matrix[0] * cx_mm + d_matrix[1] * cy_mm + d_matrix[2],
+                    d_matrix[3] * cx_mm + d_matrix[4] * cy_mm + d_matrix[5],
+                    d_matrix[6] * cx_mm + d_matrix[7] * cy_mm + d_matrix[8]);
+    return normalized(lab_coord) / wavelength;
+}
+
+/**
+ * @brief Classify a single pixel as foreground for one reflection.
+ *
+ * A pixel is foreground if ANY of its four voxel corners {px,px+1}×{py,py+1}
+ * is inside the reflection profile in ANY evaluated z-slice. Each thread
+ * computes its own pixel's corners directly, with no shared-memory corner cache
+ * and no inter-thread barrier. The corner Kabsch values are deterministic in
+ * (corner, φ), so neighbouring threads that share a corner compute the same
+ * value independently. This recomputes each interior corner up to four times, a
+ * deliberate trade: the kernel is latency-bound rather than compute-bound (see
+ * kabsch_transform), so the redundant ALU is effectively free, whereas caching
+ * the corners would need a barrier that is not. It returns on the first corner
+ * that lands inside the profile, so foreground pixels bail early and only
+ * fully-background ones pay for all four corners.
+ *
+ * Ellipsoid evaluates three z-slices (phi_low, phi_high, and phi_c when the
+ * centre falls in this slice); DIALS evaluates a single 2D ellipse at phi_low,
+ * ignoring ε₃.
+ *
+ * @tparam Algo Foreground model: Ellipsoid (3D) or DIALS (2D ellipse).
+ * @param px Pixel fast-axis index (lower corner), in pixels.
+ * @param py Pixel slow-axis index (lower corner), in pixels.
+ * @param s0 Incident beam vector (s₀), units of 1/Å.
+ * @param s1_c Predicted diffracted vector at the reflection centre (s₁ᶜ), units of 1/Å.
+ * @param phi_c Rotation angle at the reflection centre (φᶜ), in radians.
+ * @param phi_low Rotation angle at the lower z-face (φ), in radians.
+ * @param phi_high Rotation angle at the upper z-face (φ), in radians.
+ * @param centre_in_z_slice Whether φᶜ falls in this image's z-slice (Ellipsoid centre slice).
+ * @param rot_axis Unit goniometer rotation axis vector (m₂).
+ * @param d_matrix Detector coordinate transformation matrix (3x3).
+ * @param wavelength X-ray wavelength in Å.
+ * @param det_params Detector geometry parameters (pixel size, parallax, etc.).
+ * @param delta_b Foreground extent in e₁/e₂ directions (n_sigma × σ_D).
+ * @param delta_m Foreground extent in e₃ direction (n_sigma × σ_M).
+ * @return true if the pixel is foreground for this reflection, false otherwise.
+ */
+template <FGAlgorithm Algo>
+__device__ __forceinline__ bool pixel_is_foreground(
+  int px,
+  int py,
+  const Vector3D &s0,
+  const Vector3D &s1_c,
+  scalar_t phi_c,
+  scalar_t phi_low,
+  scalar_t phi_high,
+  bool centre_in_z_slice,
+  const Vector3D &rot_axis,
+  const scalar_t *d_matrix,
+  scalar_t wavelength,
+  const DetectorParameters &det_params,
+  scalar_t delta_b,
+  scalar_t delta_m) {
+#pragma unroll
+    for (int dy = 0; dy <= 1; ++dy) {
+#pragma unroll
+        for (int dx = 0; dx <= 1; ++dx) {
+            const Vector3D s_pixel =
+              corner_s_pixel(px + dx, py + dy, d_matrix, wavelength, det_params);
+            scalar_t s1_len;  // unused here, required by pixel_to_kabsch
+
+            // `if constexpr` resolves at compile time; only the chosen branch is
+            // emitted into each kernel specialization, so the unused algorithm's
+            // code (and its register footprint) is gone.
+            if constexpr (Algo == FGAlgorithm::Ellipsoid) {
+                // Lower z-face (phi_low)
+                Vector3D eps_lo =
+                  pixel_to_kabsch(s0, s1_c, phi_c, s_pixel, phi_low, rot_axis, s1_len);
+                if (is_foreground(eps_lo, delta_b, delta_m)) return true;
+
+                // Upper z-face (phi_high)
+                Vector3D eps_hi =
+                  pixel_to_kabsch(s0, s1_c, phi_c, s_pixel, phi_high, rot_axis, s1_len);
+                if (is_foreground(eps_hi, delta_b, delta_m)) return true;
+
+                // Centre z-slice: evaluate at phi_c where ε₃ = 0
+                if (centre_in_z_slice) {
+                    Vector3D eps_c = pixel_to_kabsch(
+                      s0, s1_c, phi_c, s_pixel, phi_c, rot_axis, s1_len);
+                    if (is_foreground(eps_c, delta_b, delta_m)) return true;
+                }
+            } else {
+                // DIALS: single 2D ellipse, evaluated at phi_low; ε₃ ignored
+                Vector3D eps =
+                  pixel_to_kabsch(s0, s1_c, phi_c, s_pixel, phi_low, rot_axis, s1_len);
+                scalar_t inv_delta_b_sq = scalar_t(1.0) / (delta_b * delta_b);
+                scalar_t ellipsoid_val =
+                  (eps.x * eps.x + eps.y * eps.y) * inv_delta_b_sq;
+                if (ellipsoid_val <= scalar_t(1.0)) return true;
+            }
+        }
+    }
+    return false;
+}
+
+/**
+ * @brief Shoebox-parallel Kabsch foreground/background classification kernel.
+ *
+ * One CUDA block per reflection shoebox on the current image
+ * (gridDim.x == num_reflections_this_image; blockIdx.x indexes
+ * d_reflection_indices). Threads in the block stride over the shoebox's w×h
+ * pixels; each thread classifies its own pixel via its four voxel corners
+ * (see pixel_is_foreground) and atomically accumulates into the per-reflection
+ * foreground/background buffers.
+ *
+ * There is no shared memory and no __syncthreads(): every lane works on a real
+ * shoebox pixel, and threads past the last shoebox pixel simply retire. With no
+ * barrier and no idle background lanes, warps never stall waiting on divergent
+ * siblings, which is the point of classifying per shoebox rather than over the
+ * full detector frame.
  *
  * @param d_image Pointer to image data
  * @param image_pitch Pitch of the image data in bytes
@@ -282,10 +388,8 @@ __device__ __forceinline__ void px_to_mm(int gx,
  * @param d_phi_values Array of phi values for each reflection
  * @param d_bboxes Array of bounding box structs for each reflection
  * @param d_reflection_indices Indices of reflections touching this image
- * @param num_reflections_this_image Number of reflections to process
+ * @param num_reflections_this_image Number of reflections (== gridDim.x)
  * @param d_mask Detector mask, flat width*height
- * @param origin_x Pixel x coordinate of the launch grid origin (may be negative)
- * @param origin_y Pixel y coordinate of the launch grid origin (may be negative)
  * @param delta_b Foreground extent in e₁/e₂ directions (n_sigma × σ_D)
  * @param delta_m Foreground extent in e₃ direction (n_sigma × σ_M)
  * @param d_foreground_sum Output: accumulated foreground intensities per reflection
@@ -317,8 +421,6 @@ __global__ void kabsch_transform(pixel_t *d_image,
                                  const size_t *d_reflection_indices,
                                  size_t num_reflections_this_image,
                                  const uint8_t *d_mask,
-                                 int origin_x,
-                                 int origin_y,
                                  // Summation integration parameters
                                  scalar_t delta_b,
                                  scalar_t delta_m,
@@ -331,53 +433,20 @@ __global__ void kabsch_transform(pixel_t *d_image,
                                  unsigned long long *d_intensity_times_y,
                                  unsigned long long *d_intensity_times_z,
                                  uint8_t *d_success) {
-#pragma region Shared Memory
-    // Foreground flags for each corner. For the Ellipsoid algorithm we need
-    // three slices: [0] phi_low, [1] phi_high, [2] phi_c (centre-in-slice).
-    // For DIALS we only evaluate one slice at phi_low (no e3 term).
-    //
-    // NUM_SLICES depends on Algo (template param), so it's known at compile
-    // time. DIALS launches get the smaller shared-memory allocation, which
-    // helps occupancy. A runtime algorithm flag would force us to size for
-    // the worst case here.
-    constexpr int NUM_SLICES = (Algo == FGAlgorithm::Ellipsoid) ? 3 : 1;
-    // s_is_fg is indexed [z-slice][ty][tx]. The first index selects a foreground
-    // mask in shared memory: Ellipsoid keeps 3 z-slices (phi_low, phi_high,
-    // phi_c), DIALS keeps 1 (phi_low only). Each slice is a full block-sized
-    // 2D plane shared by every thread in the block, so a thread can read its
-    // neighbours' corner flags (tx±1, ty±1) after __syncthreads() without
-    // recomputing them.
-    // Shared memory for corner foreground flags
-    __shared__ bool s_is_fg[NUM_SLICES][KABSCH_BLOCK_Y][KABSCH_BLOCK_X];
+    // One block per reflection shoebox on this image; blockIdx.x indexes the
+    // image-level reflection list directly.
+    const size_t block_refl = blockIdx.x;
+    if (block_refl >= num_reflections_this_image) return;
 
-    // Block-level reflection list: indices into the global reflection arrays
-    __shared__ size_t s_block_refl[MAX_BLOCK_REFLECTIONS];
-    __shared__ size_t s_num_block_refl;
+    const size_t refl_idx = d_reflection_indices[block_refl];
+    const Vector3D s1_c = d_s1_vectors[refl_idx];
+    const scalar_t phi_c = d_phi_values[refl_idx];
+    const BoundingBoxExtents bbox = d_bboxes[refl_idx];
 
-    const int tx = threadIdx.x;  // Thread-local x index (also indexes shared memory)
-    const int ty = threadIdx.y;  // Thread-local y index
+    // The host lists a reflection only under the images its bbox spans, so this
+    // z-test normally passes; kept for parity/safety with the old block filter.
+    if (!(image_num >= bbox.z_min && image_num < bbox.z_max)) return;
 
-    // Global corner coordinates.
-    // The stride between block origins is (BLOCK-1), NOT BLOCK.  Compare:
-    //   Normal:  gx = blockIdx.x * blockDim.x + tx          (stride 32)
-    //   Here:    gx = blockIdx.x * (KABSCH_BLOCK_X - 1) + tx (stride 31)
-    //
-    // This means Block 0 covers corners 0-31, Block 1 covers 31-62, etc.
-    // Corner 31 is computed by BOTH blocks; that's the overlap.  It ensures
-    // pixel 30 (in Block 0) can read its right-side corner (31) from shared
-    // memory, and pixel 31 (in Block 1) can read its left-side corner (31)
-    // from its own block's shared memory.
-
-    // origin_{x,y} offsets the grid into negative pixel coordinates so the
-    // launch footprint covers bboxes that overflow the detector edge.
-    const int gx =
-      origin_x + blockIdx.x * (KABSCH_BLOCK_X - 1) + tx;  // Global x coordinate
-    const int gy =
-      origin_y + blockIdx.y * (KABSCH_BLOCK_Y - 1) + ty;  // Global y coordinate
-
-#pragma endregion Shared Memory
-
-#pragma region Per-Corner Setup
     // The voxel's two z-faces, one image apart. slice converts the 0-based
     // image_num to the (z + 1 - image_range_start) frame used everywhere else.
     const int slice = image_num - image_range_start + 1;
@@ -385,210 +454,97 @@ __global__ void kabsch_transform(pixel_t *d_image,
       degrees_to_radians(osc_start + (static_cast<scalar_t>(slice) * osc_width));
     const scalar_t phi_high =
       degrees_to_radians(osc_start + (static_cast<scalar_t>(slice + 1) * osc_width));
+    // Whether the reflection centre falls in this image's z-slice (block-uniform).
+    const bool centre_in_z_slice = (phi_c >= phi_low && phi_c <= phi_high);
 
-    // s_pixel depends only on detector position (gx, gy), not phi. The
-    // px_to_mm / d_matrix mapping is geometric and well-defined beyond the
-    // detector edge, so corners outside the image carry valid Kabsch
-    // coordinates and are classified like any other.
-    Vector3D s_pixel = make_vector3d(0, 0, 0);
-    {
-        scalar_t gx_mm, gy_mm;
-        px_to_mm(gx, gy, det_params, gx_mm, gy_mm);
-
-        Vector3D lab_coord =
-          make_vector3d(d_matrix[0] * gx_mm + d_matrix[1] * gy_mm + d_matrix[2],
-                        d_matrix[3] * gx_mm + d_matrix[4] * gy_mm + d_matrix[5],
-                        d_matrix[6] * gx_mm + d_matrix[7] * gy_mm + d_matrix[8]);
-        s_pixel = normalized(lab_coord) / wavelength;
-    }
-
-#pragma endregion Per - Corner Setup
-
-#pragma region Block Reflection Filter
-    // Thread 0 scans the image-level reflection list and keeps only those
-    // whose bbox overlaps this block's corner footprint.
-    if (tx == 0 && ty == 0) {
-        s_num_block_refl = 0;
-
-        const int bx_min =
-          origin_x + static_cast<int>(blockIdx.x) * (KABSCH_BLOCK_X - 1);
-        const int bx_max = bx_min + KABSCH_BLOCK_X - 1;
-        const int by_min =
-          origin_y + static_cast<int>(blockIdx.y) * (KABSCH_BLOCK_Y - 1);
-        const int by_max = by_min + KABSCH_BLOCK_Y - 1;
-
-        for (size_t i = 0; i < num_reflections_this_image; ++i) {
-            const size_t refl_idx = d_reflection_indices[i];
-            const BoundingBoxExtents &bbox = d_bboxes[refl_idx];
-
-            // Does the reflection's bbox overlap this block AND current image?
-            const bool overlaps =
-              (bx_max >= bbox.x_min && bx_min <= bbox.x_max)
-              && (by_max >= bbox.y_min && by_min <= bbox.y_max)
-              && (image_num >= bbox.z_min && image_num < bbox.z_max);
-
-            if (overlaps && s_num_block_refl < MAX_BLOCK_REFLECTIONS) {
-                s_block_refl[s_num_block_refl++] = refl_idx;
-            }
-        }
-    }
-
-    __syncthreads();
-
-    // Early exit if no reflections overlap this block
-    if (s_num_block_refl == 0) return;
     // Pitched image accessor
     size_t elem_pitch = image_pitch / sizeof(pixel_t);
     PitchedArray2D<pixel_t> image(d_image, &elem_pitch);
 
-    // Does this thread represent a complete pixel?
-    // A pixel at (tx, ty) reads corners (tx, ty), (tx+1, ty), (tx, ty+1),
-    // (tx+1, ty+1) from shared memory.  For tx+1 and ty+1 to be valid
-    // indices, we need tx < 31 and ty < 15.  Threads on the right column
-    // (tx == 31) and bottom row (ty == 15) only contribute their corner
-    // during Phase 1; they don't process a pixel in Phase 2.
-    const bool is_pixel_thread = (tx < KABSCH_BLOCK_X - 1) && (ty < KABSCH_BLOCK_Y - 1);
-    const bool pixel_in_image = is_pixel_thread && (gx >= 0)
-                                && (gx < static_cast<int>(width)) && (gy >= 0)
-                                && (gy < static_cast<int>(height));
+    // Shoebox pixel extent. The bbox is half-open in x and y
+    // (x_min <= px < x_max), so w×h is exactly the pixel count.
+    const int w = bbox.x_max - bbox.x_min;
+    const int h = bbox.y_max - bbox.y_min;
+    const int npix = w * h;
 
-#pragma endregion Block Reflection Filter
+    // Threads stride over the shoebox pixels. Threads with p >= npix
+    // never enter the loop and retire immediately, so there is nothing
+    // for idle lanes to stall on.
+    for (int p = static_cast<int>(threadIdx.x); p < npix;
+         p += static_cast<int>(blockDim.x)) {
+        const int px = bbox.x_min + (p % w);
+        const int py = bbox.y_min + (p / w);
 
-#pragma region Reflection Processing Loop
-    // Process each reflection: compute corner flags, sync, then accumulate pixels
-    for (size_t r = 0; r < s_num_block_refl; ++r) {
-        const size_t refl_idx = s_block_refl[r];
-        const Vector3D &s1_c = d_s1_vectors[refl_idx];
-        const scalar_t phi_c = d_phi_values[refl_idx];
-        const BoundingBoxExtents &bbox = d_bboxes[refl_idx];
+        // Out-of-image pixels still classify (geometry is valid beyond the
+        // edge); a foreground pixel outside the image fails the reflection.
+        const bool pixel_in_image = (px >= 0) && (px < static_cast<int>(width))
+                                    && (py >= 0) && (py < static_cast<int>(height));
 
-        // Every thread writes its corner's foreground flag to shared memory.
-        // Per-corner bbox check avoids needless Kabsch computation.
-        const bool in_bbox = (gx >= bbox.x_min && gx <= bbox.x_max)
-                             && (gy >= bbox.y_min && gy <= bbox.y_max);
+        const bool any_fg = pixel_is_foreground<Algo>(px,
+                                                      py,
+                                                      s0,
+                                                      s1_c,
+                                                      phi_c,
+                                                      phi_low,
+                                                      phi_high,
+                                                      centre_in_z_slice,
+                                                      rot_axis,
+                                                      d_matrix,
+                                                      wavelength,
+                                                      det_params,
+                                                      delta_b,
+                                                      delta_m);
 
-        if (in_bbox) {
-            scalar_t s1_len;  // unused here, required by pixel_to_kabsch
-
-            // `if constexpr` resolves at compile time; only the chosen
-            // branch is emitted into each kernel specialization, so the
-            // unused algorithm's code (and its register footprint) is gone.
-            if constexpr (Algo == FGAlgorithm::Ellipsoid) {
-                // Lower z-face (phi_low)
-                Vector3D eps_lo =
-                  pixel_to_kabsch(s0, s1_c, phi_c, s_pixel, phi_low, rot_axis, s1_len);
-                s_is_fg[0][ty][tx] = is_foreground(eps_lo, delta_b, delta_m);
-
-                // Upper z-face (phi_high)
-                Vector3D eps_hi =
-                  pixel_to_kabsch(s0, s1_c, phi_c, s_pixel, phi_high, rot_axis, s1_len);
-                s_is_fg[1][ty][tx] = is_foreground(eps_hi, delta_b, delta_m);
-
-                // Centre z-slice: evaluate at phi_c where ε₃ = 0
-                const bool centre_in_z_slice = (phi_c >= phi_low && phi_c <= phi_high);
-                if (centre_in_z_slice) {
-                    Vector3D eps_c = pixel_to_kabsch(
-                      s0, s1_c, phi_c, s_pixel, phi_c, rot_axis, s1_len);
-                    s_is_fg[2][ty][tx] = is_foreground(eps_c, delta_b, delta_m);
-                } else {
-                    s_is_fg[2][ty][tx] = false;
-                }
+        if (any_fg) {
+            // Foreground outside the image or on a masked pixel makes the
+            // reflection unusable. d_success is only ever cleared, never set,
+            // so the concurrent writes need no atomic.
+            if (!pixel_in_image || d_mask[static_cast<size_t>(py) * width + px] == 0) {
+                d_success[refl_idx] = 0;
             } else {
-                // DIALS: single 2D ellipse, evaluated at phi_low; ε₃ ignored
-                Vector3D eps =
-                  pixel_to_kabsch(s0, s1_c, phi_c, s_pixel, phi_low, rot_axis, s1_len);
-                scalar_t inv_delta_b_sq = scalar_t(1.0) / (delta_b * delta_b);
-                scalar_t ellipsoid_val =
-                  (eps.x * eps.x + eps.y * eps.y) * inv_delta_b_sq;
-                s_is_fg[0][ty][tx] = (ellipsoid_val <= scalar_t(1.0));
+                const accumulator_t pixel_value =
+                  static_cast<accumulator_t>(image(px, py));
+                atomicAdd(&d_foreground_sum[refl_idx], pixel_value);
+                atomicAdd(&d_foreground_count[refl_idx], 1u);
+                // Accumulate intensity·coord for centre-of-mass (xyzobs.px).
+                // Baseline uses (x+0.5, y+0.5, z+0.5); we approximate the
+                // half-pixel offset by multiplying by 2x+1 etc. and dividing
+                // by 2 in finalisation to stay in integer atomics.
+                const unsigned long long pv64 =
+                  static_cast<unsigned long long>(pixel_value);
+                atomicAdd(&d_intensity_times_x[refl_idx],
+                          pv64 * static_cast<unsigned long long>(2 * px + 1));
+                atomicAdd(&d_intensity_times_y[refl_idx],
+                          pv64 * static_cast<unsigned long long>(2 * py + 1));
+                atomicAdd(&d_intensity_times_z[refl_idx],
+                          pv64 * static_cast<unsigned long long>(2 * image_num + 1));
             }
         } else {
-#pragma unroll
-            for (int z = 0; z < NUM_SLICES; ++z) {
-                s_is_fg[z][ty][tx] = false;
-            }
-        }
-
-        __syncthreads();
-
-        // Pixel centre within the bbox. Out-of-image pixels still enter
-        // here (guarded below): a foreground pixel outside the image
-        // fails the reflection.
-        const bool px_in_bbox = is_pixel_thread && (gx >= bbox.x_min && gx < bbox.x_max)
-                                && (gy >= bbox.y_min && gy < bbox.y_max);
-
-        if (px_in_bbox) {
-            // A pixel is foreground if any of its four surrounding corners
-            // is foreground in any z-slice.
-            bool any_fg = false;
-#pragma unroll
-            for (int z = 0; z < NUM_SLICES; ++z) {
-                const bool corner_00 = s_is_fg[z][ty][tx];
-                const bool corner_01 = s_is_fg[z][ty][tx + 1];
-                const bool corner_10 = s_is_fg[z][ty + 1][tx];
-                const bool corner_11 = s_is_fg[z][ty + 1][tx + 1];
-                any_fg |= corner_00 || corner_01 || corner_10 || corner_11;
-            }
-
-            if (any_fg) {
-                // Foreground outside the image or on a masked pixel makes the
-                // reflection unusable. d_success is only ever cleared, never
-                // set, so the concurrent writes need no atomic.
-                if (!pixel_in_image
-                    || d_mask[static_cast<size_t>(gy) * width + gx] == 0) {
-                    d_success[refl_idx] = 0;
-                } else {
-                    const accumulator_t pixel_value =
-                      static_cast<accumulator_t>(image(gx, gy));
-                    atomicAdd(&d_foreground_sum[refl_idx], pixel_value);
-                    atomicAdd(&d_foreground_count[refl_idx], 1u);
-                    // Accumulate intensity·coord for centre-of-mass (xyzobs.px).
-                    // Baseline uses (x+0.5, y+0.5, z+0.5); we approximate the
-                    // half-pixel offset by multiplying by 2x+1 etc. and dividing
-                    // by 2 in finalisation to stay in integer atomics.
-                    const unsigned long long pv64 =
-                      static_cast<unsigned long long>(pixel_value);
-                    atomicAdd(&d_intensity_times_x[refl_idx],
-                              pv64 * static_cast<unsigned long long>(2 * gx + 1));
-                    atomicAdd(&d_intensity_times_y[refl_idx],
-                              pv64 * static_cast<unsigned long long>(2 * gy + 1));
-                    atomicAdd(
-                      &d_intensity_times_z[refl_idx],
-                      pv64 * static_cast<unsigned long long>(2 * image_num + 1));
-                }
-            } else {
-                // Background is counted only for unmasked pixels inside the
-                // image; masked or out-of-image background is dropped. Each
-                // pixel value increments one bin of this reflection's
-                // histogram (one bin per integer count). Values at or above
-                // NUM_BG_BINS go to the overflow tail. A negative value is a
-                // sentinel/garbage pixel that slipped past the mask (reachable
-                // only when pixel_t is 32-bit and the value exceeds INT_MAX);
-                // it is not a real background measurement, so it is dropped
-                // rather than counted.
-                if (pixel_in_image
-                    && d_mask[static_cast<size_t>(gy) * width + gx] != 0) {
-                    const int bin = static_cast<int>(image(gx, gy));
-                    if (bin >= 0 && bin < NUM_BG_BINS) {
-                        atomicAdd(&d_background_hist[refl_idx * NUM_BG_BINS + bin], 1u);
-                    } else if (bin >= NUM_BG_BINS) {
-                        atomicAdd(&d_background_overflow[refl_idx], 1u);
-                    }
+            // Background is counted only for unmasked pixels inside the image;
+            // masked or out-of-image background is dropped. Each pixel value
+            // increments one bin of this reflection's histogram (one bin per
+            // integer count). Values at or above NUM_BG_BINS go to the overflow
+            // tail. A negative value is a sentinel/garbage pixel that slipped
+            // past the mask (reachable only when pixel_t is 32-bit and the value
+            // exceeds INT_MAX); it is not a real background measurement, so it
+            // is dropped rather than counted.
+            if (pixel_in_image && d_mask[static_cast<size_t>(py) * width + px] != 0) {
+                const int bin = static_cast<int>(image(px, py));
+                if (bin >= 0 && bin < NUM_BG_BINS) {
+                    atomicAdd(&d_background_hist[refl_idx * NUM_BG_BINS + bin], 1u);
+                } else if (bin >= NUM_BG_BINS) {
+                    atomicAdd(&d_background_overflow[refl_idx], 1u);
                 }
             }
         }
-
-        __syncthreads();  // Barrier before next reflection overwrites s_is_fg
     }
-#pragma endregion Reflection Processing Loop
 }
 
 /**
  * @brief Host wrapper function for image-based Kabsch computation
  *
- * Launches the 8-corner Kabsch kernel using overlapping tiles.  Each block
- * of KABSCH_BLOCK_X × KABSCH_BLOCK_Y threads covers that many corners,
- * processing (KABSCH_BLOCK_X-1) × (KABSCH_BLOCK_Y-1) complete pixels.
+ * Launches the shoebox-parallel Kabsch kernel: one block of KABSCH_THREADS
+ * threads per reflection on this image, striding over that shoebox's pixels.
  */
 void compute_kabsch_transform(pixel_t *d_image,
                               size_t image_pitch,
@@ -609,10 +565,6 @@ void compute_kabsch_transform(pixel_t *d_image,
                               const size_t *d_reflection_indices,
                               size_t num_reflections_this_image,
                               const uint8_t *d_mask,
-                              int origin_x,
-                              int origin_y,
-                              uint32_t grid_w,
-                              uint32_t grid_h,
                               scalar_t delta_b,
                               scalar_t delta_m,
                               FGAlgorithm algorithm,
@@ -625,30 +577,21 @@ void compute_kabsch_transform(pixel_t *d_image,
                               unsigned long long *d_intensity_times_z,
                               uint8_t *d_success,
                               cudaStream_t stream) {
-    // Configure kernel launch parameters.
-    // Every block is always the full 32×16 = 512 threads.
-    dim3 blockDim(KABSCH_BLOCK_X, KABSCH_BLOCK_Y);
+    // One block per reflection shoebox on this image; nothing to launch
+    // if the image has no reflections.
+    if (num_reflections_this_image == 0) return;
 
-    // Each block processes (BLOCK-1) complete pixels per dimension:
-    //   31 pixels in x, 15 pixels in y.
-    // So the number of blocks needed is ceil(image_pixels / pixels_per_block):
-    //   gridDim.x = ceil(width  / 31)
-    //   gridDim.y = ceil(height / 15)
-    // Edge blocks may extend past the image boundary; those threads
-    // simply fail the bounds check in the kernel and write false / skip.
-    // grid_w/grid_h are the padded extent (image plus any bbox overflow past
-    // the detector edge), not the raw image dimensions.
-    dim3 gridDim(ceil_div(grid_w, static_cast<uint32_t>(KABSCH_BLOCK_X - 1)),
-                 ceil_div(grid_h, static_cast<uint32_t>(KABSCH_BLOCK_Y - 1)));
+    // Configure kernel launch parameters.
+    dim3 blockDim(KABSCH_THREADS);
+    dim3 gridDim(static_cast<uint32_t>(num_reflections_this_image));
 
     // The kernel is templated on FGAlgorithm rather than taking it as a
     // runtime parameter, for two reasons:
-    //   - Shared memory size (NUM_SLICES) is allowed to depend on the
-    //     algorithm, so DIALS gets a smaller s_is_fg allocation and better
-    //     occupancy than if we always sized for the ellipsoid path.
-    //   - `if constexpr` inside the kernel deletes the unused branch
-    //     entirely. A runtime `if` would keep both paths live in every
-    //     launch, dragging registers up and occupancy down.
+    //   - The classification maths differs (Ellipsoid evaluates three z-slices,
+    //     DIALS a single 2D ellipse) and `if constexpr` selects the branch at
+    //     compile time.
+    //   - A runtime `if` would keep both paths live in every launch, dragging
+    //     registers up and occupancy down.
     //
     // The catch is that the algorithm choice comes in at runtime from the
     // CLI, but template parameters have to be compile-time. The lambda
@@ -678,8 +621,6 @@ void compute_kabsch_transform(pixel_t *d_image,
                                              d_reflection_indices,
                                              num_reflections_this_image,
                                              d_mask,
-                                             origin_x,
-                                             origin_y,
                                              delta_b,
                                              delta_m,
                                              d_foreground_sum,

--- a/integrator/kabsch.cuh
+++ b/integrator/kabsch.cuh
@@ -58,10 +58,6 @@
  * @param d_reflection_indices Device array of reflection indices for this image
  * @param num_reflections_this_image Number of reflections touching this image
  * @param d_mask Detector mask, flat width*height indexed gy*width + gx (non-zero = valid, 0 = masked)
- * @param origin_x Pixel x coordinate of the launch grid origin (may be negative)
- * @param origin_y Pixel y coordinate of the launch grid origin (may be negative)
- * @param grid_w Padded grid width in pixels (image plus bbox overflow)
- * @param grid_h Padded grid height in pixels (image plus bbox overflow)
  * @param delta_b Foreground extent in e₁/e₂ directions (n_sigma × σ_D), radians
  * @param delta_m Foreground extent in e₃ direction (n_sigma × σ_M), radians
  * @param d_foreground_sum Device array to accumulate foreground intensities per reflection
@@ -93,10 +89,6 @@ void compute_kabsch_transform(pixel_t *d_image,
                               const size_t *d_reflection_indices,
                               size_t num_reflections_this_image,
                               const uint8_t *d_mask,
-                              int origin_x,
-                              int origin_y,
-                              uint32_t grid_w,
-                              uint32_t grid_h,
                               scalar_t delta_b,
                               scalar_t delta_m,
                               FGAlgorithm algorithm,

--- a/integrator/kabsch.cuh
+++ b/integrator/kabsch.cuh
@@ -31,6 +31,15 @@
 #include "math/device_precision.cuh"
 #include "math/vector3d.cuh"
 
+/// CUDA block width (threads per block) for the shoebox-parallel Kabsch kernel.
+/// Each block strides this many threads over its shoebox's pixels, so it makes
+/// ceil(w*h / KABSCH_THREADS) passes. A block-size sweep found the kernel is
+/// compute-bound and its time is flat within ~8% from 32 to 512, so this is a
+/// fixed constant, not a tuning knob. Must be a multiple of the 32-lane warp;
+/// note 1024 exceeds the per-SM register budget at ~122 regs/thread and fails
+/// to launch.
+constexpr uint32_t KABSCH_THREADS = 128;
+
 /**
  * @brief Host wrapper function for image-based Kabsch computation
  * 

--- a/integrator/tests/test_kabsch.cc
+++ b/integrator/tests/test_kabsch.cc
@@ -364,10 +364,6 @@ void KabschTransformTest::RunPixelCountComparison(FGAlgorithm algo) {
                                  d_reflection_indices.data(),
                                  refl_indices_this_image.size(),
                                  d_mask.data(),
-                                 0,
-                                 0,
-                                 width,
-                                 height,
                                  delta_b,
                                  delta_m,
                                  algo,
@@ -591,22 +587,6 @@ void KabschTransformTest::RunIntensitySumComparison(FGAlgorithm algo) {
 #pragma endregion Allocate buffers
 
 #pragma region Dispatch
-    // Pad the launch grid to cover bboxes overflowing the detector edge, exactly
-    // as the production integrator does, so masked / out-of-image foreground
-    // fails reflections the same way the baseline does.
-    int grid_origin_x = 0;
-    int grid_origin_y = 0;
-    int grid_max_x = static_cast<int>(width);
-    int grid_max_y = static_cast<int>(height);
-    for (size_t i = 0; i < num_reflections; ++i) {
-        grid_origin_x = std::min(grid_origin_x, in.bboxes[i].x_min);
-        grid_origin_y = std::min(grid_origin_y, in.bboxes[i].y_min);
-        grid_max_x = std::max(grid_max_x, in.bboxes[i].x_max + 1);
-        grid_max_y = std::max(grid_max_y, in.bboxes[i].y_max + 1);
-    }
-    uint32_t grid_w = static_cast<uint32_t>(grid_max_x - grid_origin_x);
-    uint32_t grid_h = static_cast<uint32_t>(grid_max_y - grid_origin_y);
-
     // Iterate frames in 0-based frame space (== bbox z space, == baseline). Load
     // the real pixels for each frame and dispatch one kernel call.
     std::vector<pixel_t> host_image(static_cast<size_t>(width) * height);
@@ -663,10 +643,6 @@ void KabschTransformTest::RunIntensitySumComparison(FGAlgorithm algo) {
                                  d_reflection_indices.data(),
                                  refl_indices_this_image.size(),
                                  d_mask.data(),
-                                 grid_origin_x,
-                                 grid_origin_y,
-                                 grid_w,
-                                 grid_h,
                                  in.delta_b,
                                  in.delta_m,
                                  algo,


### PR DESCRIPTION
This PR address the speed disparity between GPU integration and DIALS
CPU integration. Where the GPU's throughput was sitting around 1%.
The GPU Kabsch kernel was spending most of its time doing nothing. This
reworks it from a full-frame pixel grid into one block per reflection
shoebox, which takes the 100-image thaumatin benchmark on an RTX 5000
from 74.1 s to 2.60 s of internal processing (~28x) with no change to
the output.

The old `kabsch_transform` launched one thread per detector pixel across
the whole padded frame, so nearly every block landed entirely on
background and touched zero reflection pixels. Profiling the old kernel
under Nsight Compute showed:

- ~1% SM throughput while the kernel was resident
- 4.2 of 32 threads active per warp (the rest were background pixels)
- over 90% of warp cycles stalled at a block-wide `__syncthreads()`

The barriers only existed so that threads could share their per-corner
foreground flags through shared memory. Because a block spanned a whole
tile of the frame, that block-wide `__syncthreads()` held up all 512 of
its threads - including the many that were nowhere near any shoebox.
They could not retire; they just parked on the barrier while a handful
of lanes did the real work, so a bigger or faster GPU did not help - as
tests on the A100 showed.

The kernel now launches one block per reflection shoebox. `blockIdx.x`
indexes the per-image reflection list directly, and each shoebox is
flattened to a linear list of its `w*h` pixels that an intentionally
small, fixed block of `KABSCH_THREADS` (128) threads strides over in
`ceil(w*h / KABSCH_THREADS)` passes (7.5 on average for thaumatin). Each
thread computes its own four corner Kabsch values inline - those values
are deterministic, so the results are identical to the old shared-memory
corner cache and just trades roughly 4x redundant arithmetic for
dropping the cache and its barrier - which is the optimisation. No shared
memory and no `__syncthreads()` remain, so a lane that runs past the
last pixel simply retires instead of holding up the block.

The block size of 128 is deliberate - if arbitrary. It keeps many blocks
resident per SM for occupancy, while the strided passes let one fixed
size cover a shoebox of any dimension. A block-width sweep under ncu
found the kernel compute-bound and its time flat within ~8% from 32 to
512 threads, so 128 is fixed rather than exposed as a tuning knob and
lives in `kabsch.cuh` so the launch and diagnostics share one source of
truth. A debug-level startup histogram reports how well that width fits
the data (passes per block, lane utilisation).

### Old vs new mapping

```text
OLD    grid = whole padded frame, one thread per pixel

  +-------------------------------------------+
  |                       #                   |   # reflection pixels
  |        #                                  |   . background (idle lanes)
  |                              #            |
  |   +--------+                              |   a 512-thread block:
  |   |....#...|  most lanes hit background   |   ~4 of 32 lanes work,
  |   |........|  and park at __syncthreads() |   ~508 park at the barrier
  |   +--------+                              |   The WHOLE GRID sat idle waiting
  +-------------------------------------------+   for the few threads in the shoebox

NEW    grid = one block per reflection shoebox

     block 0     block 1     block 2      blockIdx.x indexes the
     +----+      +----+      +----+       per-image reflection list;
     |####|      |####|      |####|       128 lanes stride the
     |####|      |####|      |####|       shoebox's w*h pixels
     +----+      +----+      +----+       every lane on a real pixel

  Nothing launched over background. No shared memory. No `__syncthreads()`.
```

### Changes:

- Launch `num_reflections_this_image` blocks of `KABSCH_THREADS` instead
  of tiling the padded frame; drop the `origin_x`/`origin_y`/`grid_w`/
  `grid_h` parameters and the padded-grid computation
- Add `corner_s_pixel` and `pixel_is_foreground<Algo>` device helpers;
  keep `is_foreground`, `pixel_to_kabsch`, `px_to_mm` and every atomic
  accumulator write unchanged
- Remove the `MAX_BLOCK_REFLECTIONS = 64` per-tile cap, which silently
  dropped reflections wherever more than 64 shoeboxes overlapped one
  tile - a latent correctness bug, not just a perf limit
- Move `KABSCH_THREADS` into `kabsch.cuh` and launch with it
- Add `format_shoebox_pass_histogram` and emit it as a single
  debug-level message, guarded by `should_log` so the
  O(num_reflections) scan is skipped entirely above debug
- Replace the runtime image-number check in `compute_kabsch_transform`
  with an assert, since the host maps a reflection only to the images
  its bbox spans
- Drop the unused `s1_len_out` output from the device `pixel_to_kabsch`;
  no GPU caller read it and `norm(s1_c)` is still computed internally for
  the ε₁/ε₂ normalisation, so results are unchanged
- Update the `test_kabsch` call sites to the trimmed signatures

### Testing:

- `test_kabsch` reports zero mismatches against the CPU baseline for both
  the Ellipsoid and DIALS foreground algorithms.
- Full integration run on the thaumatin i03 rotation dataset (100 images,
  `--background constant`, `--sigma_b 0.03 --sigma_m 0.1`) preserves the
  exact 49,579-reflection output count and reproduces the reference
  intensities.
- Internal processing time on an RTX 5000 (CUDA 12.6, CC 7.5) drops from
  74.1 s to 2.60 s for that dataset.
- On thaumatin the pass histogram reports avg 903 px/block, 7.5
  passes/block, 93% lane utilisation.
