### PR TITLE
Build the container image for several GPU architectures

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,31 +9,9 @@ include(ResolveGitVersion)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CUDA_STANDARD 20)
 
-# Set CUDA compute capability target
-# Override with just the number: cmake -DCUDA_ARCH=86 ..
-# Set default to 7.5 (Turing)
-set(CUDA_ARCH "75 - Turing (RTX 20xx, GTX 16xx)" CACHE STRING "CUDA compute capability target architecture")
-set_property(CACHE CUDA_ARCH PROPERTY STRINGS 
-    "52 - Maxwell (GTX 9xx, Titan X)"
-    "60 - Pascal (GTX 10xx, P100)"
-    "61 - Pascal (GTX 1050/1030)"
-    "70 - Volta (V100, Titan V100)"
-    "75 - Turing (RTX 20xx, GTX 16xx)"
-    "80 - Ampere (A100)"
-    "86 - Ampere (RTX 30xx)"
-    "89 - Ada Lovelace (RTX 40xx)"
-    "90 - Hopper (H100)"
-    "100 - Blackwell (GB200, B200)"
-    "103 - Blackwell (GB300, B300)"
-    "110 - Blackwell Jetson (T5000, T4000)"
-    "120 - Blackwell (RTX 50xx, RTX PRO)"
-    "121 - Blackwell (DGX Spark GB10)"
-)
-
-# Extract just the number from the selection (digits before the " - " label)
-string(REGEX MATCH "^[0-9]+" CUDA_ARCH_NUMBER "${CUDA_ARCH}")
-set(CMAKE_CUDA_ARCHITECTURES ${CUDA_ARCH_NUMBER})
-message(STATUS "CUDA architecture set to: sm_${CMAKE_CUDA_ARCHITECTURES}")
+# Set the CUDA compute capability target(s). Defaults to autodetecting
+# the GPU in the build machine and building for that
+include(SetCudaArchitectures)
 
 project(fast-feedback-service LANGUAGES CXX VERSION ${FFS_VERSION_CMAKE})
 
@@ -165,31 +143,38 @@ if (CUDAToolkit_FOUND)
     message(STATUS "CUDA found: Building CUDA components.")
     set(FFS_ENABLE_CUDA ON)
     
-    # Try to detect GPU compute capability
-    execute_process(
-        COMMAND nvidia-smi --query-gpu=compute_cap --format=csv,noheader
-        OUTPUT_VARIABLE DETECTED_GPU_CAPS
-        OUTPUT_STRIP_TRAILING_WHITESPACE
-        ERROR_QUIET
-    )
-    
-    if(DETECTED_GPU_CAPS)
-        # nvidia-smi returns "7.5" format, convert to "75"
-        string(REPLACE "." "" DETECTED_GPU_ARCH "${DETECTED_GPU_CAPS}")
-        # Get first GPU if multiple
-        string(REGEX MATCH "[0-9]+" DETECTED_GPU_ARCH "${DETECTED_GPU_ARCH}")
-        message(STATUS "Detected GPU compute capability: sm_${DETECTED_GPU_ARCH}")
-        
-        # Warn if configured architecture doesn't match detected GPU
-        if(NOT CUDA_ARCH_NUMBER STREQUAL DETECTED_GPU_ARCH)
-            message(WARNING 
-                "Target CUDA architecture (sm_${CUDA_ARCH_NUMBER}) differs from detected GPU (sm_${DETECTED_GPU_ARCH}).\n"
-                "   The compiled code may not run optimally or at all on this system.\n"
-                "   To build for the detected GPU: cmake -DCUDA_ARCH=${DETECTED_GPU_ARCH} ..\n"
-                "   To build for a different target: ensure the target system has sm_${CUDA_ARCH_NUMBER} or newer."
-            )
+    # SetCudaArchitectures already probed the local GPU; check that what
+    # we are about to compile can actually run on it.
+    if(FFS_DETECTED_GPU_ARCH)
+        # A cubin loads on any later minor revision of its own major
+        # generation but never across one (an sm_80 cubin runs on 8.6,
+        # 8.7 and 8.9), and the driver can JIT PTX onto any device at or
+        # above its virtual architecture. Warn only when neither route
+        # covers the card that is actually here.
+        set(GPU_IS_COVERED FALSE)
+        math(EXPR DETECTED_MAJOR "${FFS_DETECTED_GPU_ARCH} / 10")
+        foreach(arch IN LISTS FFS_CUDA_ARCH_REAL)
+            math(EXPR ARCH_MAJOR "${arch} / 10")
+            if(ARCH_MAJOR EQUAL DETECTED_MAJOR AND NOT arch GREATER FFS_DETECTED_GPU_ARCH)
+                set(GPU_IS_COVERED TRUE)
+            endif()
+        endforeach()
+        foreach(arch IN LISTS FFS_CUDA_ARCH_VIRTUAL)
+            if(NOT arch GREATER FFS_DETECTED_GPU_ARCH)
+                set(GPU_IS_COVERED TRUE)
+            endif()
+        endforeach()
+
+        if(GPU_IS_COVERED)
+            message(STATUS "✓ Compiled architectures cover the detected GPU")
         else()
-            message(STATUS "✓ Configured architecture matches detected GPU")
+            message(WARNING
+                "Nothing being compiled can run on the GPU in this machine (sm_${FFS_DETECTED_GPU_ARCH}).\n"
+                "   Building for: ${CMAKE_CUDA_ARCHITECTURES}\n"
+                "   The resulting binaries will fail to load here.\n"
+                "   To build for the detected GPU: cmake -DCUDA_ARCH=native ..\n"
+                "   To build what the container ships: cmake -DCUDA_ARCH=all-supported .."
+            )
         endif()
     else()
         message(STATUS "Could not detect GPU compute capability (nvidia-smi not available or no GPU present)")

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN cmake /opt/ffs_src \
     -DCMAKE_INSTALL_PREFIX=/opt/ffs \
     -DHDF5_ROOT=/opt/ffs \
     -DPython3_ROOT_DIR=/opt/ffs \
-    -DCUDA_ARCH=80 \
+    -DCUDA_ARCH=all-supported \
     -DUSE_REDUCED_PRECISION=OFF
 
 RUN cmake --build .

--- a/README.md
+++ b/README.md
@@ -92,6 +92,40 @@ make                        # Compile the code
 ```
 This will create the executable `spotfinder` in the [`build/bin/`] directory.
 
+#### Choosing a GPU architecture
+CUDA code is compiled for specific compute capabilities, and a binary
+will not load on a GPU it was not compiled for. The `CUDA_ARCH` cmake
+option controls this:
+
+```bash
+cmake ..                            # native: auto detect the GPU in this machine (default)
+cmake .. -DCUDA_ARCH=86             # a specific compute capability
+cmake .. -DCUDA_ARCH="80;90"        # several
+cmake .. -DCUDA_ARCH=all-supported  # everything the container image ships
+```
+
+The default, `native`, reads the compute capability from `nvidia-smi`
+and builds a single cubin for it, which is the fastest option for local
+development. If no GPU is present it falls back to `sm_75`.
+
+`all-supported` is what the published container image is built with. It
+produces a fat binary carrying native code for every architecture from
+Turing to Blackwell, plus PTX so that a card newer than any of them is
+JIT-compiled by the driver rather than rejected. It takes considerably
+longer to compile.
+
+Note that CUDA 13 dropped Maxwell, Pascal and Volta, so `sm_75` (Turing)
+is the oldest architecture the container image can target.
+
+For what a fat binary actually contains and how the driver picks out of
+it, see [nvcc GPU Compilation][nvcc-gpu-compilation] on virtual versus
+real architectures, cubins and PTX, and the [Blackwell Compatibility
+Guide][blackwell-compat] for the rules on which cubin runs on which
+card.
+
+[nvcc-gpu-compilation]: https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html#gpu-compilation
+[blackwell-compat]: https://docs.nvidia.com/cuda/blackwell-compatibility-guide/
+
 ### Installing the python module (for indexing)
 This project defines a small python module, to provide functionality for indexing.
 To run indexing code, this needs to be installed into the python environment by

--- a/cmake/Modules/SetCudaArchitectures.cmake
+++ b/cmake/Modules/SetCudaArchitectures.cmake
@@ -1,0 +1,119 @@
+# Resolve CUDA_ARCH into CMAKE_CUDA_ARCHITECTURES.
+#
+# CUDA_ARCH accepts:
+#   native          the compute capability of the GPU in this machine
+#                   (the default), so a local build produces one cubin
+#   all-supported   every architecture the published image ships, for
+#                   deployment builds
+#   anything else   a bare compute capability number, a ";"-separated
+#                   list of them, or one of the labelled entries offered
+#                   in the cache selector below
+#
+# Exports FFS_CUDA_ARCH_REAL, FFS_CUDA_ARCH_VIRTUAL and
+# FFS_DETECTED_GPU_ARCH as bare compute capability numbers, which the
+# root script uses to set the build.
+#
+# Must be included before project(), because CMAKE_CUDA_ARCHITECTURES is
+# read when a subdirectory enables the CUDA language.
+
+# Only do this if we're being called from the root CMakeLists
+if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+  # Architectures the published container image is built for: one cubin
+  # per compute capability target, so the image needs no JIT anywhere
+  # from Turing to Blackwell.
+  set(_ffs_deploy_real 75 80 86 89 90 100 103 120 121)
+
+  # PTX to fall back on when no cubin above matches, so the driver JITs
+  # instead of refusing to load. compute_120 catches cards newer than
+  # anything we compiled for; compute_103 is the only route onto Thor
+  # (sm_110), since cubins never cross a major revision but PTX does.
+  set(_ffs_deploy_virtual 103 120)
+
+  # Compute capability to fall back on when there is no GPU to probe.
+  # Turing is the oldest CUDA 13 still compiles for; it dropped Maxwell,
+  # Pascal and Volta.
+  set(_ffs_fallback_arch 75)
+
+  set(CUDA_ARCH "native" CACHE STRING "CUDA compute capability target architecture")
+  set_property(CACHE CUDA_ARCH PROPERTY STRINGS
+      "native"
+      "all-supported"
+      "75 - Turing (RTX 20xx, Quadro RTX)"
+      "80 - Ampere (A100)"
+      "86 - Ampere (RTX 30xx, A40)"
+      "89 - Ada Lovelace (RTX 40xx, L40S)"
+      "90 - Hopper (H100, GH200)"
+      "100 - Blackwell (B200, GB200)"
+      "103 - Blackwell (B300, GB300)"
+      "120 - Blackwell (RTX 50xx, RTX PRO)"
+      "121 - Blackwell (DGX Spark GB10)"
+  )
+
+  # Probe the local GPU once. This decides the target for "native" and
+  # is advisory otherwise, so it runs unconditionally and sets
+  # FFS_DETECTED_GPU_ARCH to a bare compute capability number or empty
+  # if no GPU is present.
+  execute_process(
+    COMMAND nvidia-smi --query-gpu=compute_cap --format=csv,noheader
+    OUTPUT_VARIABLE _ffs_detected_caps
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_QUIET
+  )
+  # Take the first GPU and convert the "X.Y" string to a bare number
+  # "XY" for comparison with the requested architectures.
+  string(REGEX MATCH "[0-9]+\\.[0-9]+" _ffs_first_cap "${_ffs_detected_caps}")
+  string(REPLACE "." "" FFS_DETECTED_GPU_ARCH "${_ffs_first_cap}")
+
+  if(FFS_DETECTED_GPU_ARCH)
+    message(STATUS "Detected GPU compute capability: sm_${FFS_DETECTED_GPU_ARCH}")
+  endif()
+
+  if(CUDA_ARCH STREQUAL "native")
+    if(FFS_DETECTED_GPU_ARCH)
+      set(FFS_CUDA_ARCH_REAL ${FFS_DETECTED_GPU_ARCH})
+    else()
+      message(STATUS
+        "No GPU detected for CUDA_ARCH=native; falling back to sm_${_ffs_fallback_arch}. "
+        "Pass -DCUDA_ARCH=<capability> to target a specific card, or "
+        "-DCUDA_ARCH=all-supported to build what the container ships."
+      )
+      set(FFS_CUDA_ARCH_REAL ${_ffs_fallback_arch})
+    endif()
+    # No PTX: a native build targets exactly the card in front of you, so
+    # a JIT fallback would only inflate the binary.
+    set(FFS_CUDA_ARCH_VIRTUAL "")
+  elseif(CUDA_ARCH STREQUAL "all-supported")
+    set(FFS_CUDA_ARCH_REAL ${_ffs_deploy_real})
+    set(FFS_CUDA_ARCH_VIRTUAL ${_ffs_deploy_virtual})
+  else()
+    set(FFS_CUDA_ARCH_REAL "")
+    foreach(_entry IN LISTS CUDA_ARCH)
+      # Pull the leading number off each entry, so "80;90" becomes "80"
+      # and "90", and "86 - Ampere" becomes "86".
+      string(REGEX MATCH "^[0-9]+" _number "${_entry}")
+      if(NOT _number)
+        message(FATAL_ERROR
+          "CUDA_ARCH entry \"${_entry}\" does not begin with a compute "
+          "capability number. Expected something like 86, \"80;90\", "
+          "native, or all-supported."
+        )
+      endif()
+      list(APPEND FFS_CUDA_ARCH_REAL ${_number})
+    endforeach()
+    list(REMOVE_DUPLICATES FFS_CUDA_ARCH_REAL)
+    list(SORT FFS_CUDA_ARCH_REAL COMPARE NATURAL)
+    # PTX for the newest capability asked for, so a card newer than
+    # anything we compiled JITs instead of failing to load.
+    list(GET FFS_CUDA_ARCH_REAL -1 FFS_CUDA_ARCH_VIRTUAL)
+  endif()
+
+  set(CMAKE_CUDA_ARCHITECTURES "")
+  foreach(_arch IN LISTS FFS_CUDA_ARCH_REAL)
+    list(APPEND CMAKE_CUDA_ARCHITECTURES "${_arch}-real")
+  endforeach()
+  foreach(_arch IN LISTS FFS_CUDA_ARCH_VIRTUAL)
+    list(APPEND CMAKE_CUDA_ARCHITECTURES "${_arch}-virtual")
+  endforeach()
+
+  message(STATUS "CUDA architectures (CUDA_ARCH=${CUDA_ARCH}): ${CMAKE_CUDA_ARCHITECTURES}")
+endif()


### PR DESCRIPTION
This PR updates the CMake to allow for multiple GPU architectures to be
selected, enables automatic architecture selection and updates the CI
process to include this new functionality in order to produce a fat
binary of all supported architectures.

Previously, only a single architecture could be selected, and the
default was to build for sm_75 (Turing) locally and sm_80 (Ampere) for
the container image. This meant that the container was only compatible
with GPUs like the A100. Now, the default is to build for all supported
architectures, which means that the container is compatible with all
GPUs from Turing to Blackwell, and will JIT compile for any newer GPUs.
The local build defaults to the architecture of the GPU in the machine,
or sm_75 if no GPU is present. The user can also select a specific
architecture or a list of architectures to build for.

### Changes

- Added `cmake/Modules/SetCudaArchitectures.cmake` to own `CUDA_ARCH`
  and resolve it into `CMAKE_CUDA_ARCHITECTURES`. It accepts `native`,
  `all-supported`, a bare capability, a `;`-separated list or one of
  the labelled selector entries, and runs the `nvidia-smi` probe once
  so the root script can reuse the answer.
- Replaced the inline architecture block in `CMakeLists.txt` with the
  module include, which has to stay above `project()`, and rewrote the
  coverage warning to understand lists and cubin minor-version
  compatibility instead of comparing a single number with `STREQUAL`.
- Pointed the `Dockerfile` at `all-supported`, so the list itself stays
  in cmake and a new GPU generation is a one-line edit there.
- Documented the option in `README.md`, which previously mentioned it
  only in a cmake comment and in the text of a warning.
