### PR TITLE
Push per-arch images by digest for the manifest

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -23,13 +23,13 @@ jobs:
     runs-on: ${{ matrix.runner }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           submodules: true
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -53,7 +53,7 @@ jobs:
       - name: Build and push Docker image
         if: ${{github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push'}}
         id: push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           platforms: ${{ matrix.platform }}
@@ -67,7 +67,7 @@ jobs:
 
     steps:
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -11,14 +11,14 @@ jobs:
 
   build:
     strategy:
+      # Don't cancel the other arch build if one fails so we can see both.
+      fail-fast: false
       matrix:
         include:
           - runner: ubuntu-latest
             platform: linux/amd64
-            tag-suffix: amd64
           - runner: ubuntu-24.04-arm
             platform: linux/arm64
-            tag-suffix: arm64
 
     runs-on: ${{ matrix.runner }}
 
@@ -35,30 +35,45 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Generate image tags
-        id: tags
+      - name: Prepare
+        id: prep
         run: |
-          # Use the current repository name
+          # Registry image name.
           IMAGE_NAME="ghcr.io/$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')"
-          echo "image-name=${IMAGE_NAME}" >> $GITHUB_OUTPUT
+          echo "image-name=${IMAGE_NAME}" >> "$GITHUB_OUTPUT"
+          # linux/amd64 becomes linux-amd64, for a filesystem-safe artifact name.
+          platform="${{ matrix.platform }}"
+          echo "platform-pair=${platform//\//-}" >> "$GITHUB_OUTPUT"
 
-          if [ "${{ github.event_name }}" == "pull_request" ]; then
-            echo "suffix=pr-${{ github.event.pull_request.number }}-${{ matrix.tag-suffix }}" >> $GITHUB_OUTPUT
-            echo "manifest-tag=pr-${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
-          else
-            echo "suffix=${{ matrix.tag-suffix }}" >> $GITHUB_OUTPUT
-            echo "manifest-tag=latest" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Build and push Docker image
+      - name: Build and push by digest
+        id: build
         if: ${{github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push'}}
-        id: push
         uses: docker/build-push-action@v7
         with:
           context: .
           platforms: ${{ matrix.platform }}
-          push: true
-          tags: ${{ steps.tags.outputs.image-name }}:${{ steps.tags.outputs.suffix }}
+          # Push the per-arch image with no tag; it is addressable only by
+          # its digest. This keeps intermediate arch builds out of the tag
+          # list - the manifest job assembles the real tag from digests.
+          outputs: type=image,name=${{ steps.prep.outputs.image-name }},push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        if: ${{github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push'}}
+        run: |
+          mkdir -p "${{ runner.temp }}/digests"
+          # Empty file whose name is the digest (minus the sha256: prefix);
+          # the merge job only needs the names.
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        if: ${{github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push'}}
+        uses: actions/upload-artifact@v7
+        with:
+          name: digests-${{ steps.prep.outputs.platform-pair }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
 
   create-manifest:
     if: ${{github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push'}}
@@ -66,6 +81,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Download digests
+        uses: actions/download-artifact@v8
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v4
         with:
@@ -76,22 +100,25 @@ jobs:
       - name: Determine tags
         id: tags
         run: |
-          # Use the current repository name
           IMAGE_NAME="ghcr.io/$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')"
-          echo "image-name=${IMAGE_NAME}" >> $GITHUB_OUTPUT
+          echo "image-name=${IMAGE_NAME}" >> "$GITHUB_OUTPUT"
 
           if [ "${{ github.event_name }}" == "pull_request" ]; then
-            echo "manifest-tag=pr-${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
-            echo "amd64-tag=pr-${{ github.event.pull_request.number }}-amd64" >> $GITHUB_OUTPUT
-            echo "arm64-tag=pr-${{ github.event.pull_request.number }}-arm64" >> $GITHUB_OUTPUT
+            echo "manifest-tag=pr-${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
           else
-            echo "manifest-tag=latest" >> $GITHUB_OUTPUT
-            echo "amd64-tag=amd64" >> $GITHUB_OUTPUT
-            echo "arm64-tag=arm64" >> $GITHUB_OUTPUT
+            echo "manifest-tag=latest" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Create and push multi-arch manifest
+        working-directory: ${{ runner.temp }}/digests
         run: |
-          docker buildx imagetools create -t ${{ steps.tags.outputs.image-name }}:${{ steps.tags.outputs.manifest-tag }} \
-            ${{ steps.tags.outputs.image-name }}:${{ steps.tags.outputs.amd64-tag }} \
-            ${{ steps.tags.outputs.image-name }}:${{ steps.tags.outputs.arm64-tag }}
+          # Each downloaded file is named for one arch digest; reference
+          # the images by digest so the manifest points straight at them.
+          docker buildx imagetools create \
+            -t ${{ steps.tags.outputs.image-name }}:${{ steps.tags.outputs.manifest-tag }} \
+            $(printf '${{ steps.tags.outputs.image-name }}@sha256:%s ' *)
+
+      - name: Inspect manifest
+        run: |
+          docker buildx imagetools inspect \
+            ${{ steps.tags.outputs.image-name }}:${{ steps.tags.outputs.manifest-tag }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -120,5 +120,16 @@ jobs:
 
       - name: Inspect manifest
         run: |
-          docker buildx imagetools inspect \
-            ${{ steps.tags.outputs.image-name }}:${{ steps.tags.outputs.manifest-tag }}
+          image="${{ steps.tags.outputs.image-name }}:${{ steps.tags.outputs.manifest-tag }}"
+          # GHCR takes a moment to make a freshly pushed tag readable, so
+          # the create above can succeed while an immediate inspect still
+          # 404s. Retry for a bit instead of failing the job over that gap.
+          for attempt in 1 2 3 4 5; do
+            if docker buildx imagetools inspect "$image"; then
+              exit 0
+            fi
+            echo "Manifest not visible yet (attempt ${attempt}); retrying..."
+            sleep 3
+          done
+          echo "Manifest still not visible after retries" >&2
+          exit 1


### PR DESCRIPTION
This PR changes how the multi-arch Docker image is pushed to GHCR and
bumps the CI actions to their latest majors. The build runs one native
runner per architecture and merges the two into a manifest list. It
used to push each arch under its own `:amd64` / `:arm64` tag and stitch
those together, leaving those intermediate tags in GHCR forever. Now
each arch image is pushed untagged (`push-by-digest`), the digest is
handed to the merge job as an artifact, and the manifest is assembled
by digest reference, so GHCR only carries the tags intended to be seen.

### Changes

- Bumped the pinned actions to their latest majors (`checkout@v7`,
  `setup-buildx-action@v4`, `login-action@v4`, `build-push-action@v7`)
  to clear the Node 20 deprecation warnings.
- Reworked the multi-arch manifest to push by digest, added a
  closing `imagetools inspect` to confirm the merge, and set
  `fail-fast: false` so one arch failing no longer cancels the other.