### PR TITLE
Issue the Kabsch mask and image loads together

### DIFF
--- a/integrator/kabsch.cu
+++ b/integrator/kabsch.cu
@@ -563,15 +563,26 @@ __global__ void kabsch_transform(pixel_t *d_image,
         const bool pixel_in_image = (px >= 0) && (px < static_cast<int>(width))
                                     && (py >= 0) && (py < static_cast<int>(height));
 
+        // Both paths below need the mask flag and the pixel value, so the two
+        // loads are issued together rather than letting the mask test gate the
+        // image load and serialise two L1TEX round trips per pixel. Hoisting
+        // them past the corner-fill barrier goes further still, but costs
+        // registers, and registers bind occupancy on this kernel.
+        uint8_t mask_flag = 0;
+        pixel_t raw_value = 0;
+        if (pixel_in_image) {
+            mask_flag = d_mask[static_cast<size_t>(py) * width + px];
+            raw_value = image(px, py);
+        }
+
         if (any_fg) {
             // Foreground outside the image or on a masked pixel makes the
             // reflection unusable. d_success is only ever cleared, never set,
             // so the concurrent writes need no atomic.
-            if (!pixel_in_image || d_mask[static_cast<size_t>(py) * width + px] == 0) {
+            if (!pixel_in_image || mask_flag == 0) {
                 d_success[refl_idx] = 0;
             } else {
-                const accumulator_t pixel_value =
-                  static_cast<accumulator_t>(image(px, py));
+                const accumulator_t pixel_value = static_cast<accumulator_t>(raw_value);
                 atomicAdd(&d_foreground_sum[refl_idx], pixel_value);
                 atomicAdd(&d_foreground_count[refl_idx], 1u);
                 // Accumulate intensity·coord for centre-of-mass (xyzobs.px).
@@ -596,8 +607,8 @@ __global__ void kabsch_transform(pixel_t *d_image,
             // past the mask (reachable only when pixel_t is 32-bit and the value
             // exceeds INT_MAX); it is not a real background measurement, so it
             // is dropped rather than counted.
-            if (pixel_in_image && d_mask[static_cast<size_t>(py) * width + px] != 0) {
-                const int bin = static_cast<int>(image(px, py));
+            if (pixel_in_image && mask_flag != 0) {
+                const int bin = static_cast<int>(raw_value);
                 if (bin >= 0 && bin < NUM_BG_BINS) {
                     atomicAdd(&d_background_hist[refl_idx * NUM_BG_BINS + bin], 1u);
                 } else if (bin >= NUM_BG_BINS) {


### PR DESCRIPTION
The corner tile in #114 removed most of the redundant FP64, and the
shoebox `kabsch_transform` is no longer compute bound on A100. It is
latency bound: `long_scoreboard`, the stall for warps waiting on L1TEX,
is now the leading stall reason at 31% of all warp cycles.

Both the foreground and the background path in the accumulate step need
the detector mask flag and the pixel value, but the mask test gated the
image load, so the emitted code was:

```
LDG.E.U8  R14, [R14.64]            // load mask
ISETP.NE.AND P0, PT, R14, RZ, PT   // consume it on the very next instruction
@!P0 BRA 0x40c0                    // branch on the result
LDG.E.U16 R21, [R20.64]            // only now issue the image load
```

A `LDG` does not stall when it issues, only when something reads the
register it loads. Here the mask is read on the very next instruction,
so the warp waits out the full memory latency, and because that read is
a branch condition, the image load cannot even start until the mask
arrives. Every pixel therefore waits twice instead of once.

Putting both loads under a single bounds check fixes it. They now issue
five instructions apart with nothing reading either in between, so the
two waits overlap into one. The guard also becomes a predicate (`@P1`, a
per-thread on/off bit) instead of a branch, which leaves the region as
straight-line code the scheduler can reorder, so the corner-tile `LDS`
reads and the four-corner OR land in the gap.

### Measured on A100

| | before | after |
|---|---:|---:|
| Kernel duration (mean of 3 reps) | 453.9 us | **415.7 us (-8.4%)** |
| `long_scoreboard`, cycles/issue-active | 3.314 (31.1%) | **2.140 (21.9%)** |

### Follow-up:

`__launch_bounds__(KABSCH_THREADS, 5)` clamps the kernel to 96
registers, which is the next occupancy step on sm_80 (4 down to 5
blocks/SM, 25% to 31.25% theoretical), and measures a further -10.4%,
415.7 down to 372.4 us. It reaches 96 by spilling, but the spill does
not seem to execute on this workload. Profiling counted zero
local-memory instructions in a report where global loads are 500,000+.

This is put off as it was only profiled on the DIALS algorithm and not
on Ellipsoid (which is only 2 registers short of occupancy loss). A
follow-up PR will add the `__launch_bounds__` to the kernel provided the
Ellipsoid test on the A100 shows promise.

### Changes:

- `integrator/kabsch.cu` - in the `accumulate` lambda, read the mask
  flag and pixel value into locals under a single `pixel_in_image`
  guard, and branch on those instead of re-loading inside each path.