### PR TITLE
Cache the Docker build so CI stops rebuilding from scratch

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -45,7 +45,7 @@ jobs:
           platform="${{ matrix.platform }}"
           echo "platform-pair=${platform//\//-}" >> "$GITHUB_OUTPUT"
 
-      # Persist the ccache dir across runs. actions/cache moves it in and out of the GHA cache.
+      # Persist the ccache and FetchContent dirs across runs. actions/cache moves them in and out of the GHA cache.
       - name: Restore ccache
         if: ${{github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push'}}
         uses: actions/cache@v6
@@ -55,12 +55,24 @@ jobs:
           restore-keys: |
             ccache-${{ steps.prep.outputs.platform-pair }}-
 
-      - name: Inject ccache into buildx
+      - name: Restore FetchContent deps
+        if: ${{github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push'}}
+        uses: actions/cache@v6
+        with:
+          path: ${{ runner.temp }}/deps-${{ steps.prep.outputs.platform-pair }}
+          key: deps-${{ steps.prep.outputs.platform-pair }}-${{ hashFiles('CMakeLists.txt') }}
+          restore-keys: |
+            deps-${{ steps.prep.outputs.platform-pair }}-
+
+      - name: Inject caches into buildx
         if: ${{github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push'}}
         uses: reproducible-containers/buildkit-cache-dance@v3
         with:
           cache-map: |
-            { "${{ runner.temp }}/ccache-${{ steps.prep.outputs.platform-pair }}": "/ccache" }
+            {
+              "${{ runner.temp }}/ccache-${{ steps.prep.outputs.platform-pair }}": "/ccache",
+              "${{ runner.temp }}/deps-${{ steps.prep.outputs.platform-pair }}": "/deps"
+            }
 
       - name: Build and push by digest
         id: build

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -45,6 +45,23 @@ jobs:
           platform="${{ matrix.platform }}"
           echo "platform-pair=${platform//\//-}" >> "$GITHUB_OUTPUT"
 
+      # Persist the ccache dir across runs. actions/cache moves it in and out of the GHA cache.
+      - name: Restore ccache
+        if: ${{github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push'}}
+        uses: actions/cache@v6
+        with:
+          path: ${{ runner.temp }}/ccache-${{ steps.prep.outputs.platform-pair }}
+          key: ccache-${{ steps.prep.outputs.platform-pair }}-${{ github.sha }}
+          restore-keys: |
+            ccache-${{ steps.prep.outputs.platform-pair }}-
+
+      - name: Inject ccache into buildx
+        if: ${{github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push'}}
+        uses: reproducible-containers/buildkit-cache-dance@v3
+        with:
+          cache-map: |
+            { "${{ runner.temp }}/ccache-${{ steps.prep.outputs.platform-pair }}": "/ccache" }
+
       - name: Build and push by digest
         id: build
         if: ${{github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push'}}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -52,6 +52,11 @@ jobs:
         with:
           context: .
           platforms: ${{ matrix.platform }}
+          # Reuse the build-stage layers (base image, conda envs) from the
+          # GHA cache across runs, scoped per arch. mode=max caches the
+          # throwaway build stage, not just the runtime image.
+          cache-from: type=gha,scope=${{ steps.prep.outputs.platform-pair }}
+          cache-to: type=gha,mode=max,scope=${{ steps.prep.outputs.platform-pair }}
           # Push the per-arch image with no tag; it is addressable only by
           # its digest. This keeps intermediate arch builds out of the tag
           # list - the manifest job assembles the real tag from digests.

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -45,7 +45,7 @@ jobs:
           platform="${{ matrix.platform }}"
           echo "platform-pair=${platform//\//-}" >> "$GITHUB_OUTPUT"
 
-      # Persist the ccache and FetchContent dirs across runs. actions/cache moves them in and out of the GHA cache.
+      # Persist the ccache dir across runs. actions/cache moves it in and out of the GHA cache.
       - name: Restore ccache
         if: ${{github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push'}}
         uses: actions/cache@v6
@@ -55,24 +55,12 @@ jobs:
           restore-keys: |
             ccache-${{ steps.prep.outputs.platform-pair }}-
 
-      - name: Restore FetchContent deps
-        if: ${{github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push'}}
-        uses: actions/cache@v6
-        with:
-          path: ${{ runner.temp }}/deps-${{ steps.prep.outputs.platform-pair }}
-          key: deps-${{ steps.prep.outputs.platform-pair }}-${{ hashFiles('CMakeLists.txt') }}
-          restore-keys: |
-            deps-${{ steps.prep.outputs.platform-pair }}-
-
-      - name: Inject caches into buildx
+      - name: Inject ccache into buildx
         if: ${{github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push'}}
         uses: reproducible-containers/buildkit-cache-dance@v3
         with:
           cache-map: |
-            {
-              "${{ runner.temp }}/ccache-${{ steps.prep.outputs.platform-pair }}": "/ccache",
-              "${{ runner.temp }}/deps-${{ steps.prep.outputs.platform-pair }}": "/deps"
-            }
+            { "${{ runner.temp }}/ccache-${{ steps.prep.outputs.platform-pair }}": "/ccache" }
 
       - name: Build and push by digest
         id: build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 ARG CUDA_VERSION=13.0.2
 
 FROM nvcr.io/nvidia/cuda:${CUDA_VERSION}-devel-ubuntu24.04 AS build
@@ -5,7 +6,7 @@ FROM nvcr.io/nvidia/cuda:${CUDA_VERSION}-devel-ubuntu24.04 AS build
 # Install dependencies
 RUN DEBIAN_FRONTEND=noninteractive \
     apt-get update && \
-    apt-get install -y --no-install-recommends git ca-certificates curl
+    apt-get install -y --no-install-recommends git ca-certificates curl ccache
 
 # Install micromamba. Prefer install script so we don't have to determine platform here
 RUN curl -sL micro.mamba.pm/install.sh | BIN_FOLDER=/opt/bin INIT_YES=no bash
@@ -25,6 +26,7 @@ RUN micromamba create -y -f /opt/runtime-environment.yml -p /opt/ffs
 # Copy source
 COPY . /opt/ffs_src
 ENV CMAKE_GENERATOR=Ninja
+ENV CCACHE_DIR=/ccache
 
 # Build the C++/CUDA backend
 WORKDIR /opt/build
@@ -34,9 +36,14 @@ RUN cmake /opt/ffs_src \
     -DHDF5_ROOT=/opt/ffs \
     -DPython3_ROOT_DIR=/opt/ffs \
     -DCUDA_ARCH=80 \
-    -DUSE_REDUCED_PRECISION=OFF
+    -DUSE_REDUCED_PRECISION=OFF \
+    # Route both the host and CUDA compilers through ccache
+    -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+    -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache
 
-RUN cmake --build .
+# Mount the persistent ccache dir for the compile and print stats
+RUN --mount=type=cache,target=/ccache \
+    cmake --build . && ccache -s
 
 RUN cmake --install .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,8 @@ ENV CCACHE_DIR=/ccache
 
 # Build the C++/CUDA backend
 WORKDIR /opt/build
-RUN cmake /opt/ffs_src \
+RUN --mount=type=cache,target=/deps \
+    cmake /opt/ffs_src \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_INSTALL_PREFIX=/opt/ffs \
     -DHDF5_ROOT=/opt/ffs \
@@ -39,10 +40,13 @@ RUN cmake /opt/ffs_src \
     -DUSE_REDUCED_PRECISION=OFF \
     # Route both the host and CUDA compilers through ccache
     -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-    -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache
+    -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache \
+    # Persist the fetched dependency sources so they download once and are reused
+    -DFETCHCONTENT_BASE_DIR=/deps
 
-# Mount the persistent ccache dir for the compile and print stats
+# Mount the persistent ccache and /deps dirs for the compile and print stats
 RUN --mount=type=cache,target=/ccache \
+    --mount=type=cache,target=/deps \
     cmake --build . && ccache -s
 
 RUN cmake --install .

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,8 +30,7 @@ ENV CCACHE_DIR=/ccache
 
 # Build the C++/CUDA backend
 WORKDIR /opt/build
-RUN --mount=type=cache,target=/deps \
-    cmake /opt/ffs_src \
+RUN cmake /opt/ffs_src \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_INSTALL_PREFIX=/opt/ffs \
     -DHDF5_ROOT=/opt/ffs \
@@ -40,13 +39,10 @@ RUN --mount=type=cache,target=/deps \
     -DUSE_REDUCED_PRECISION=OFF \
     # Route both the host and CUDA compilers through ccache
     -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-    -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache \
-    # Persist the fetched dependency sources so they download once and are reused
-    -DFETCHCONTENT_BASE_DIR=/deps
+    -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache
 
-# Mount the persistent ccache and /deps dirs for the compile and print stats
+# Mount the persistent ccache dir for the compile and print stats
 RUN --mount=type=cache,target=/ccache \
-    --mount=type=cache,target=/deps \
     cmake --build . && ccache -s
 
 RUN cmake --install .


### PR DESCRIPTION
This PR caches the Docker image build so CI stops rebuilding it from
scratch on every run. It used to run completely cold nothing cached,
taking around five minutes per arch, rebuilding everything each time.
Now the build-stage layers and the compilation are cached and reused
across runs, with the ccache directory persisted through the ephemeral
runners by `actions/cache` and `buildkit-cache-dance`.

### Changes

- Added `type=gha` layer caching to the per-arch build so the base image
  and conda environments are reused.
- Fronted the host and CUDA compilers with ccache on a persistent
  `/ccache` mount, printing `ccache -s`.
- Explored caching the FetchContent dependency downloads too, but
  reverted it: the sources landed on a mount `cmake --install` cannot
  see, and the saving was only the one-time download.