### PR TITLE
Reuse Kabsch voxel corners across neighbouring pixels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,7 @@ _build*/
 # Python build artifacts
 *.egg-info/
 .venv/
+
+# Profiling artifacts
+profiling/
+out/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,8 +40,12 @@ project(fast-feedback-service LANGUAGES CXX VERSION ${FFS_VERSION_CMAKE})
 set(CMAKE_EXPORT_COMPILE_COMMANDS yes)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
-# Option to use double precision for CUDA calculations
-option(USE_DOUBLE_PRECISION "Use double precision for CUDA calculations" OFF)
+# Precision for CUDA calculations. Double is the default because it is
+# bit-exact against the CPU baseline; the reduced-precision (single) path
+# is faster on FP64-throttled GPUs but drifts the pixel classification off
+# the double result on ~1% of reflections (intensity impact stays within
+# noise, but parity is lost). Opt into it deliberately.
+option(USE_REDUCED_PRECISION "Use reduced (single) precision for CUDA calculations - faster but drifts pixel classification off the bit-exact double result" OFF)
 
 include(SetDefaultBuildRelWithDebInfo)
 include(AlwaysColourCompilation)
@@ -132,11 +136,11 @@ add_library(version STATIC version.cc)
 add_library(compile_options INTERFACE)
 
 # Add compile definitions if enabled
-if(USE_DOUBLE_PRECISION)
-    target_compile_definitions(compile_options INTERFACE USE_DOUBLE_PRECISION)
-    message(STATUS "Building with double precision")
+if(USE_REDUCED_PRECISION)
+    target_compile_definitions(compile_options INTERFACE USE_REDUCED_PRECISION)
+    message(STATUS "Building with reduced (single) precision")
 else()
-    message(STATUS "Building with single precision")
+    message(STATUS "Building with double precision")
 endif()
 
 # Make a common C++ library for shared code

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,8 @@ RUN cmake /opt/ffs_src \
     -DCMAKE_INSTALL_PREFIX=/opt/ffs \
     -DHDF5_ROOT=/opt/ffs \
     -DPython3_ROOT_DIR=/opt/ffs \
-    -DCUDA_ARCH=80
+    -DCUDA_ARCH=80 \
+    -DUSE_REDUCED_PRECISION=OFF
 
 RUN cmake --build .
 

--- a/build.sh
+++ b/build.sh
@@ -208,16 +208,16 @@ main() {
         
         # Build production version
         if [[ "$PIXEL_32BIT" == "true" ]]; then
-            build_directory "build" "-DPIXEL_DATA_32BIT=ON -DUSE_DOUBLE_PRECISION=ON -DCMAKE_BUILD_TYPE=Release" "production (32-bit, double precision)"
+            build_directory "build" "-DPIXEL_DATA_32BIT=ON -DUSE_REDUCED_PRECISION=OFF -DCMAKE_BUILD_TYPE=Release" "production (32-bit, double precision)"
         else
-            build_directory "build" "-DUSE_DOUBLE_PRECISION=ON -DCMAKE_BUILD_TYPE=Release" "production (16-bit, double precision)"
+            build_directory "build" "-DUSE_REDUCED_PRECISION=OFF -DCMAKE_BUILD_TYPE=Release" "production (16-bit, double precision)"
         fi
     else
         print_status "Development build mode"
         
         # Build both 16-bit and 32-bit versions
-        build_directory "build" "-DUSE_DOUBLE_PRECISION=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo" "development (16-bit, double precision)"
-        build_directory "build_32bit" "-DPIXEL_DATA_32BIT=ON -DUSE_DOUBLE_PRECISION=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo" "development (32-bit, double precision)"
+        build_directory "build" "-DUSE_REDUCED_PRECISION=OFF -DCMAKE_BUILD_TYPE=RelWithDebInfo" "development (16-bit, double precision)"
+        build_directory "build_32bit" "-DPIXEL_DATA_32BIT=ON -DUSE_REDUCED_PRECISION=OFF -DCMAKE_BUILD_TYPE=RelWithDebInfo" "development (32-bit, double precision)"
     fi
     
     print_success "Build completed successfully!"

--- a/include/math/device_precision.cuh
+++ b/include/math/device_precision.cuh
@@ -3,27 +3,20 @@
  * @brief Centralized precision configuration for CUDA device code
  * 
  * This header provides unified type aliases and precision-aware
- * function macros that automatically select appropriate precision based
- * on the USE_DOUBLE_PRECISION compile flag.
+ * function macros that select the working precision based on the
+ * USE_REDUCED_PRECISION compile flag. Double is the default (bit-exact
+ * against the CPU baseline); defining USE_REDUCED_PRECISION switches to
+ * single precision, which is faster on FP64-throttled GPUs but drifts the
+ * pixel classification off the double result.
  */
 
 #pragma once
 
 #include <cuda_runtime.h>
 
-// Precision-dependent configuration
-#ifdef USE_DOUBLE_PRECISION
-using scalar_t = double;
-
-// Double precision math functions
-#define CUDA_MIN fmin
-#define CUDA_MAX fmax
-#define CUDA_FLOOR floor
-#define CUDA_CEIL ceil
-#define CUDA_ABS fabs
-#define CUDA_SQRT sqrt
-#define CUDA_EXP exp
-#else
+// Precision-dependent configuration. Double is the default; defining
+// USE_REDUCED_PRECISION switches to single.
+#ifdef USE_REDUCED_PRECISION
 using scalar_t = float;
 
 // Single precision math functions
@@ -34,6 +27,17 @@ using scalar_t = float;
 #define CUDA_ABS fabsf
 #define CUDA_SQRT sqrtf
 #define CUDA_EXP expf
+#else
+using scalar_t = double;
+
+// Double precision math functions
+#define CUDA_MIN fmin
+#define CUDA_MAX fmax
+#define CUDA_FLOOR floor
+#define CUDA_CEIL ceil
+#define CUDA_ABS fabs
+#define CUDA_SQRT sqrt
+#define CUDA_EXP exp
 #endif
 
 // Accumulator type for summation/reduction operations.

--- a/include/math/vector3d.cuh
+++ b/include/math/vector3d.cuh
@@ -19,9 +19,10 @@
  * - Data access: span() for mdspan integration
  * 
  * Precision Control:
- * The library supports compile-time precision switching via USE_DOUBLE_PRECISION:
- * - Default: single precision (float3) for optimal GPU performance
- * - With -DUSE_DOUBLE_PRECISION: double precision (double3) for accuracy
+ * The library supports compile-time precision switching via USE_REDUCED_PRECISION:
+ * - Default: double precision (double3) for accuracy and bit-exact parity
+ * - With -DUSE_REDUCED_PRECISION: single precision (float3) for speed on
+ *   FP64-throttled GPUs (drifts pixel classification off the double result)
  * 
  * Usage Examples:
  * ```cpp
@@ -57,13 +58,14 @@
 
 namespace fastvec {
 
-// Type configuration
-#ifdef USE_DOUBLE_PRECISION
-using Vector3D = double3;
-#define MAKE_VECTOR3D make_double3
-#else
+// Type configuration. Double is the default; defining USE_REDUCED_PRECISION
+// switches to single.
+#ifdef USE_REDUCED_PRECISION
 using Vector3D = float3;
 #define MAKE_VECTOR3D make_float3
+#else
+using Vector3D = double3;
+#define MAKE_VECTOR3D make_double3
 #endif
 
 // Convenience aliases for mdspan types

--- a/integrator/integrator.cc
+++ b/integrator/integrator.cc
@@ -593,15 +593,26 @@ int main(int argc, char **argv) {
     // Map reflections by z layer (image number), excluding dont_integrate ones
     logger.info("Mapping reflections by image number (z layer)");
     std::unordered_map<int, std::vector<size_t>> reflections_by_image;
+    // Per-image maximum (w+1)*(h+1) corner grid, which sizes the Kabsch
+    // kernel's dynamic shared-memory corner tile for that image's launch.
+    std::unordered_map<int, uint32_t> corner_tile_by_image;
 
     for (size_t refl_id = 0; refl_id < num_reflections; ++refl_id) {
         if (dont_integrate[refl_id]) continue;
         const auto &bbox = computed_bboxes[refl_id];
 
+        // The bbox is half-open in x and y, so w×h is exactly the pixel
+        // count and the corner grid is one larger on each axis.
+        const uint32_t corner_grid =
+          static_cast<uint32_t>(bbox.x_max - bbox.x_min + 1)
+          * static_cast<uint32_t>(bbox.y_max - bbox.y_min + 1);
+
         // Add this reflection to all images it spans. The shoebox z
         // range is half-open [z_min, z_max), so z_max is excluded.
         for (int z = bbox.z_min; z < bbox.z_max; ++z) {
             reflections_by_image[z].push_back(refl_id);
+            uint32_t &image_max = corner_tile_by_image[z];
+            image_max = std::max(image_max, corner_grid);
         }
     }
 
@@ -974,6 +985,7 @@ int main(int argc, char **argv) {
                                          d_reflection_indices.data(),
                                          num_refls_this_image,
                                          d_mask.data(),
+                                         corner_tile_by_image.at(image_num),
                                          delta_b,
                                          delta_m,
                                          fg_algorithm,

--- a/integrator/integrator.cc
+++ b/integrator/integrator.cc
@@ -11,6 +11,8 @@
 #include <bitshuffle.h>
 
 #include <Eigen/Dense>
+#include <algorithm>
+#include <array>
 #include <atomic>
 #include <barrier>
 #include <chrono>
@@ -70,6 +72,85 @@ static BackgroundModel parse_background_model(const std::string &name) {
     if (name == "constant" || name == "tukey") return BackgroundModel::Constant;
     if (name == "glm") return BackgroundModel::Glm;
     throw std::runtime_error("Unknown background model: " + name);
+}
+
+/**
+ * @brief Build a per-block pass-count histogram for the Kabsch kernel as one
+ * multi-line string (a startup diagnostic; the caller logs it at debug level).
+ *
+ * Each reflection launches one GPU block per image it spans, and every block
+ * strides a block_threads-wide thread vector over the shoebox's w*h pixels, so
+ * it makes ceil(w*h / block_threads) passes. Every pass but the last fills all
+ * lanes; the tail pass is the only place lanes sit idle. Blocks are bucketed by
+ * pass count, weighted by z-depth (the real block population), and summarised
+ * with the overall lane utilisation. One pass over the reflections,
+ * O(bboxes.size()); returns an empty string when there are no blocks.
+ */
+static std::string format_shoebox_pass_histogram(
+  const std::vector<BoundingBoxExtents> &bboxes,
+  const std::vector<uint8_t> &dont_integrate,
+  int block_threads) {
+    struct Bucket {
+        int lo;  // inclusive pass count
+        int hi;  // inclusive pass count
+        const char *label;
+    };
+    static constexpr std::array<Bucket, 6> buckets = {{{1, 1, "    1x"},
+                                                       {2, 2, "    2x"},
+                                                       {3, 4, "  3-4x"},
+                                                       {5, 8, "  5-8x"},
+                                                       {9, 16, " 9-16x"},
+                                                       {17, 1 << 30, "  >16x"}}};
+    std::array<size_t, 6> block_counts{};
+    size_t total_blocks = 0;
+    size_t total_px = 0;
+    size_t total_slots = 0;  // passes * block_threads, i.e. lanes launched
+    for (size_t refl_id = 0; refl_id < bboxes.size(); ++refl_id) {
+        if (dont_integrate[refl_id]) continue;
+        const auto &bbox = bboxes[refl_id];
+        const int npix = (bbox.x_max - bbox.x_min) * (bbox.y_max - bbox.y_min);
+        const int depth = bbox.z_max - bbox.z_min;
+        if (npix <= 0 || depth <= 0) continue;
+        const size_t d = static_cast<size_t>(depth);
+        const int passes = (npix + block_threads - 1) / block_threads;
+        for (size_t b = 0; b < buckets.size(); ++b) {
+            if (passes >= buckets[b].lo && passes <= buckets[b].hi) {
+                block_counts[b] += d;
+                break;
+            }
+        }
+        total_blocks += d;
+        total_px += static_cast<size_t>(npix) * d;
+        total_slots += static_cast<size_t>(passes) * block_threads * d;
+    }
+    if (total_blocks == 0) return {};
+
+    const size_t max_count =
+      *std::max_element(block_counts.begin(), block_counts.end());
+    constexpr int kBarWidth = 24;
+    std::string out =
+      fmt::format("Shoebox passes per block over {} GPU blocks ({} threads/block):",
+                  total_blocks,
+                  block_threads);
+    for (size_t b = 0; b < buckets.size(); ++b) {
+        const int fill =
+          max_count ? static_cast<int>((block_counts[b] * kBarWidth + max_count - 1)
+                                       / max_count)
+                    : 0;
+        std::string bar;
+        for (int i = 0; i < kBarWidth; ++i) bar += (i < fill) ? "█" : "░";
+        out += fmt::format("\n  {}  {}  {:5.1f}%  ({})",
+                           buckets[b].label,
+                           bar,
+                           100.0 * block_counts[b] / total_blocks,
+                           block_counts[b]);
+    }
+    out += fmt::format(
+      "\n  avg {:.0f} px/block, {:.1f} passes/block, {:.0f}% lane utilisation",
+      static_cast<double>(total_px) / total_blocks,
+      static_cast<double>(total_slots) / total_blocks / block_threads,
+      100.0 * total_px / total_slots);
+    return out;
 }
 
 using namespace std::chrono_literals;
@@ -545,6 +626,14 @@ int main(int argc, char **argv) {
                     min_refls_per_image,
                     max_refls_per_image,
                     avg_refls_per_image);
+    }
+
+    // Per-block pass-count histogram for the Kabsch kernel. The guard
+    // skips the O(num_reflections) scan entirely at higher levels.
+    if (logger.should_log(spdlog::level::debug)) {
+        std::string hist = format_shoebox_pass_histogram(
+          computed_bboxes, dont_integrate, static_cast<int>(KABSCH_THREADS));
+        if (!hist.empty()) logger.debug("{}", hist);
     }
 
     // Get threading parameters (0 = auto-select)

--- a/integrator/integrator.cc
+++ b/integrator/integrator.cc
@@ -702,25 +702,19 @@ int main(int argc, char **argv) {
     double time_waiting_for_images = 0.0;
 
 #pragma region Prep GPU Data Buffers
-    // Get detector d_matrix and flatten for GPU
-    Eigen::Matrix3d d_matrix_eigen = panel.get_d_matrix();
-    std::vector<scalar_t> d_matrix_flat(9);
-    for (int i = 0; i < 3; ++i) {
-        for (int j = 0; j < 3; ++j) {
-            d_matrix_flat[i * 3 + j] = static_cast<scalar_t>(d_matrix_eigen(i, j));
-        }
-    }
+    // Flatten the detector d-matrix to row-major scalar_t for the GPU.
+    // Eigen stores column-major, so cast into an explicitly row-major
+    // matrix; that reorders and converts precision in one expression and
+    // leaves .data() as the contiguous row-major block the kernel wants.
+    Eigen::Matrix<scalar_t, 3, 3, Eigen::RowMajor> d_matrix_flat =
+      panel.get_d_matrix().cast<scalar_t>();
 
-    // Convert s1_vectors to Vector3D array for GPU
+    // Pack the per-reflection GPU inputs in one pass: the s1 vectors as
+    // fastvec::Vector3D, and the phi rotation angle (column 2 of xyzcal.mm).
     std::vector<fastvec::Vector3D> s1_vectors_vec(num_reflections);
-    for (size_t i = 0; i < num_reflections; ++i) {
-        s1_vectors_vec[i] = to_vector3d(s1_vectors, i);
-    }
-
-    // phi_positions_converted_data already contains phi values (column index 2 of xyzcal.mm)
-    // Need to extract just the phi component (3rd column)
     std::vector<scalar_t> phi_values_vec(num_reflections);
     for (size_t i = 0; i < num_reflections; ++i) {
+        s1_vectors_vec[i] = to_vector3d(s1_vectors, i);
         phi_values_vec[i] = static_cast<scalar_t>(phi_column(i, 2));
     }
 

--- a/integrator/integrator.cc
+++ b/integrator/integrator.cc
@@ -664,31 +664,6 @@ int main(int argc, char **argv) {
     DeviceBuffer<uint8_t> d_mask(static_cast<size_t>(width) * height);
     d_mask.assign(h_mask.data());
 
-    // Reflection bboxes are not clamped to the detector in x/y, so
-    // foreground pixels can fall outside the image. The launch grid is
-    // padded to span this overflow; its origin may be negative.
-    // Foreground pixels landing outside the image fail their reflection
-    // in the kernel.
-    int grid_origin_x = 0;
-    int grid_origin_y = 0;
-    int grid_max_x = static_cast<int>(width);
-    int grid_max_y = static_cast<int>(height);
-    for (size_t i = 0; i < num_reflections; ++i) {
-        if (dont_integrate[i]) continue;
-        const auto &bb = computed_bboxes[i];
-        grid_origin_x = std::min(grid_origin_x, bb.x_min);
-        grid_origin_y = std::min(grid_origin_y, bb.y_min);
-        grid_max_x = std::max(grid_max_x, bb.x_max + 1);
-        grid_max_y = std::max(grid_max_y, bb.y_max + 1);
-    }
-    uint32_t grid_w = static_cast<uint32_t>(grid_max_x - grid_origin_x);
-    uint32_t grid_h = static_cast<uint32_t>(grid_max_y - grid_origin_y);
-    logger.info("Kabsch launch grid: origin=({},{}), extent={}x{}",
-                grid_origin_x,
-                grid_origin_y,
-                grid_w,
-                grid_h);
-
     DetectorParameters det_params = make_detector_params(panel);
 
     // Convert beam parameters to Vector3D
@@ -910,10 +885,6 @@ int main(int argc, char **argv) {
                                          d_reflection_indices.data(),
                                          num_refls_this_image,
                                          d_mask.data(),
-                                         grid_origin_x,
-                                         grid_origin_y,
-                                         grid_w,
-                                         grid_h,
                                          delta_b,
                                          delta_m,
                                          fg_algorithm,

--- a/integrator/integrator.cc
+++ b/integrator/integrator.cc
@@ -44,7 +44,6 @@
 #include "cuda_common.hpp"
 #include "ffs_logger.hpp"
 #include "h5read.h"
-#include "integrator.cuh"
 #include "integrator/background.cuh"
 #include "integrator/background.hpp"
 #include "integrator/coordinate_system.hpp"
@@ -379,7 +378,7 @@ int main(int argc, char **argv) {
     const auto [osc_start, osc_width] = scan.get_oscillation();
     int image_range_start = scan.get_image_range()[0];
     int image_range_end = scan.get_image_range()[1];
-    double wl = beam.get_wavelength();
+    double wavelength = beam.get_wavelength();
     gemmi::UnitCell cell = crystal.get_unit_cell();
 
     // Foreground algorithm and zeta cutoff for host-side filtering.
@@ -454,7 +453,7 @@ int main(int argc, char **argv) {
     }
     auto flags = *flags_column_opt;
     bool all_predicted = true;
-    for (int i = 0; i < flags.extent(0); ++i) {
+    for (size_t i = 0; i < flags.extent(0); ++i) {
         auto f = flags(i, 0);
         if (!(f & predicted_flag)) {
             all_predicted = false;
@@ -482,7 +481,6 @@ int main(int argc, char **argv) {
             logger.info("Monochromatic static prediction");
         }
 
-        double wavelength = beam.get_wavelength();
         double dmin_min = 0.5 * wavelength;
         // FIXME: Need a better dmin_default from .expt file (like in DIALS)
         double dmin_default = dmin_min;
@@ -555,18 +553,6 @@ int main(int argc, char **argv) {
                                     beam);
 
     logger.info("Bounding box computation completed");
-
-    // Convert BoundingBoxExtents to flat array format for storage
-    std::vector<double> computed_bbox_data(num_reflections * 6);
-    for (size_t i = 0; i < num_reflections; ++i) {
-        const int step = 6 * i;
-        computed_bbox_data[step + 0] = computed_bboxes[i].x_min;
-        computed_bbox_data[step + 1] = computed_bboxes[i].x_max;
-        computed_bbox_data[step + 2] = computed_bboxes[i].y_min;
-        computed_bbox_data[step + 3] = computed_bboxes[i].y_max;
-        computed_bbox_data[step + 4] = static_cast<double>(computed_bboxes[i].z_min);
-        computed_bbox_data[step + 5] = static_cast<double>(computed_bboxes[i].z_max);
-    }
 
     // Build per-reflection coordinate systems and apply host-side min_zeta
     // filter. Reflections with |zeta| < min_zeta are skipped (dont_integrate).
@@ -769,7 +755,7 @@ int main(int argc, char **argv) {
     // Convert beam parameters to Vector3D
     fastvec::Vector3D s0_vec = to_vector3d(s0);
     fastvec::Vector3D rot_axis_vec = to_vector3d(rotation_axis);
-    scalar_t wavelength = static_cast<scalar_t>(wl);
+    scalar_t wavelength_scalar = static_cast<scalar_t>(wavelength);
     scalar_t osc_start_scalar = static_cast<scalar_t>(osc_start);
     scalar_t osc_width_scalar = static_cast<scalar_t>(osc_width);
 
@@ -972,7 +958,7 @@ int main(int argc, char **argv) {
                                          height,
                                          image_num,
                                          d_d_matrix.data(),
-                                         wavelength,
+                                         wavelength_scalar,
                                          det_params,
                                          osc_start_scalar,
                                          osc_width_scalar,

--- a/integrator/kabsch.cu
+++ b/integrator/kabsch.cu
@@ -437,9 +437,9 @@ __global__ void kabsch_transform(pixel_t *d_image,
     const scalar_t phi_c = d_phi_values[refl_idx];
     const BoundingBoxExtents bbox = d_bboxes[refl_idx];
 
-    // The host lists a reflection only under the images its bbox spans, so this
-    // z-test normally passes; kept for parity/safety with the old block filter.
-    if (!(image_num >= bbox.z_min && image_num < bbox.z_max)) return;
+    // The shoebox's z-range is half-open: [z_min, z_max). The current
+    // image_num must be within that range.
+    assert(image_num >= bbox.z_min && image_num < bbox.z_max);
 
     // The voxel's two z-faces, one image apart. slice converts the 0-based
     // image_num to the (z + 1 - image_range_start) frame used everywhere else.

--- a/integrator/kabsch.cu
+++ b/integrator/kabsch.cu
@@ -510,33 +510,45 @@ __global__ void kabsch_transform(pixel_t *d_image,
     const int h = bbox.y_max - bbox.y_min;
     const int npix = w * h;
 
-    // Threads stride over the shoebox pixels. Threads with p >= npix
-    // never enter the loop and retire immediately, so there is nothing
-    // for idle lanes to stall on.
-    for (int p = static_cast<int>(threadIdx.x); p < npix;
-         p += static_cast<int>(blockDim.x)) {
-        const int px = bbox.x_min + (p % w);
-        const int py = bbox.y_min + (p / w);
+    // Shared-memory corner-flag tile. corner_is_foreground depends only
+    // on the corner and the block's reflection/image constants, so each
+    // of the (w+1)×(h+1) corners is evaluated once here and reused by
+    // the (up to four) pixels that touch it, removing the full 4x
+    // corner redundancy. Threads stride densely over the corner grid to
+    // fill it, one uniform __syncthreads() separates fill from read,
+    // and that barrier syncs a uniform workload.
+    //
+    // The tile is a fixed static allocation; a shoebox whose corner grid exceeds
+    // it falls back to per-pixel recompute. At ~122 regs/thread occupancy is
+    // register-limited to 4 blocks/SM, so the tile's shared memory is not the
+    // occupancy binder.
+    constexpr int MAX_TILE_DIM = 64;  // corners per side (pixel shoebox up to 63)
+    __shared__ uint8_t s_corner[MAX_TILE_DIM * MAX_TILE_DIM];
 
+    auto corner_fg = [&](int cx, int cy) -> bool {
+        return corner_is_foreground<Algo>(cx,
+                                          cy,
+                                          s0,
+                                          s1_c,
+                                          phi_c,
+                                          phi_low,
+                                          phi_high,
+                                          centre_in_z_slice,
+                                          rot_axis,
+                                          d_matrix,
+                                          wavelength,
+                                          det_params,
+                                          delta_b,
+                                          delta_m);
+    };
+
+    // Classify + accumulate one shoebox pixel. Shared by the tile and fallback
+    // paths; the accumulation itself is unchanged from the per-pixel kernel.
+    auto accumulate = [&](int px, int py, bool any_fg) {
         // Out-of-image pixels still classify (geometry is valid beyond the
         // edge); a foreground pixel outside the image fails the reflection.
         const bool pixel_in_image = (px >= 0) && (px < static_cast<int>(width))
                                     && (py >= 0) && (py < static_cast<int>(height));
-
-        const bool any_fg = pixel_is_foreground<Algo>(px,
-                                                      py,
-                                                      s0,
-                                                      s1_c,
-                                                      phi_c,
-                                                      phi_low,
-                                                      phi_high,
-                                                      centre_in_z_slice,
-                                                      rot_axis,
-                                                      d_matrix,
-                                                      wavelength,
-                                                      det_params,
-                                                      delta_b,
-                                                      delta_m);
 
         if (any_fg) {
             // Foreground outside the image or on a masked pixel makes the
@@ -579,6 +591,59 @@ __global__ void kabsch_transform(pixel_t *d_image,
                     atomicAdd(&d_background_overflow[refl_idx], 1u);
                 }
             }
+        }
+    };
+
+    // Corner grid dimensions (one more than the pixel grid on each axis). The
+    // bbox is block-uniform, so the tile-vs-fallback choice below is taken by
+    // every thread identically and the __syncthreads() is never divergent.
+    const int cw = w + 1;
+    const int ch = h + 1;
+
+    if (cw <= MAX_TILE_DIM && ch <= MAX_TILE_DIM) {
+        // Fill the corner tile: one corner_is_foreground per corner, threads
+        // striding densely over the (w+1)×(h+1) grid.
+        const int num_corners = cw * ch;
+        for (int c = static_cast<int>(threadIdx.x); c < num_corners;
+             c += static_cast<int>(blockDim.x)) {
+            const int lcx = c % cw;
+            const int lcy = c / cw;
+            s_corner[c] = corner_fg(bbox.x_min + lcx, bbox.y_min + lcy) ? 1u : 0u;
+        }
+        __syncthreads();
+
+        // Read the tile: each pixel ORs its four corner bits.
+        for (int p = static_cast<int>(threadIdx.x); p < npix;
+             p += static_cast<int>(blockDim.x)) {
+            const int lx = p % w;
+            const int ly = p / w;
+            const bool any_fg = s_corner[ly * cw + lx] | s_corner[ly * cw + lx + 1]
+                                | s_corner[(ly + 1) * cw + lx]
+                                | s_corner[(ly + 1) * cw + lx + 1];
+            accumulate(bbox.x_min + lx, bbox.y_min + ly, any_fg);
+        }
+    } else {
+        // Oversized shoebox: per-pixel recompute (no reuse), identical result.
+        for (int p = static_cast<int>(threadIdx.x); p < npix;
+             p += static_cast<int>(blockDim.x)) {
+            const int px = bbox.x_min + (p % w);
+            const int py = bbox.y_min + (p / w);
+            accumulate(px,
+                       py,
+                       pixel_is_foreground<Algo>(px,
+                                                 py,
+                                                 s0,
+                                                 s1_c,
+                                                 phi_c,
+                                                 phi_low,
+                                                 phi_high,
+                                                 centre_in_z_slice,
+                                                 rot_axis,
+                                                 d_matrix,
+                                                 wavelength,
+                                                 det_params,
+                                                 delta_b,
+                                                 delta_m));
         }
     }
 }

--- a/integrator/kabsch.cu
+++ b/integrator/kabsch.cu
@@ -46,11 +46,15 @@
 
 #include <cuda_runtime.h>
 
+#include <algorithm>
+#include <atomic>
 #include <cstddef>
+#include <mutex>
 #include <type_traits>
 
 #include "cuda_common.hpp"
 #include "device_common.cuh"
+#include "ffs_logger.hpp"
 #include "h5read.h"
 #include "integrator.cuh"
 #include "integrator/extent.hpp"
@@ -409,11 +413,13 @@ __device__ __forceinline__ bool pixel_is_foreground(
  * (see pixel_is_foreground) and atomically accumulates into the per-reflection
  * foreground/background buffers.
  *
- * There is no shared memory and no __syncthreads(): every lane works on a real
- * shoebox pixel, and threads past the last shoebox pixel simply retire. With no
- * barrier and no idle background lanes, warps never stall waiting on divergent
- * siblings, which is the point of classifying per shoebox rather than over the
- * full detector frame.
+ * The block first fills a corner-flag tile in dynamic shared memory
+ * (one corner_is_foreground evaluation per corner of the shoebox's
+ * (w+1)×(h+1) corner grid), then classifies each pixel as the OR of its
+ * four corner flags. The single __syncthreads() between fill and read
+ * separates two uniform, densely-strided phases, so no lane idles at
+ * the barrier. A shoebox whose corner grid exceeds tile_capacity falls
+ * back to per-pixel corner recompute (identical result, no reuse).
  *
  * @param d_image Pointer to image data
  * @param image_pitch Pitch of the image data in bytes
@@ -433,6 +439,8 @@ __device__ __forceinline__ bool pixel_is_foreground(
  * @param d_reflection_indices Indices of reflections touching this image
  * @param num_reflections_this_image Number of reflections (== gridDim.x)
  * @param d_mask Detector mask, flat width*height
+ * @param tile_capacity Corner slots in the dynamic shared-memory tile (the
+ *        launch allocates this many bytes); block-uniform
  * @param delta_b Foreground extent in e₁/e₂ directions (n_sigma × σ_D)
  * @param delta_m Foreground extent in e₃ direction (n_sigma × σ_M)
  * @param d_foreground_sum Output: accumulated foreground intensities per reflection
@@ -464,6 +472,7 @@ __global__ void kabsch_transform(pixel_t *d_image,
                                  const size_t *d_reflection_indices,
                                  size_t num_reflections_this_image,
                                  const uint8_t *d_mask,
+                                 uint32_t tile_capacity,
                                  // Summation integration parameters
                                  scalar_t delta_b,
                                  scalar_t delta_m,
@@ -518,12 +527,16 @@ __global__ void kabsch_transform(pixel_t *d_image,
     // fill it, one uniform __syncthreads() separates fill from read,
     // and that barrier syncs a uniform workload.
     //
-    // The tile is a fixed static allocation; a shoebox whose corner grid exceeds
-    // it falls back to per-pixel recompute. At ~122 regs/thread occupancy is
-    // register-limited to 4 blocks/SM, so the tile's shared memory is not the
-    // occupancy binder.
-    constexpr int MAX_TILE_DIM = 64;  // corners per side (pixel shoebox up to 63)
-    __shared__ uint8_t s_corner[MAX_TILE_DIM * MAX_TILE_DIM];
+    // The tile lives in dynamic shared memory: the host sizes the
+    // launch to the largest corner grid on this image (clamped to the
+    // per-block limit), so the allocation tracks the data instead of a
+    // compile-time cap. A shoebox whose corner grid still exceeds
+    // tile_capacity falls back to per-pixel recompute. The kernel's
+    // register pressure limits occupancy well before this tile does:
+    // the tile costs one byte per corner, so at realistic shoebox sizes
+    // it is far from the shared-memory limit that would bind first. The
+    // host warns once if a request is large enough to change that.
+    extern __shared__ uint8_t s_corner[];
 
     auto corner_fg = [&](int cx, int cy) -> bool {
         return corner_is_foreground<Algo>(cx,
@@ -594,13 +607,15 @@ __global__ void kabsch_transform(pixel_t *d_image,
         }
     };
 
-    // Corner grid dimensions (one more than the pixel grid on each axis). The
-    // bbox is block-uniform, so the tile-vs-fallback choice below is taken by
-    // every thread identically and the __syncthreads() is never divergent.
+    // Corner grid dimensions (one more than the pixel grid on each axis
+    // as we are calculating corners). The bbox and tile_capacity are
+    // block-uniform, so the tile-vs-fallback choice below is taken by
+    // every thread identically and the __syncthreads() is never
+    // divergent.
     const int cw = w + 1;
     const int ch = h + 1;
 
-    if (cw <= MAX_TILE_DIM && ch <= MAX_TILE_DIM) {
+    if (static_cast<uint32_t>(cw) * static_cast<uint32_t>(ch) <= tile_capacity) {
         // Fill the corner tile: one corner_is_foreground per corner, threads
         // striding densely over the (w+1)×(h+1) grid.
         const int num_corners = cw * ch;
@@ -673,6 +688,7 @@ void compute_kabsch_transform(pixel_t *d_image,
                               const size_t *d_reflection_indices,
                               size_t num_reflections_this_image,
                               const uint8_t *d_mask,
+                              uint32_t max_corner_tile_corners,
                               scalar_t delta_b,
                               scalar_t delta_m,
                               FGAlgorithm algorithm,
@@ -693,6 +709,24 @@ void compute_kabsch_transform(pixel_t *d_image,
     dim3 blockDim(KABSCH_THREADS);
     dim3 gridDim(static_cast<uint32_t>(num_reflections_this_image));
 
+    // Dynamic shared memory for the corner tile: one byte per corner slot,
+    // sized by the caller to the largest (w+1)*(h+1) corner grid on this
+    // image and clamped to the device's per-block dynamic limit (48 KB
+    // without opt-in). Opting in above that limit is exactly the regime
+    // that costs occupancy, so a shoebox beyond the clamp takes the
+    // kernel's per-pixel fallback instead of a bigger allocation.
+    // Profile opt in on A100?
+    static const uint32_t max_smem_per_block = [] {
+        int device = 0;
+        cudaGetDevice(&device);
+        int bytes = 0;
+        cudaDeviceGetAttribute(&bytes, cudaDevAttrMaxSharedMemoryPerBlock, device);
+        return static_cast<uint32_t>(bytes);
+    }();
+    const uint32_t tile_capacity =
+      std::min(max_corner_tile_corners, max_smem_per_block);
+    const size_t smem_bytes = tile_capacity * sizeof(uint8_t);
+
     // The kernel is templated on FGAlgorithm rather than taking it as a
     // runtime parameter, for two reasons:
     //   - The classification maths differs (Ellipsoid evaluates three z-slices,
@@ -706,39 +740,82 @@ void compute_kabsch_transform(pixel_t *d_image,
     // fixes this by passing an integral_constant tag that forces a
     // fresh instantiation per call site with `algo` bound to a literal, which
     // then names the right specialisation. The argument list also only has
-    // to be written once, which is a nice
+    // to be written once.
     auto launch = [&](auto algo_tag) {
         constexpr FGAlgorithm algo = decltype(algo_tag)::value;
+        // Warn if a tile allocation is large enough to cost occupancy:
+        // compare achievable blocks/SM with and without the dynamic
+        // allocation. Registers bind first on this kernel, so this only
+        // fires for genuinely large shoeboxes.
+        //
+        // The occupancy query is a CUDA runtime call, and running it on
+        // every launch serialises the worker threads on the runtime lock.
+        // A smaller request can never occupy worse than a larger one, so
+        // the query only has to run when a launch asks for more shared
+        // memory than any before it. So we track the high-water mark in
+        // an atomic and only query when it is exceeded.
+        static std::atomic<uint32_t> smem_high_water{0};
+        uint32_t prev_high = smem_high_water.load(std::memory_order_relaxed);
+        if (smem_bytes > prev_high
+            && smem_high_water.compare_exchange_strong(
+              prev_high, static_cast<uint32_t>(smem_bytes))) {
+            int blocks_no_smem = 0;
+            int blocks_with_smem = 0;
+            cudaOccupancyMaxActiveBlocksPerMultiprocessor(
+              &blocks_no_smem,
+              kabsch_transform<algo>,
+              static_cast<int>(KABSCH_THREADS),
+              0);
+            cudaOccupancyMaxActiveBlocksPerMultiprocessor(
+              &blocks_with_smem,
+              kabsch_transform<algo>,
+              static_cast<int>(KABSCH_THREADS),
+              smem_bytes);
+            if (blocks_with_smem < blocks_no_smem) {
+                static std::once_flag occupancy_warning_flag;
+                std::call_once(occupancy_warning_flag, [&] {
+                    logger.warn(
+                      "Kabsch corner tile of {} B (largest shoebox on image {}) "
+                      "reduces occupancy from {} to {} blocks/SM; further "
+                      "occurrences are not reported",
+                      smem_bytes,
+                      image_num,
+                      blocks_no_smem,
+                      blocks_with_smem);
+                });
+            }
+        }
         kabsch_transform<algo>
-          <<<gridDim, blockDim, 0, stream>>>(d_image,
-                                             image_pitch,
-                                             width,
-                                             height,
-                                             image_num,
-                                             d_matrix,
-                                             wavelength,
-                                             det_params,
-                                             osc_start,
-                                             osc_width,
-                                             image_range_start,
-                                             s0,
-                                             rot_axis,
-                                             d_s1_vectors,
-                                             d_phi_values,
-                                             d_bboxes,
-                                             d_reflection_indices,
-                                             num_reflections_this_image,
-                                             d_mask,
-                                             delta_b,
-                                             delta_m,
-                                             d_foreground_sum,
-                                             d_foreground_count,
-                                             d_background_hist,
-                                             d_background_overflow,
-                                             d_intensity_times_x,
-                                             d_intensity_times_y,
-                                             d_intensity_times_z,
-                                             d_success);
+          <<<gridDim, blockDim, smem_bytes, stream>>>(d_image,
+                                                      image_pitch,
+                                                      width,
+                                                      height,
+                                                      image_num,
+                                                      d_matrix,
+                                                      wavelength,
+                                                      det_params,
+                                                      osc_start,
+                                                      osc_width,
+                                                      image_range_start,
+                                                      s0,
+                                                      rot_axis,
+                                                      d_s1_vectors,
+                                                      d_phi_values,
+                                                      d_bboxes,
+                                                      d_reflection_indices,
+                                                      num_reflections_this_image,
+                                                      d_mask,
+                                                      tile_capacity,
+                                                      delta_b,
+                                                      delta_m,
+                                                      d_foreground_sum,
+                                                      d_foreground_count,
+                                                      d_background_hist,
+                                                      d_background_overflow,
+                                                      d_intensity_times_x,
+                                                      d_intensity_times_y,
+                                                      d_intensity_times_z,
+                                                      d_success);
     };
     if (algorithm == FGAlgorithm::Ellipsoid) {
         launch(std::integral_constant<FGAlgorithm, FGAlgorithm::Ellipsoid>{});

--- a/integrator/kabsch.cu
+++ b/integrator/kabsch.cu
@@ -109,7 +109,6 @@ __device__ __forceinline__ bool is_foreground(const Vector3D &eps,
  * @param s_pixel Diffracted vector at the current pixel (S′), units of 1/Å
  * @param phi_pixel Rotation angle at the pixel (φ′), in radians
  * @param rot_axis Unit goniometer rotation axis vector (m₂)
- * @param s1_len_out Output parameter for magnitude of s₁ᶜ (|s₁|)
  * @return Transformed coordinates in Kabsch space (ε₁, ε₂, ε₃)
  */
 __device__ Vector3D pixel_to_kabsch(const Vector3D &s0,
@@ -117,8 +116,7 @@ __device__ Vector3D pixel_to_kabsch(const Vector3D &s0,
                                     scalar_t phi_c,
                                     const Vector3D &s_pixel,
                                     scalar_t phi_pixel,
-                                    const Vector3D &rot_axis,
-                                    scalar_t &s1_len_out) {
+                                    const Vector3D &rot_axis) {
     // Define the local Kabsch basis vectors:
 
     // e1 is perpendicular to the scattering plane
@@ -132,7 +130,6 @@ __device__ Vector3D pixel_to_kabsch(const Vector3D &s0,
 
     // Compute the length of the predicted diffracted vector (|s₁|)
     scalar_t s1_len = norm(s1_c);
-    s1_len_out = s1_len;
 
     // Rotation offset between the pixel and reflection centre
     scalar_t dphi = phi_pixel - phi_c;
@@ -314,7 +311,6 @@ __device__ __forceinline__ bool pixel_is_foreground(
         for (int dx = 0; dx <= 1; ++dx) {
             const Vector3D s_pixel =
               corner_s_pixel(px + dx, py + dy, d_matrix, wavelength, det_params);
-            scalar_t s1_len;  // unused here, required by pixel_to_kabsch
 
             // `if constexpr` resolves at compile time; only the chosen branch is
             // emitted into each kernel specialization, so the unused algorithm's
@@ -322,24 +318,24 @@ __device__ __forceinline__ bool pixel_is_foreground(
             if constexpr (Algo == FGAlgorithm::Ellipsoid) {
                 // Lower z-face (phi_low)
                 Vector3D eps_lo =
-                  pixel_to_kabsch(s0, s1_c, phi_c, s_pixel, phi_low, rot_axis, s1_len);
+                  pixel_to_kabsch(s0, s1_c, phi_c, s_pixel, phi_low, rot_axis);
                 if (is_foreground(eps_lo, delta_b, delta_m)) return true;
 
                 // Upper z-face (phi_high)
                 Vector3D eps_hi =
-                  pixel_to_kabsch(s0, s1_c, phi_c, s_pixel, phi_high, rot_axis, s1_len);
+                  pixel_to_kabsch(s0, s1_c, phi_c, s_pixel, phi_high, rot_axis);
                 if (is_foreground(eps_hi, delta_b, delta_m)) return true;
 
                 // Centre z-slice: evaluate at phi_c where ε₃ = 0
                 if (centre_in_z_slice) {
-                    Vector3D eps_c = pixel_to_kabsch(
-                      s0, s1_c, phi_c, s_pixel, phi_c, rot_axis, s1_len);
+                    Vector3D eps_c =
+                      pixel_to_kabsch(s0, s1_c, phi_c, s_pixel, phi_c, rot_axis);
                     if (is_foreground(eps_c, delta_b, delta_m)) return true;
                 }
             } else {
                 // DIALS: single 2D ellipse, evaluated at phi_low; ε₃ ignored
                 Vector3D eps =
-                  pixel_to_kabsch(s0, s1_c, phi_c, s_pixel, phi_low, rot_axis, s1_len);
+                  pixel_to_kabsch(s0, s1_c, phi_c, s_pixel, phi_low, rot_axis);
                 scalar_t inv_delta_b_sq = scalar_t(1.0) / (delta_b * delta_b);
                 scalar_t ellipsoid_val =
                   (eps.x * eps.x + eps.y * eps.y) * inv_delta_b_sq;

--- a/integrator/kabsch.cu
+++ b/integrator/kabsch.cu
@@ -59,12 +59,6 @@
 
 using namespace fastvec;
 
-// Threads per block for the shoebox-parallel Kabsch kernel. One block handles
-// one reflection shoebox; its threads stride over the shoebox's w×h pixels, so
-// this is a scheduling knob, not a shoebox-size limit. 128 keeps register
-// pressure low enough for several blocks per SM; tune against the profiler.
-constexpr int KABSCH_THREADS = 128;
-
 /**
  * @brief Check if a pixel is in the foreground region of a reflection
  *

--- a/integrator/kabsch.cu
+++ b/integrator/kabsch.cu
@@ -254,23 +254,92 @@ corner_s_pixel(int cx,
 }
 
 /**
+ * @brief Classify a single detector corner as inside the reflection profile.
+ *
+ * Evaluates one voxel corner (cx, cy): maps it to its scattered
+ * wavevector, then tests whether that corner falls inside the profile
+ * in any evaluated z-slice. The result depends only on (cx, cy) and the
+ * block's reflection/image constants, so it is the reusable unit shared
+ * between the (up to four) pixels that touch this corner.
+ *
+ * Ellipsoid evaluates three z-slices (phi_low, phi_high, and phi_c when
+ * the centre falls in this slice); DIALS evaluates a single 2D ellipse
+ * at phi_low, ignoring ε₃.
+ *
+ * @tparam Algo Foreground model: Ellipsoid (3D) or DIALS (2D ellipse).
+ * @param cx Corner fast-axis index, in pixels.
+ * @param cy Corner slow-axis index, in pixels.
+ * @param s0 Incident beam vector (s₀), units of 1/Å.
+ * @param s1_c Predicted diffracted vector at the reflection centre (s₁ᶜ), units of 1/Å.
+ * @param phi_c Rotation angle at the reflection centre (φᶜ), in radians.
+ * @param phi_low Rotation angle at the lower z-face (φ), in radians.
+ * @param phi_high Rotation angle at the upper z-face (φ), in radians.
+ * @param centre_in_z_slice Whether φᶜ falls in this image's z-slice (Ellipsoid centre slice).
+ * @param rot_axis Unit goniometer rotation axis vector (m₂).
+ * @param d_matrix Detector coordinate transformation matrix (3x3).
+ * @param wavelength X-ray wavelength in Å.
+ * @param det_params Detector geometry parameters (pixel size, parallax, etc.).
+ * @param delta_b Foreground extent in e₁/e₂ directions (n_sigma × σ_D).
+ * @param delta_m Foreground extent in e₃ direction (n_sigma × σ_M).
+ * @return true if the corner is inside the reflection profile, false otherwise.
+ */
+template <FGAlgorithm Algo>
+__device__ __forceinline__ bool corner_is_foreground(
+  int cx,
+  int cy,
+  const Vector3D &s0,
+  const Vector3D &s1_c,
+  scalar_t phi_c,
+  scalar_t phi_low,
+  scalar_t phi_high,
+  bool centre_in_z_slice,
+  const Vector3D &rot_axis,
+  const scalar_t *d_matrix,
+  scalar_t wavelength,
+  const DetectorParameters &det_params,
+  scalar_t delta_b,
+  scalar_t delta_m) {
+    const Vector3D s_pixel = corner_s_pixel(cx, cy, d_matrix, wavelength, det_params);
+
+    // `if constexpr` resolves at compile time; only the chosen branch is
+    // emitted into each kernel specialization, so the unused algorithm's
+    // code (and its register footprint) is gone.
+    if constexpr (Algo == FGAlgorithm::Ellipsoid) {
+        // Lower z-face (phi_low)
+        Vector3D eps_lo = pixel_to_kabsch(s0, s1_c, phi_c, s_pixel, phi_low, rot_axis);
+        if (is_foreground(eps_lo, delta_b, delta_m)) return true;
+
+        // Upper z-face (phi_high)
+        Vector3D eps_hi = pixel_to_kabsch(s0, s1_c, phi_c, s_pixel, phi_high, rot_axis);
+        if (is_foreground(eps_hi, delta_b, delta_m)) return true;
+
+        // Centre z-slice: evaluate at phi_c where ε₃ = 0
+        if (centre_in_z_slice) {
+            Vector3D eps_c = pixel_to_kabsch(s0, s1_c, phi_c, s_pixel, phi_c, rot_axis);
+            if (is_foreground(eps_c, delta_b, delta_m)) return true;
+        }
+        return false;
+    } else {
+        // DIALS: single 2D ellipse, evaluated at phi_low; ε₃ ignored
+        Vector3D eps = pixel_to_kabsch(s0, s1_c, phi_c, s_pixel, phi_low, rot_axis);
+        scalar_t inv_delta_b_sq = scalar_t(1.0) / (delta_b * delta_b);
+        scalar_t ellipsoid_val = (eps.x * eps.x + eps.y * eps.y) * inv_delta_b_sq;
+        return ellipsoid_val <= scalar_t(1.0);
+    }
+}
+
+/**
  * @brief Classify a single pixel as foreground for one reflection.
  *
  * A pixel is foreground if ANY of its four voxel corners {px,px+1}×{py,py+1}
- * is inside the reflection profile in ANY evaluated z-slice. Each thread
+ * is inside the reflection profile (see corner_is_foreground). Each thread
  * computes its own pixel's corners directly, with no shared-memory corner cache
- * and no inter-thread barrier. The corner Kabsch values are deterministic in
+ * and no inter-thread barrier. The corner classification is deterministic in
  * (corner, φ), so neighbouring threads that share a corner compute the same
  * value independently. This recomputes each interior corner up to four times, a
- * deliberate trade: the kernel is latency-bound rather than compute-bound (see
- * kabsch_transform), so the redundant ALU is effectively free, whereas caching
- * the corners would need a barrier that is not. It returns on the first corner
- * that lands inside the profile, so foreground pixels bail early and only
- * fully-background ones pay for all four corners.
- *
- * Ellipsoid evaluates three z-slices (phi_low, phi_high, and phi_c when the
- * centre falls in this slice); DIALS evaluates a single 2D ellipse at phi_low,
- * ignoring ε₃.
+ * deliberate trade: caching the corners would need a barrier. It returns on the
+ * first corner that lands inside the profile, so foreground pixels bail early
+ * and only fully-background ones pay for all four corners.
  *
  * @tparam Algo Foreground model: Ellipsoid (3D) or DIALS (2D ellipse).
  * @param px Pixel fast-axis index (lower corner), in pixels.
@@ -309,37 +378,21 @@ __device__ __forceinline__ bool pixel_is_foreground(
     for (int dy = 0; dy <= 1; ++dy) {
 #pragma unroll
         for (int dx = 0; dx <= 1; ++dx) {
-            const Vector3D s_pixel =
-              corner_s_pixel(px + dx, py + dy, d_matrix, wavelength, det_params);
-
-            // `if constexpr` resolves at compile time; only the chosen branch is
-            // emitted into each kernel specialization, so the unused algorithm's
-            // code (and its register footprint) is gone.
-            if constexpr (Algo == FGAlgorithm::Ellipsoid) {
-                // Lower z-face (phi_low)
-                Vector3D eps_lo =
-                  pixel_to_kabsch(s0, s1_c, phi_c, s_pixel, phi_low, rot_axis);
-                if (is_foreground(eps_lo, delta_b, delta_m)) return true;
-
-                // Upper z-face (phi_high)
-                Vector3D eps_hi =
-                  pixel_to_kabsch(s0, s1_c, phi_c, s_pixel, phi_high, rot_axis);
-                if (is_foreground(eps_hi, delta_b, delta_m)) return true;
-
-                // Centre z-slice: evaluate at phi_c where ε₃ = 0
-                if (centre_in_z_slice) {
-                    Vector3D eps_c =
-                      pixel_to_kabsch(s0, s1_c, phi_c, s_pixel, phi_c, rot_axis);
-                    if (is_foreground(eps_c, delta_b, delta_m)) return true;
-                }
-            } else {
-                // DIALS: single 2D ellipse, evaluated at phi_low; ε₃ ignored
-                Vector3D eps =
-                  pixel_to_kabsch(s0, s1_c, phi_c, s_pixel, phi_low, rot_axis);
-                scalar_t inv_delta_b_sq = scalar_t(1.0) / (delta_b * delta_b);
-                scalar_t ellipsoid_val =
-                  (eps.x * eps.x + eps.y * eps.y) * inv_delta_b_sq;
-                if (ellipsoid_val <= scalar_t(1.0)) return true;
+            if (corner_is_foreground<Algo>(px + dx,
+                                           py + dy,
+                                           s0,
+                                           s1_c,
+                                           phi_c,
+                                           phi_low,
+                                           phi_high,
+                                           centre_in_z_slice,
+                                           rot_axis,
+                                           d_matrix,
+                                           wavelength,
+                                           det_params,
+                                           delta_b,
+                                           delta_m)) {
+                return true;
             }
         }
     }

--- a/integrator/kabsch.cu
+++ b/integrator/kabsch.cu
@@ -59,26 +59,11 @@
 
 using namespace fastvec;
 
-// Block dimensions for the Kabsch transform kernel.
-// Used by both the kernel (shared memory sizing) and host wrapper (grid launch).
-//
-// Each block of KABSCH_BLOCK_X × KABSCH_BLOCK_Y threads maps 1:1 to corners.
-// A pixel's voxel has 4 xy-corners: (px,py), (px+1,py), (px,py+1), (px+1,py+1).
-// All 4 must be in the same block's shared memory so the pixel thread can read
-// them after __syncthreads(). This means a block of 32×16 corners can only
-// service (32-1)×(16-1) = 31×15 complete pixels. The rightmost column and
-// bottom row of threads are "helper" corners that exist solely so the last
-// interior pixel has a right/bottom neighbour to read.
-//
-// The grid is launched with a stride of (BLOCK-1) so adjacent blocks overlap
-// by one column/row of corners.  That single shared column/row is computed
-// by both blocks (redundantly), which costs ~3-6% extra work but keeps
-// everything in fast shared memory within a single kernel launch.
-constexpr int KABSCH_BLOCK_X = 32;
-constexpr int KABSCH_BLOCK_Y = 16;
-
-// Maximum number of reflections that can overlap a single block's footprint
-constexpr size_t MAX_BLOCK_REFLECTIONS = 64;
+// Threads per block for the shoebox-parallel Kabsch kernel. One block handles
+// one reflection shoebox; its threads stride over the shoebox's w×h pixels, so
+// this is a scheduling knob, not a shoebox-size limit. 128 keeps register
+// pressure low enough for several blocks per SM; tune against the profiler.
+constexpr int KABSCH_THREADS = 128;
 
 /**
  * @brief Check if a pixel is in the foreground region of a reflection
@@ -251,20 +236,141 @@ __device__ __forceinline__ void px_to_mm(int gx,
 }
 
 /**
- * @brief CUDA kernel with 8-corner voxel foreground classification
+ * @brief Scattered beam wavevector s1 (magnitude 1/λ) at a detector corner
+ *        (cx, cy).
  *
- * Each thread represents a corner in the (width+1)×(height+1) corner grid.
- * Blocks use overlapping tiles: KABSCH_BLOCK_X × KABSCH_BLOCK_Y threads
- * cover that many corners, yielding (KABSCH_BLOCK_X-1) × (KABSCH_BLOCK_Y-1)
- * complete pixels per block.  Adjacent blocks share one row/column of corners.
+ * The px -> reciprocal-space mapping is pure geometry, so it holds fine past
+ * the detector edge. Corners off the image still give real Kabsch coordinates
+ * and classify the same as any other, so we don't guard for them here.
  *
- * Algorithm:
- *   1. Every thread computes Kabsch coordinates for its corner at two φ values
- *      (lower and upper z-faces of the voxel) and writes foreground flags to
- *      shared memory.
- *   2. After sync, interior threads (representing complete pixels) check all
- *      8 voxel corners. If ANY corner is foreground, the pixel is foreground;
- *      otherwise it's background.
+ * @param wavelength Beam wavelength in Å.
+ * @return s1 in lab frame, units of 1/Å (lies on the Ewald sphere).
+ */
+__device__ __forceinline__ Vector3D
+corner_s_pixel(int cx,
+               int cy,
+               const scalar_t *d_matrix,
+               scalar_t wavelength,
+               const DetectorParameters &det_params) {
+    scalar_t cx_mm, cy_mm;
+    px_to_mm(cx, cy, det_params, cx_mm, cy_mm);
+
+    Vector3D lab_coord =
+      make_vector3d(d_matrix[0] * cx_mm + d_matrix[1] * cy_mm + d_matrix[2],
+                    d_matrix[3] * cx_mm + d_matrix[4] * cy_mm + d_matrix[5],
+                    d_matrix[6] * cx_mm + d_matrix[7] * cy_mm + d_matrix[8]);
+    return normalized(lab_coord) / wavelength;
+}
+
+/**
+ * @brief Classify a single pixel as foreground for one reflection.
+ *
+ * A pixel is foreground if ANY of its four voxel corners {px,px+1}×{py,py+1}
+ * is inside the reflection profile in ANY evaluated z-slice. Each thread
+ * computes its own pixel's corners directly, with no shared-memory corner cache
+ * and no inter-thread barrier. The corner Kabsch values are deterministic in
+ * (corner, φ), so neighbouring threads that share a corner compute the same
+ * value independently. This recomputes each interior corner up to four times, a
+ * deliberate trade: the kernel is latency-bound rather than compute-bound (see
+ * kabsch_transform), so the redundant ALU is effectively free, whereas caching
+ * the corners would need a barrier that is not. It returns on the first corner
+ * that lands inside the profile, so foreground pixels bail early and only
+ * fully-background ones pay for all four corners.
+ *
+ * Ellipsoid evaluates three z-slices (phi_low, phi_high, and phi_c when the
+ * centre falls in this slice); DIALS evaluates a single 2D ellipse at phi_low,
+ * ignoring ε₃.
+ *
+ * @tparam Algo Foreground model: Ellipsoid (3D) or DIALS (2D ellipse).
+ * @param px Pixel fast-axis index (lower corner), in pixels.
+ * @param py Pixel slow-axis index (lower corner), in pixels.
+ * @param s0 Incident beam vector (s₀), units of 1/Å.
+ * @param s1_c Predicted diffracted vector at the reflection centre (s₁ᶜ), units of 1/Å.
+ * @param phi_c Rotation angle at the reflection centre (φᶜ), in radians.
+ * @param phi_low Rotation angle at the lower z-face (φ), in radians.
+ * @param phi_high Rotation angle at the upper z-face (φ), in radians.
+ * @param centre_in_z_slice Whether φᶜ falls in this image's z-slice (Ellipsoid centre slice).
+ * @param rot_axis Unit goniometer rotation axis vector (m₂).
+ * @param d_matrix Detector coordinate transformation matrix (3x3).
+ * @param wavelength X-ray wavelength in Å.
+ * @param det_params Detector geometry parameters (pixel size, parallax, etc.).
+ * @param delta_b Foreground extent in e₁/e₂ directions (n_sigma × σ_D).
+ * @param delta_m Foreground extent in e₃ direction (n_sigma × σ_M).
+ * @return true if the pixel is foreground for this reflection, false otherwise.
+ */
+template <FGAlgorithm Algo>
+__device__ __forceinline__ bool pixel_is_foreground(
+  int px,
+  int py,
+  const Vector3D &s0,
+  const Vector3D &s1_c,
+  scalar_t phi_c,
+  scalar_t phi_low,
+  scalar_t phi_high,
+  bool centre_in_z_slice,
+  const Vector3D &rot_axis,
+  const scalar_t *d_matrix,
+  scalar_t wavelength,
+  const DetectorParameters &det_params,
+  scalar_t delta_b,
+  scalar_t delta_m) {
+#pragma unroll
+    for (int dy = 0; dy <= 1; ++dy) {
+#pragma unroll
+        for (int dx = 0; dx <= 1; ++dx) {
+            const Vector3D s_pixel =
+              corner_s_pixel(px + dx, py + dy, d_matrix, wavelength, det_params);
+            scalar_t s1_len;  // unused here, required by pixel_to_kabsch
+
+            // `if constexpr` resolves at compile time; only the chosen branch is
+            // emitted into each kernel specialization, so the unused algorithm's
+            // code (and its register footprint) is gone.
+            if constexpr (Algo == FGAlgorithm::Ellipsoid) {
+                // Lower z-face (phi_low)
+                Vector3D eps_lo =
+                  pixel_to_kabsch(s0, s1_c, phi_c, s_pixel, phi_low, rot_axis, s1_len);
+                if (is_foreground(eps_lo, delta_b, delta_m)) return true;
+
+                // Upper z-face (phi_high)
+                Vector3D eps_hi =
+                  pixel_to_kabsch(s0, s1_c, phi_c, s_pixel, phi_high, rot_axis, s1_len);
+                if (is_foreground(eps_hi, delta_b, delta_m)) return true;
+
+                // Centre z-slice: evaluate at phi_c where ε₃ = 0
+                if (centre_in_z_slice) {
+                    Vector3D eps_c = pixel_to_kabsch(
+                      s0, s1_c, phi_c, s_pixel, phi_c, rot_axis, s1_len);
+                    if (is_foreground(eps_c, delta_b, delta_m)) return true;
+                }
+            } else {
+                // DIALS: single 2D ellipse, evaluated at phi_low; ε₃ ignored
+                Vector3D eps =
+                  pixel_to_kabsch(s0, s1_c, phi_c, s_pixel, phi_low, rot_axis, s1_len);
+                scalar_t inv_delta_b_sq = scalar_t(1.0) / (delta_b * delta_b);
+                scalar_t ellipsoid_val =
+                  (eps.x * eps.x + eps.y * eps.y) * inv_delta_b_sq;
+                if (ellipsoid_val <= scalar_t(1.0)) return true;
+            }
+        }
+    }
+    return false;
+}
+
+/**
+ * @brief Shoebox-parallel Kabsch foreground/background classification kernel.
+ *
+ * One CUDA block per reflection shoebox on the current image
+ * (gridDim.x == num_reflections_this_image; blockIdx.x indexes
+ * d_reflection_indices). Threads in the block stride over the shoebox's w×h
+ * pixels; each thread classifies its own pixel via its four voxel corners
+ * (see pixel_is_foreground) and atomically accumulates into the per-reflection
+ * foreground/background buffers.
+ *
+ * There is no shared memory and no __syncthreads(): every lane works on a real
+ * shoebox pixel, and threads past the last shoebox pixel simply retire. With no
+ * barrier and no idle background lanes, warps never stall waiting on divergent
+ * siblings, which is the point of classifying per shoebox rather than over the
+ * full detector frame.
  *
  * @param d_image Pointer to image data
  * @param image_pitch Pitch of the image data in bytes
@@ -282,10 +388,8 @@ __device__ __forceinline__ void px_to_mm(int gx,
  * @param d_phi_values Array of phi values for each reflection
  * @param d_bboxes Array of bounding box structs for each reflection
  * @param d_reflection_indices Indices of reflections touching this image
- * @param num_reflections_this_image Number of reflections to process
+ * @param num_reflections_this_image Number of reflections (== gridDim.x)
  * @param d_mask Detector mask, flat width*height
- * @param origin_x Pixel x coordinate of the launch grid origin (may be negative)
- * @param origin_y Pixel y coordinate of the launch grid origin (may be negative)
  * @param delta_b Foreground extent in e₁/e₂ directions (n_sigma × σ_D)
  * @param delta_m Foreground extent in e₃ direction (n_sigma × σ_M)
  * @param d_foreground_sum Output: accumulated foreground intensities per reflection
@@ -317,8 +421,6 @@ __global__ void kabsch_transform(pixel_t *d_image,
                                  const size_t *d_reflection_indices,
                                  size_t num_reflections_this_image,
                                  const uint8_t *d_mask,
-                                 int origin_x,
-                                 int origin_y,
                                  // Summation integration parameters
                                  scalar_t delta_b,
                                  scalar_t delta_m,
@@ -331,53 +433,20 @@ __global__ void kabsch_transform(pixel_t *d_image,
                                  unsigned long long *d_intensity_times_y,
                                  unsigned long long *d_intensity_times_z,
                                  uint8_t *d_success) {
-#pragma region Shared Memory
-    // Foreground flags for each corner. For the Ellipsoid algorithm we need
-    // three slices: [0] phi_low, [1] phi_high, [2] phi_c (centre-in-slice).
-    // For DIALS we only evaluate one slice at phi_low (no e3 term).
-    //
-    // NUM_SLICES depends on Algo (template param), so it's known at compile
-    // time. DIALS launches get the smaller shared-memory allocation, which
-    // helps occupancy. A runtime algorithm flag would force us to size for
-    // the worst case here.
-    constexpr int NUM_SLICES = (Algo == FGAlgorithm::Ellipsoid) ? 3 : 1;
-    // s_is_fg is indexed [z-slice][ty][tx]. The first index selects a foreground
-    // mask in shared memory: Ellipsoid keeps 3 z-slices (phi_low, phi_high,
-    // phi_c), DIALS keeps 1 (phi_low only). Each slice is a full block-sized
-    // 2D plane shared by every thread in the block, so a thread can read its
-    // neighbours' corner flags (tx±1, ty±1) after __syncthreads() without
-    // recomputing them.
-    // Shared memory for corner foreground flags
-    __shared__ bool s_is_fg[NUM_SLICES][KABSCH_BLOCK_Y][KABSCH_BLOCK_X];
+    // One block per reflection shoebox on this image; blockIdx.x indexes the
+    // image-level reflection list directly.
+    const size_t block_refl = blockIdx.x;
+    if (block_refl >= num_reflections_this_image) return;
 
-    // Block-level reflection list: indices into the global reflection arrays
-    __shared__ size_t s_block_refl[MAX_BLOCK_REFLECTIONS];
-    __shared__ size_t s_num_block_refl;
+    const size_t refl_idx = d_reflection_indices[block_refl];
+    const Vector3D s1_c = d_s1_vectors[refl_idx];
+    const scalar_t phi_c = d_phi_values[refl_idx];
+    const BoundingBoxExtents bbox = d_bboxes[refl_idx];
 
-    const int tx = threadIdx.x;  // Thread-local x index (also indexes shared memory)
-    const int ty = threadIdx.y;  // Thread-local y index
+    // The host lists a reflection only under the images its bbox spans, so this
+    // z-test normally passes; kept for parity/safety with the old block filter.
+    if (!(image_num >= bbox.z_min && image_num < bbox.z_max)) return;
 
-    // Global corner coordinates.
-    // The stride between block origins is (BLOCK-1), NOT BLOCK.  Compare:
-    //   Normal:  gx = blockIdx.x * blockDim.x + tx          (stride 32)
-    //   Here:    gx = blockIdx.x * (KABSCH_BLOCK_X - 1) + tx (stride 31)
-    //
-    // This means Block 0 covers corners 0-31, Block 1 covers 31-62, etc.
-    // Corner 31 is computed by BOTH blocks; that's the overlap.  It ensures
-    // pixel 30 (in Block 0) can read its right-side corner (31) from shared
-    // memory, and pixel 31 (in Block 1) can read its left-side corner (31)
-    // from its own block's shared memory.
-
-    // origin_{x,y} offsets the grid into negative pixel coordinates so the
-    // launch footprint covers bboxes that overflow the detector edge.
-    const int gx =
-      origin_x + blockIdx.x * (KABSCH_BLOCK_X - 1) + tx;  // Global x coordinate
-    const int gy =
-      origin_y + blockIdx.y * (KABSCH_BLOCK_Y - 1) + ty;  // Global y coordinate
-
-#pragma endregion Shared Memory
-
-#pragma region Per-Corner Setup
     // The voxel's two z-faces, one image apart. slice converts the 0-based
     // image_num to the (z + 1 - image_range_start) frame used everywhere else.
     const int slice = image_num - image_range_start + 1;
@@ -385,210 +454,97 @@ __global__ void kabsch_transform(pixel_t *d_image,
       degrees_to_radians(osc_start + (static_cast<scalar_t>(slice) * osc_width));
     const scalar_t phi_high =
       degrees_to_radians(osc_start + (static_cast<scalar_t>(slice + 1) * osc_width));
+    // Whether the reflection centre falls in this image's z-slice (block-uniform).
+    const bool centre_in_z_slice = (phi_c >= phi_low && phi_c <= phi_high);
 
-    // s_pixel depends only on detector position (gx, gy), not phi. The
-    // px_to_mm / d_matrix mapping is geometric and well-defined beyond the
-    // detector edge, so corners outside the image carry valid Kabsch
-    // coordinates and are classified like any other.
-    Vector3D s_pixel = make_vector3d(0, 0, 0);
-    {
-        scalar_t gx_mm, gy_mm;
-        px_to_mm(gx, gy, det_params, gx_mm, gy_mm);
-
-        Vector3D lab_coord =
-          make_vector3d(d_matrix[0] * gx_mm + d_matrix[1] * gy_mm + d_matrix[2],
-                        d_matrix[3] * gx_mm + d_matrix[4] * gy_mm + d_matrix[5],
-                        d_matrix[6] * gx_mm + d_matrix[7] * gy_mm + d_matrix[8]);
-        s_pixel = normalized(lab_coord) / wavelength;
-    }
-
-#pragma endregion Per - Corner Setup
-
-#pragma region Block Reflection Filter
-    // Thread 0 scans the image-level reflection list and keeps only those
-    // whose bbox overlaps this block's corner footprint.
-    if (tx == 0 && ty == 0) {
-        s_num_block_refl = 0;
-
-        const int bx_min =
-          origin_x + static_cast<int>(blockIdx.x) * (KABSCH_BLOCK_X - 1);
-        const int bx_max = bx_min + KABSCH_BLOCK_X - 1;
-        const int by_min =
-          origin_y + static_cast<int>(blockIdx.y) * (KABSCH_BLOCK_Y - 1);
-        const int by_max = by_min + KABSCH_BLOCK_Y - 1;
-
-        for (size_t i = 0; i < num_reflections_this_image; ++i) {
-            const size_t refl_idx = d_reflection_indices[i];
-            const BoundingBoxExtents &bbox = d_bboxes[refl_idx];
-
-            // Does the reflection's bbox overlap this block AND current image?
-            const bool overlaps =
-              (bx_max >= bbox.x_min && bx_min <= bbox.x_max)
-              && (by_max >= bbox.y_min && by_min <= bbox.y_max)
-              && (image_num >= bbox.z_min && image_num < bbox.z_max);
-
-            if (overlaps && s_num_block_refl < MAX_BLOCK_REFLECTIONS) {
-                s_block_refl[s_num_block_refl++] = refl_idx;
-            }
-        }
-    }
-
-    __syncthreads();
-
-    // Early exit if no reflections overlap this block
-    if (s_num_block_refl == 0) return;
     // Pitched image accessor
     size_t elem_pitch = image_pitch / sizeof(pixel_t);
     PitchedArray2D<pixel_t> image(d_image, &elem_pitch);
 
-    // Does this thread represent a complete pixel?
-    // A pixel at (tx, ty) reads corners (tx, ty), (tx+1, ty), (tx, ty+1),
-    // (tx+1, ty+1) from shared memory.  For tx+1 and ty+1 to be valid
-    // indices, we need tx < 31 and ty < 15.  Threads on the right column
-    // (tx == 31) and bottom row (ty == 15) only contribute their corner
-    // during Phase 1; they don't process a pixel in Phase 2.
-    const bool is_pixel_thread = (tx < KABSCH_BLOCK_X - 1) && (ty < KABSCH_BLOCK_Y - 1);
-    const bool pixel_in_image = is_pixel_thread && (gx >= 0)
-                                && (gx < static_cast<int>(width)) && (gy >= 0)
-                                && (gy < static_cast<int>(height));
+    // Shoebox pixel extent. The bbox is half-open in x and y
+    // (x_min <= px < x_max), so w×h is exactly the pixel count.
+    const int w = bbox.x_max - bbox.x_min;
+    const int h = bbox.y_max - bbox.y_min;
+    const int npix = w * h;
 
-#pragma endregion Block Reflection Filter
+    // Threads stride over the shoebox pixels. Threads with p >= npix
+    // never enter the loop and retire immediately, so there is nothing
+    // for idle lanes to stall on.
+    for (int p = static_cast<int>(threadIdx.x); p < npix;
+         p += static_cast<int>(blockDim.x)) {
+        const int px = bbox.x_min + (p % w);
+        const int py = bbox.y_min + (p / w);
 
-#pragma region Reflection Processing Loop
-    // Process each reflection: compute corner flags, sync, then accumulate pixels
-    for (size_t r = 0; r < s_num_block_refl; ++r) {
-        const size_t refl_idx = s_block_refl[r];
-        const Vector3D &s1_c = d_s1_vectors[refl_idx];
-        const scalar_t phi_c = d_phi_values[refl_idx];
-        const BoundingBoxExtents &bbox = d_bboxes[refl_idx];
+        // Out-of-image pixels still classify (geometry is valid beyond the
+        // edge); a foreground pixel outside the image fails the reflection.
+        const bool pixel_in_image = (px >= 0) && (px < static_cast<int>(width))
+                                    && (py >= 0) && (py < static_cast<int>(height));
 
-        // Every thread writes its corner's foreground flag to shared memory.
-        // Per-corner bbox check avoids needless Kabsch computation.
-        const bool in_bbox = (gx >= bbox.x_min && gx <= bbox.x_max)
-                             && (gy >= bbox.y_min && gy <= bbox.y_max);
+        const bool any_fg = pixel_is_foreground<Algo>(px,
+                                                      py,
+                                                      s0,
+                                                      s1_c,
+                                                      phi_c,
+                                                      phi_low,
+                                                      phi_high,
+                                                      centre_in_z_slice,
+                                                      rot_axis,
+                                                      d_matrix,
+                                                      wavelength,
+                                                      det_params,
+                                                      delta_b,
+                                                      delta_m);
 
-        if (in_bbox) {
-            scalar_t s1_len;  // unused here, required by pixel_to_kabsch
-
-            // `if constexpr` resolves at compile time; only the chosen
-            // branch is emitted into each kernel specialization, so the
-            // unused algorithm's code (and its register footprint) is gone.
-            if constexpr (Algo == FGAlgorithm::Ellipsoid) {
-                // Lower z-face (phi_low)
-                Vector3D eps_lo =
-                  pixel_to_kabsch(s0, s1_c, phi_c, s_pixel, phi_low, rot_axis, s1_len);
-                s_is_fg[0][ty][tx] = is_foreground(eps_lo, delta_b, delta_m);
-
-                // Upper z-face (phi_high)
-                Vector3D eps_hi =
-                  pixel_to_kabsch(s0, s1_c, phi_c, s_pixel, phi_high, rot_axis, s1_len);
-                s_is_fg[1][ty][tx] = is_foreground(eps_hi, delta_b, delta_m);
-
-                // Centre z-slice: evaluate at phi_c where ε₃ = 0
-                const bool centre_in_z_slice = (phi_c >= phi_low && phi_c <= phi_high);
-                if (centre_in_z_slice) {
-                    Vector3D eps_c = pixel_to_kabsch(
-                      s0, s1_c, phi_c, s_pixel, phi_c, rot_axis, s1_len);
-                    s_is_fg[2][ty][tx] = is_foreground(eps_c, delta_b, delta_m);
-                } else {
-                    s_is_fg[2][ty][tx] = false;
-                }
+        if (any_fg) {
+            // Foreground outside the image or on a masked pixel makes the
+            // reflection unusable. d_success is only ever cleared, never set,
+            // so the concurrent writes need no atomic.
+            if (!pixel_in_image || d_mask[static_cast<size_t>(py) * width + px] == 0) {
+                d_success[refl_idx] = 0;
             } else {
-                // DIALS: single 2D ellipse, evaluated at phi_low; ε₃ ignored
-                Vector3D eps =
-                  pixel_to_kabsch(s0, s1_c, phi_c, s_pixel, phi_low, rot_axis, s1_len);
-                scalar_t inv_delta_b_sq = scalar_t(1.0) / (delta_b * delta_b);
-                scalar_t ellipsoid_val =
-                  (eps.x * eps.x + eps.y * eps.y) * inv_delta_b_sq;
-                s_is_fg[0][ty][tx] = (ellipsoid_val <= scalar_t(1.0));
+                const accumulator_t pixel_value =
+                  static_cast<accumulator_t>(image(px, py));
+                atomicAdd(&d_foreground_sum[refl_idx], pixel_value);
+                atomicAdd(&d_foreground_count[refl_idx], 1u);
+                // Accumulate intensity·coord for centre-of-mass (xyzobs.px).
+                // Baseline uses (x+0.5, y+0.5, z+0.5); we approximate the
+                // half-pixel offset by multiplying by 2x+1 etc. and dividing
+                // by 2 in finalisation to stay in integer atomics.
+                const unsigned long long pv64 =
+                  static_cast<unsigned long long>(pixel_value);
+                atomicAdd(&d_intensity_times_x[refl_idx],
+                          pv64 * static_cast<unsigned long long>(2 * px + 1));
+                atomicAdd(&d_intensity_times_y[refl_idx],
+                          pv64 * static_cast<unsigned long long>(2 * py + 1));
+                atomicAdd(&d_intensity_times_z[refl_idx],
+                          pv64 * static_cast<unsigned long long>(2 * image_num + 1));
             }
         } else {
-#pragma unroll
-            for (int z = 0; z < NUM_SLICES; ++z) {
-                s_is_fg[z][ty][tx] = false;
-            }
-        }
-
-        __syncthreads();
-
-        // Pixel centre within the bbox. Out-of-image pixels still enter
-        // here (guarded below): a foreground pixel outside the image
-        // fails the reflection.
-        const bool px_in_bbox = is_pixel_thread && (gx >= bbox.x_min && gx < bbox.x_max)
-                                && (gy >= bbox.y_min && gy < bbox.y_max);
-
-        if (px_in_bbox) {
-            // A pixel is foreground if any of its four surrounding corners
-            // is foreground in any z-slice.
-            bool any_fg = false;
-#pragma unroll
-            for (int z = 0; z < NUM_SLICES; ++z) {
-                const bool corner_00 = s_is_fg[z][ty][tx];
-                const bool corner_01 = s_is_fg[z][ty][tx + 1];
-                const bool corner_10 = s_is_fg[z][ty + 1][tx];
-                const bool corner_11 = s_is_fg[z][ty + 1][tx + 1];
-                any_fg |= corner_00 || corner_01 || corner_10 || corner_11;
-            }
-
-            if (any_fg) {
-                // Foreground outside the image or on a masked pixel makes the
-                // reflection unusable. d_success is only ever cleared, never
-                // set, so the concurrent writes need no atomic.
-                if (!pixel_in_image
-                    || d_mask[static_cast<size_t>(gy) * width + gx] == 0) {
-                    d_success[refl_idx] = 0;
-                } else {
-                    const accumulator_t pixel_value =
-                      static_cast<accumulator_t>(image(gx, gy));
-                    atomicAdd(&d_foreground_sum[refl_idx], pixel_value);
-                    atomicAdd(&d_foreground_count[refl_idx], 1u);
-                    // Accumulate intensity·coord for centre-of-mass (xyzobs.px).
-                    // Baseline uses (x+0.5, y+0.5, z+0.5); we approximate the
-                    // half-pixel offset by multiplying by 2x+1 etc. and dividing
-                    // by 2 in finalisation to stay in integer atomics.
-                    const unsigned long long pv64 =
-                      static_cast<unsigned long long>(pixel_value);
-                    atomicAdd(&d_intensity_times_x[refl_idx],
-                              pv64 * static_cast<unsigned long long>(2 * gx + 1));
-                    atomicAdd(&d_intensity_times_y[refl_idx],
-                              pv64 * static_cast<unsigned long long>(2 * gy + 1));
-                    atomicAdd(
-                      &d_intensity_times_z[refl_idx],
-                      pv64 * static_cast<unsigned long long>(2 * image_num + 1));
-                }
-            } else {
-                // Background is counted only for unmasked pixels inside the
-                // image; masked or out-of-image background is dropped. Each
-                // pixel value increments one bin of this reflection's
-                // histogram (one bin per integer count). Values at or above
-                // NUM_BG_BINS go to the overflow tail. A negative value is a
-                // sentinel/garbage pixel that slipped past the mask (reachable
-                // only when pixel_t is 32-bit and the value exceeds INT_MAX);
-                // it is not a real background measurement, so it is dropped
-                // rather than counted.
-                if (pixel_in_image
-                    && d_mask[static_cast<size_t>(gy) * width + gx] != 0) {
-                    const int bin = static_cast<int>(image(gx, gy));
-                    if (bin >= 0 && bin < NUM_BG_BINS) {
-                        atomicAdd(&d_background_hist[refl_idx * NUM_BG_BINS + bin], 1u);
-                    } else if (bin >= NUM_BG_BINS) {
-                        atomicAdd(&d_background_overflow[refl_idx], 1u);
-                    }
+            // Background is counted only for unmasked pixels inside the image;
+            // masked or out-of-image background is dropped. Each pixel value
+            // increments one bin of this reflection's histogram (one bin per
+            // integer count). Values at or above NUM_BG_BINS go to the overflow
+            // tail. A negative value is a sentinel/garbage pixel that slipped
+            // past the mask (reachable only when pixel_t is 32-bit and the value
+            // exceeds INT_MAX); it is not a real background measurement, so it
+            // is dropped rather than counted.
+            if (pixel_in_image && d_mask[static_cast<size_t>(py) * width + px] != 0) {
+                const int bin = static_cast<int>(image(px, py));
+                if (bin >= 0 && bin < NUM_BG_BINS) {
+                    atomicAdd(&d_background_hist[refl_idx * NUM_BG_BINS + bin], 1u);
+                } else if (bin >= NUM_BG_BINS) {
+                    atomicAdd(&d_background_overflow[refl_idx], 1u);
                 }
             }
         }
-
-        __syncthreads();  // Barrier before next reflection overwrites s_is_fg
     }
-#pragma endregion Reflection Processing Loop
 }
 
 /**
  * @brief Host wrapper function for image-based Kabsch computation
  *
- * Launches the 8-corner Kabsch kernel using overlapping tiles.  Each block
- * of KABSCH_BLOCK_X × KABSCH_BLOCK_Y threads covers that many corners,
- * processing (KABSCH_BLOCK_X-1) × (KABSCH_BLOCK_Y-1) complete pixels.
+ * Launches the shoebox-parallel Kabsch kernel: one block of KABSCH_THREADS
+ * threads per reflection on this image, striding over that shoebox's pixels.
  */
 void compute_kabsch_transform(pixel_t *d_image,
                               size_t image_pitch,
@@ -609,10 +565,6 @@ void compute_kabsch_transform(pixel_t *d_image,
                               const size_t *d_reflection_indices,
                               size_t num_reflections_this_image,
                               const uint8_t *d_mask,
-                              int origin_x,
-                              int origin_y,
-                              uint32_t grid_w,
-                              uint32_t grid_h,
                               scalar_t delta_b,
                               scalar_t delta_m,
                               FGAlgorithm algorithm,
@@ -625,30 +577,21 @@ void compute_kabsch_transform(pixel_t *d_image,
                               unsigned long long *d_intensity_times_z,
                               uint8_t *d_success,
                               cudaStream_t stream) {
-    // Configure kernel launch parameters.
-    // Every block is always the full 32×16 = 512 threads.
-    dim3 blockDim(KABSCH_BLOCK_X, KABSCH_BLOCK_Y);
+    // One block per reflection shoebox on this image; nothing to launch
+    // if the image has no reflections.
+    if (num_reflections_this_image == 0) return;
 
-    // Each block processes (BLOCK-1) complete pixels per dimension:
-    //   31 pixels in x, 15 pixels in y.
-    // So the number of blocks needed is ceil(image_pixels / pixels_per_block):
-    //   gridDim.x = ceil(width  / 31)
-    //   gridDim.y = ceil(height / 15)
-    // Edge blocks may extend past the image boundary; those threads
-    // simply fail the bounds check in the kernel and write false / skip.
-    // grid_w/grid_h are the padded extent (image plus any bbox overflow past
-    // the detector edge), not the raw image dimensions.
-    dim3 gridDim(ceil_div(grid_w, static_cast<uint32_t>(KABSCH_BLOCK_X - 1)),
-                 ceil_div(grid_h, static_cast<uint32_t>(KABSCH_BLOCK_Y - 1)));
+    // Configure kernel launch parameters.
+    dim3 blockDim(KABSCH_THREADS);
+    dim3 gridDim(static_cast<uint32_t>(num_reflections_this_image));
 
     // The kernel is templated on FGAlgorithm rather than taking it as a
     // runtime parameter, for two reasons:
-    //   - Shared memory size (NUM_SLICES) is allowed to depend on the
-    //     algorithm, so DIALS gets a smaller s_is_fg allocation and better
-    //     occupancy than if we always sized for the ellipsoid path.
-    //   - `if constexpr` inside the kernel deletes the unused branch
-    //     entirely. A runtime `if` would keep both paths live in every
-    //     launch, dragging registers up and occupancy down.
+    //   - The classification maths differs (Ellipsoid evaluates three z-slices,
+    //     DIALS a single 2D ellipse) and `if constexpr` selects the branch at
+    //     compile time.
+    //   - A runtime `if` would keep both paths live in every launch, dragging
+    //     registers up and occupancy down.
     //
     // The catch is that the algorithm choice comes in at runtime from the
     // CLI, but template parameters have to be compile-time. The lambda
@@ -678,8 +621,6 @@ void compute_kabsch_transform(pixel_t *d_image,
                                              d_reflection_indices,
                                              num_reflections_this_image,
                                              d_mask,
-                                             origin_x,
-                                             origin_y,
                                              delta_b,
                                              delta_m,
                                              d_foreground_sum,

--- a/integrator/kabsch.cuh
+++ b/integrator/kabsch.cuh
@@ -36,8 +36,8 @@
 /// ceil(w*h / KABSCH_THREADS) passes. A block-size sweep found the kernel is
 /// compute-bound and its time is flat within ~8% from 32 to 512, so this is a
 /// fixed constant, not a tuning knob. Must be a multiple of the 32-lane warp;
-/// note 1024 exceeds the per-SM register budget at ~122 regs/thread and fails
-/// to launch.
+/// note 1024 exceeds the per-block register budget at this kernel's register
+/// pressure and fails to launch.
 constexpr uint32_t KABSCH_THREADS = 128;
 
 /**
@@ -67,6 +67,11 @@ constexpr uint32_t KABSCH_THREADS = 128;
  * @param d_reflection_indices Device array of reflection indices for this image
  * @param num_reflections_this_image Number of reflections touching this image
  * @param d_mask Detector mask, flat width*height indexed gy*width + gx (non-zero = valid, 0 = masked)
+ * @param max_corner_tile_corners Corner slots for the shared-memory corner tile:
+ *        the maximum (w+1)*(h+1) over this image's reflection shoeboxes. Sizes
+ *        the kernel's dynamic shared memory (one byte per corner), clamped
+ *        internally to the device per-block limit; a shoebox beyond the clamp
+ *        falls back to per-pixel corner recompute
  * @param delta_b Foreground extent in e₁/e₂ directions (n_sigma × σ_D), radians
  * @param delta_m Foreground extent in e₃ direction (n_sigma × σ_M), radians
  * @param d_foreground_sum Device array to accumulate foreground intensities per reflection
@@ -98,6 +103,7 @@ void compute_kabsch_transform(pixel_t *d_image,
                               const size_t *d_reflection_indices,
                               size_t num_reflections_this_image,
                               const uint8_t *d_mask,
+                              uint32_t max_corner_tile_corners,
                               scalar_t delta_b,
                               scalar_t delta_m,
                               FGAlgorithm algorithm,

--- a/integrator/kabsch.cuh
+++ b/integrator/kabsch.cuh
@@ -58,10 +58,6 @@
  * @param d_reflection_indices Device array of reflection indices for this image
  * @param num_reflections_this_image Number of reflections touching this image
  * @param d_mask Detector mask, flat width*height indexed gy*width + gx (non-zero = valid, 0 = masked)
- * @param origin_x Pixel x coordinate of the launch grid origin (may be negative)
- * @param origin_y Pixel y coordinate of the launch grid origin (may be negative)
- * @param grid_w Padded grid width in pixels (image plus bbox overflow)
- * @param grid_h Padded grid height in pixels (image plus bbox overflow)
  * @param delta_b Foreground extent in e₁/e₂ directions (n_sigma × σ_D), radians
  * @param delta_m Foreground extent in e₃ direction (n_sigma × σ_M), radians
  * @param d_foreground_sum Device array to accumulate foreground intensities per reflection
@@ -93,10 +89,6 @@ void compute_kabsch_transform(pixel_t *d_image,
                               const size_t *d_reflection_indices,
                               size_t num_reflections_this_image,
                               const uint8_t *d_mask,
-                              int origin_x,
-                              int origin_y,
-                              uint32_t grid_w,
-                              uint32_t grid_h,
                               scalar_t delta_b,
                               scalar_t delta_m,
                               FGAlgorithm algorithm,

--- a/integrator/kabsch.cuh
+++ b/integrator/kabsch.cuh
@@ -31,6 +31,15 @@
 #include "math/device_precision.cuh"
 #include "math/vector3d.cuh"
 
+/// CUDA block width (threads per block) for the shoebox-parallel Kabsch kernel.
+/// Each block strides this many threads over its shoebox's pixels, so it makes
+/// ceil(w*h / KABSCH_THREADS) passes. A block-size sweep found the kernel is
+/// compute-bound and its time is flat within ~8% from 32 to 512, so this is a
+/// fixed constant, not a tuning knob. Must be a multiple of the 32-lane warp;
+/// note 1024 exceeds the per-SM register budget at ~122 regs/thread and fails
+/// to launch.
+constexpr uint32_t KABSCH_THREADS = 128;
+
 /**
  * @brief Host wrapper function for image-based Kabsch computation
  * 

--- a/integrator/tests/test_kabsch.cc
+++ b/integrator/tests/test_kabsch.cc
@@ -364,10 +364,6 @@ void KabschTransformTest::RunPixelCountComparison(FGAlgorithm algo) {
                                  d_reflection_indices.data(),
                                  refl_indices_this_image.size(),
                                  d_mask.data(),
-                                 0,
-                                 0,
-                                 width,
-                                 height,
                                  delta_b,
                                  delta_m,
                                  algo,
@@ -591,22 +587,6 @@ void KabschTransformTest::RunIntensitySumComparison(FGAlgorithm algo) {
 #pragma endregion Allocate buffers
 
 #pragma region Dispatch
-    // Pad the launch grid to cover bboxes overflowing the detector edge, exactly
-    // as the production integrator does, so masked / out-of-image foreground
-    // fails reflections the same way the baseline does.
-    int grid_origin_x = 0;
-    int grid_origin_y = 0;
-    int grid_max_x = static_cast<int>(width);
-    int grid_max_y = static_cast<int>(height);
-    for (size_t i = 0; i < num_reflections; ++i) {
-        grid_origin_x = std::min(grid_origin_x, in.bboxes[i].x_min);
-        grid_origin_y = std::min(grid_origin_y, in.bboxes[i].y_min);
-        grid_max_x = std::max(grid_max_x, in.bboxes[i].x_max + 1);
-        grid_max_y = std::max(grid_max_y, in.bboxes[i].y_max + 1);
-    }
-    uint32_t grid_w = static_cast<uint32_t>(grid_max_x - grid_origin_x);
-    uint32_t grid_h = static_cast<uint32_t>(grid_max_y - grid_origin_y);
-
     // Iterate frames in 0-based frame space (== bbox z space, == baseline). Load
     // the real pixels for each frame and dispatch one kernel call.
     std::vector<pixel_t> host_image(static_cast<size_t>(width) * height);
@@ -663,10 +643,6 @@ void KabschTransformTest::RunIntensitySumComparison(FGAlgorithm algo) {
                                  d_reflection_indices.data(),
                                  refl_indices_this_image.size(),
                                  d_mask.data(),
-                                 grid_origin_x,
-                                 grid_origin_y,
-                                 grid_w,
-                                 grid_h,
                                  in.delta_b,
                                  in.delta_m,
                                  algo,

--- a/integrator/tests/test_kabsch.cc
+++ b/integrator/tests/test_kabsch.cc
@@ -332,9 +332,16 @@ void KabschTransformTest::RunPixelCountComparison(FGAlgorithm algo) {
 
     for (int image_num = image_range_start; image_num <= image_range_end; ++image_num) {
         refl_indices_this_image.clear();
+        // Largest (w+1)*(h+1) corner grid on this image, sizing the kernel's
+        // dynamic shared-memory corner tile (as the integrator does).
+        uint32_t max_corner_tile = 0;
         for (size_t i = 0; i < num_reflections; ++i) {
             if (bboxes[i].z_min <= image_num && image_num < bboxes[i].z_max) {
                 refl_indices_this_image.push_back(i);
+                const uint32_t corner_grid =
+                  static_cast<uint32_t>(bboxes[i].x_max - bboxes[i].x_min + 1)
+                  * static_cast<uint32_t>(bboxes[i].y_max - bboxes[i].y_min + 1);
+                max_corner_tile = std::max(max_corner_tile, corner_grid);
             }
         }
         if (refl_indices_this_image.empty()) continue;
@@ -364,6 +371,7 @@ void KabschTransformTest::RunPixelCountComparison(FGAlgorithm algo) {
                                  d_reflection_indices.data(),
                                  refl_indices_this_image.size(),
                                  d_mask.data(),
+                                 max_corner_tile,
                                  delta_b,
                                  delta_m,
                                  algo,
@@ -596,9 +604,16 @@ void KabschTransformTest::RunIntensitySumComparison(FGAlgorithm algo) {
 
     for (int image_num = 0; image_num < num_images; ++image_num) {
         refl_indices_this_image.clear();
+        // Largest (w+1)*(h+1) corner grid on this image, sizing the kernel's
+        // dynamic shared-memory corner tile (as the integrator does).
+        uint32_t max_corner_tile = 0;
         for (size_t i = 0; i < num_reflections; ++i) {
             if (in.bboxes[i].z_min <= image_num && image_num < in.bboxes[i].z_max) {
                 refl_indices_this_image.push_back(i);
+                const uint32_t corner_grid =
+                  static_cast<uint32_t>(in.bboxes[i].x_max - in.bboxes[i].x_min + 1)
+                  * static_cast<uint32_t>(in.bboxes[i].y_max - in.bboxes[i].y_min + 1);
+                max_corner_tile = std::max(max_corner_tile, corner_grid);
             }
         }
         if (refl_indices_this_image.empty()) continue;
@@ -643,6 +658,7 @@ void KabschTransformTest::RunIntensitySumComparison(FGAlgorithm algo) {
                                  d_reflection_indices.data(),
                                  refl_indices_this_image.size(),
                                  d_mask.data(),
+                                 max_corner_tile,
                                  in.delta_b,
                                  in.delta_m,
                                  algo,


### PR DESCRIPTION
The shoebox-parallel kernel from #113 left the Kabsch transform
compute-bound on the FP64 pipe (RTX 5000: 88.4% SM throughput, FP64 pipe
89.7%). Most of that FP64 is per-corner geometry the kernel recomputed
from scratch for every pixel. This caches each corner once in shared
memory, cutting the kernel 3.45x on the RTX 5000 and 2.57x on an A100.

`pixel_is_foreground` evaluates a pixel's four voxel corners. An
interior corner is shared by a 2x2 neighbourhood, so each corner was
evaluated up to four times. That redundancy was the tradeoff made when
the large grid of the kernel was barrier-bound. After #113, the kernel
is compute-bound and the corner work dominates, so the redundancy is the
next thing to cut.

Threads stride densely over the corner grid to fill a shared tile, one
uniform `__syncthreads()` separates fill from read, and each pixel's
classification becomes an OR of four bytes. The barrier #113 removed is
back, but it now syncs a uniform corner fill rather than the idle
background lanes of the old full-frame kernel.

Executed instructions drop 220.7M -> 76.2M and FP64 ~99.5M -> ~28.2M for
a single launch, with average active threads/warp 28.75 -> 30.96.

FP64 also stops being the limiter on Ampere: the top pipe falls to 56.5%
with ncu calling it "not a bottleneck", and the leading stall becomes an
L1TEX access pattern rather than math-pipe throttle.

A warp-shuffle version was tried first and was slower. Each warp took a
32-wide row segment and pulled the right-hand corner pair from the next
lane via `__shfl_down_sync`. Rotation shoeboxes here are narrow, so
warp-aligned rows park ~45% of every warp on columns that do not exist
(active threads/warp 28.75 -> 17.54), and that waste cancels the reuse.
Any warp-aligned scheme hits this floor on data this narrow.

### Changes:

- `integrator/kabsch.cu`: factor `corner_is_foreground<Algo>` out of
  `pixel_is_foreground`; fill an `extern __shared__` corner tile with
  one evaluation per corner, one uniform `__syncthreads()`, then
  classify each pixel as the OR of its four corner bits. The host
  wrapper sizes the launch's dynamic shared memory to the per-image max
  corner grid (clamped to the per-block limit).
- `integrator/integrator.cc`: build `corner_tile_by_image` alongside
  `reflections_by_image` and pass the per-image max at the call site.
- `integrator/tests/test_kabsch.cc`: both dispatch loops compute and
  pass the per-image max corner grid.
- `CMakeLists.txt`, `include/math/device_precision.cuh`,
  `include/math/vector3d.cuh`: rename the option to
  `USE_REDUCED_PRECISION` and flip the enable branch, guarding the
  single-precision `scalar_t`/`Vector3D`/math-macro definitions on it
  with double as the `#else` default.
- `build.sh`, `Dockerfile`: pass `-DUSE_REDUCED_PRECISION=OFF`
  explicitly so the deployed precision is stated, not inherited.
- `integrator/integrator.cc` (cleanup): drop the unused
  `computed_bbox_data` flatten and a duplicate include, reuse the single
  `wavelength` read, replace the row-major d-matrix transpose with an
  `Eigen::Matrix<scalar_t, 3, 3, RowMajor>` cast, and fold the two
  adjacent per-reflection packing loops into one pass.

### Performance:

Double, DIALS, 100-image thaumatin (`--sigma_b 0.03 --sigma_m 0.1
--background constant`)

RTX 5000 (Turing, FP64):

- Kernel 23.3 ms -> 6.75 ms (3.45x)
- Executed instructions 220.7M -> 76.2M, FP64 ~99.5M -> ~28.2M
- Average active threads/warp 28.75 -> 30.96
- Achieved occupancy 45.7% -> 49.8%, registers/thread 122 -> 118,
  register-bound at 4 blocks/SM either way
- Still FP64-bound afterwards: 88.4% SM throughput, FP64 the top pipe at
  89.7%
- Dynamic against static tile: 6.75 vs 6.79 ms kernel, 2.12 vs 4.10 KB
  shared memory per block
- Rejected warp-shuffle prototype: active threads/warp 28.75 -> 17.54,
  slower than the pre-tile kernel it replaced

A100 (Ampere, FP64):

- Kernel 1.17 ms -> 455 µs (2.57x)
- Executed instructions 211.2M -> 72.5M, FP64 99.7M -> 27.9M (47.2% ->
  38.4% of instructions)
- SM throughput 76.5% -> 55.3%, and FP64 is no longer the limiter: ncu
  reports the top pipe at 56.5%
- `math_pipe_throttle` stall 20.0% -> 9.4%; the leading stall is now
  `long_scoreboard` at 31.0%, so the next optimisation would be the load
  pattern
- The reintroduced `__syncthreads()` costs 2.7% of warp cycles
- Same registers/thread and same 4 blocks/SM as Turing; 25% occupancy
  reads lower only because Ampere allows 64 warps/SM against Turing's 32