### PR TITLE
Address container build warnings and fix associated bugs

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -26,6 +26,8 @@ jobs:
       - uses: actions/checkout@v7
         with:
           submodules: true
+          # Full history and tags, so `git describe` below has something to describe
+          fetch-depth: 0
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
       - name: Login to GitHub Container Registry
@@ -44,6 +46,7 @@ jobs:
           # linux/amd64 becomes linux-amd64, for a filesystem-safe artifact name.
           platform="${{ matrix.platform }}"
           echo "platform-pair=${platform//\//-}" >> "$GITHUB_OUTPUT"
+          echo "version-describe=$(git describe --tags --long --first-parent)" >> "$GITHUB_OUTPUT"
 
       - name: Build and push by digest
         id: build
@@ -52,6 +55,8 @@ jobs:
         with:
           context: .
           platforms: ${{ matrix.platform }}
+          build-args: |
+            FFS_VERSION_DESCRIBE=${{ steps.prep.outputs.version-describe }}
           # Push the per-arch image with no tag; it is addressable only by
           # its digest. This keeps intermediate arch builds out of the tag
           # list - the manifest job assembles the real tag from digests.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,6 +110,9 @@ project(version CXX)
 configure_file(version.cc.in version.cc @ONLY)
 add_library(version STATIC version.cc)
 
+# Drop the resolved version somewhere the container build can read it
+file(WRITE "${CMAKE_BINARY_DIR}/FFS_VERSION" "${FFS_VERSION_FULL}")
+
 # Create an interface library for compile definitions
 add_library(compile_options INTERFACE)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,6 +113,11 @@ add_library(version STATIC version.cc)
 # Create an interface library for compile definitions
 add_library(compile_options INTERFACE)
 
+# Eigen's device std::complex helpers need constexpr as __host__ __device__ (#20015).
+target_compile_options(compile_options INTERFACE
+    "$<$<COMPILE_LANGUAGE:CUDA>:--expt-relaxed-constexpr>"
+)
+
 # Add compile definitions if enabled
 if(USE_REDUCED_PRECISION)
     target_compile_definitions(compile_options INTERFACE USE_REDUCED_PRECISION)

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,8 @@ RUN cmake /opt/ffs_src \
     -DPython3_ROOT_DIR=/opt/ffs \
     -DCUDA_ARCH=all-supported \
     -DFFS_VERSION_DESCRIBE="${FFS_VERSION_DESCRIBE}" \
+    -DCMAKE_INSTALL_RPATH=/opt/ffs/lib \
+    -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON \
     -DUSE_REDUCED_PRECISION=OFF
 
 RUN cmake --build .

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,9 @@ RUN micromamba create -y -f /opt/runtime-environment.yml -p /opt/ffs
 COPY . /opt/ffs_src
 ENV CMAKE_GENERATOR=Ninja
 
+# Placeholder for the version string to be passed from the build system.
+ARG FFS_VERSION_DESCRIBE=
+
 # Build the C++/CUDA backend
 WORKDIR /opt/build
 RUN cmake /opt/ffs_src \
@@ -34,14 +37,17 @@ RUN cmake /opt/ffs_src \
     -DHDF5_ROOT=/opt/ffs \
     -DPython3_ROOT_DIR=/opt/ffs \
     -DCUDA_ARCH=all-supported \
+    -DFFS_VERSION_DESCRIBE="${FFS_VERSION_DESCRIBE}" \
     -DUSE_REDUCED_PRECISION=OFF
 
 RUN cmake --build .
 
 RUN cmake --install .
 
-# Install Python package
-RUN SETUPTOOLS_SCM_PRETEND_VERSION_FOR_FFS=1.0 /opt/ffs/bin/pip3 install /opt/ffs_src
+# Install Python package. setuptools_scm has no git history to read
+# here, so hand it the version cmake already resolved.
+RUN SETUPTOOLS_SCM_PRETEND_VERSION_FOR_FFS="$(cat /opt/build/FFS_VERSION)" \
+    /opt/ffs/bin/pip3 install /opt/ffs_src
 
 # Now copy this into an isolated runtime container
 FROM nvcr.io/nvidia/cuda:${CUDA_VERSION}-runtime-ubuntu24.04

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ RUN cmake --install .
 # Install Python package. setuptools_scm has no git history to read
 # here, so hand it the version cmake already resolved.
 RUN SETUPTOOLS_SCM_PRETEND_VERSION_FOR_FFS="$(cat /opt/build/FFS_VERSION)" \
-    /opt/ffs/bin/pip3 install /opt/ffs_src
+    /opt/ffs/bin/pip3 install --root-user-action=ignore /opt/ffs_src
 
 # Now copy this into an isolated runtime container
 FROM nvcr.io/nvidia/cuda:${CUDA_VERSION}-runtime-ubuntu24.04

--- a/cmake/Modules/ResolveGitVersion.cmake
+++ b/cmake/Modules/ResolveGitVersion.cmake
@@ -11,10 +11,23 @@
 #       things like dev, rc, prerelease). Dev versions will have the
 #       X.Y.0 of the next release, and non-dev branches will be plain
 #       X.Y.Z.
+#
+# Accepts:
+#   FFS_VERSION_DESCRIBE
+#       A `git describe --tags --long --first-parent` string to use in
+#       place of asking git. Set this where the build tree has no git
+#       history to query - the container build copies the source without
+#       .git, so the binaries still carry the real version instead of
+#       the 0.0.0.dev0 fallback.
+
+set(FFS_VERSION_DESCRIBE "" CACHE STRING "git describe output to use instead of querying git")
 
 find_package(Git QUIET)
 
-if(NOT Git_FOUND)
+if(FFS_VERSION_DESCRIBE)
+    set(REPO_VERSION "${FFS_VERSION_DESCRIBE}")
+    message(STATUS "Using supplied version description: ${REPO_VERSION}")
+elseif(NOT Git_FOUND)
     set(FFS_VERSION_FULL "0.0.0.dev0+g000000")
     set(FFS_VERSION_CMAKE "0.0.0")
     message(WARNING "No git, could not determine repository version")
@@ -28,6 +41,9 @@ else()
         ERROR_QUIET
         OUTPUT_STRIP_TRAILING_WHITESPACE
     )
+endif()
+
+if(NOT DEFINED FFS_VERSION_FULL)
     if (NOT REPO_VERSION)
         set(FFS_VERSION_FULL "0.0.0.dev0+g000000")
         set(FFS_VERSION_CMAKE "0.0.0")

--- a/environment.yml
+++ b/environment.yml
@@ -14,6 +14,7 @@ dependencies:
   - gtest=1.17.0
   - hdf5=1.14.6
   - hdf5-external-filter-plugins=0.1.0
+  - lz4-c=1.10.0
   - nlohmann_json=3.12.0
   - numpy=2.3.4
   - pre-commit=4.3.0

--- a/include/predictor/index_generators.hpp
+++ b/include/predictor/index_generators.hpp
@@ -11,6 +11,7 @@
 #include <Eigen/Dense>
 #include <algorithm>
 #include <array>
+#include <cmath>
 #include <cstddef>
 #include <gemmi/symmetry.hpp>
 #include <optional>
@@ -164,16 +165,16 @@ class ReekeIndexGenerator {
         // Conditionally combine the Ewald and resolution limits
         // The logic here is that is if the point of tangency between a plane of constant h and the Ewald sphere lies
         // outside the resolution sphere, we use the corresponding resolution limit. Otherwise, we keep the Ewald limit.
-        if (2 * (s0_1_len * s0_1_len + abs(s0_1_len * s0_1_dot_a1) / a1_len)
+        if (2 * (s0_1_len * s0_1_len + std::abs(s0_1_len * s0_1_dot_a1) / a1_len)
             > 1 / (dmin * dmin))
             h_limits_1->first = h_limits_resolution_1.first;
-        if (2 * (s0_1_len * s0_1_len - abs(s0_1_len * s0_1_dot_a1) / a1_len)
+        if (2 * (s0_1_len * s0_1_len - std::abs(s0_1_len * s0_1_dot_a1) / a1_len)
             > 1 / (dmin * dmin))
             h_limits_1->second = h_limits_resolution_1.second;
-        if (2 * (s0_2_len * s0_2_len + abs(s0_2_len * s0_2_dot_a2) / a2_len)
+        if (2 * (s0_2_len * s0_2_len + std::abs(s0_2_len * s0_2_dot_a2) / a2_len)
             > 1 / (dmin * dmin))
             h_limits_2->first = h_limits_resolution_2.first;
-        if (2 * (s0_2_len * s0_2_len - abs(s0_2_len * s0_2_dot_a2) / a2_len)
+        if (2 * (s0_2_len * s0_2_len - std::abs(s0_2_len * s0_2_dot_a2) / a2_len)
             > 1 / (dmin * dmin))
             h_limits_2->second = h_limits_resolution_2.second;
 

--- a/runtime-environment.yml
+++ b/runtime-environment.yml
@@ -7,6 +7,7 @@ dependencies:
   - gemmi=0.7.3
   - hdf5=1.14.6
   - hdf5-external-filter-plugins=0.1.0
+  - lz4-c=1.10.0
   - h5py
   - python=3.13.7
   - pip

--- a/src/predictor/ray_predictors.cc
+++ b/src/predictor/ray_predictors.cc
@@ -27,14 +27,14 @@ std::optional<Ray> predict_ray_monochromatic_stills(const std::array<int, 3> &in
     // Find the angle by which the reciprocal lattice vector must be rotated to intersect
     // with the Ewald sphere, and the corresponding rotation matrix.
     double delta_psi = acos(-r_unit.dot(s0_unit)) - acos(r / (2 * s));
-    if (abs(delta_psi) < delta_psi_tolerance) return std::nullopt;
+    if (std::abs(delta_psi) < delta_psi_tolerance) return std::nullopt;
     Rotator rotator(s0_unit.cross(r_unit));
     const Vector3d rotated_r = rotator.rotate(r_vec, delta_psi * 180 / M_PI);
     const Vector3d s1 = s0 + rotated_r;
 
     // Create a Ray object, where the angle now represents |delta_phi|,
     // NOT the goniometer angle.
-    return Ray{s1, abs(delta_psi), false};
+    return Ray{s1, std::abs(delta_psi), false};
 }
 
 std::array<std::optional<Ray>, 2> predict_ray_monochromatic_static(


### PR DESCRIPTION
This PR clears the warnings from the Docker Image CI build. The last run
completed while emitting 2520 copies of one nvcc diagnostic, one per
Eigen template instantiation, with a handful of others buried
underneath. Two of which were actual bugs.

An unqualified `abs` on a `double` fell to the C integer overload unless
the double form had reached the global namespace, which depended on the
include chain rather than anything at the call site. gcc 13.4 locally
resolved it correctly and gcc 14.3 in the container did not, so the
predictor was working from truncated magnitudes wherever the newer
compiler was used. Separately, `.dockerignore` excludes `.git`, so
`git describe` in the build stage had nothing to describe and every
image reported `0.0.0.dev0+g000000` while the Python package carried a
hardcoded `1.0`. The version is now resolved on the runner and passed
in, and both halves of the container read the same answer.

### Changes

- Fixed the six `double` `abs` to use `std::abs` in the predictor
  sources, and imported `<cmath>` explicitly in `index_generators.hpp`.
- Put `--expt-relaxed-constexpr` on the `compile_options` interface
  target, which clears the 2520 and also puts Eigen's min and max on the
  implementation the host compiler was already using.
- Added `FFS_VERSION_DESCRIBE` to `ResolveGitVersion.cmake`. It takes
  the describe string rather than a finished version, so the injected
  path reuses the existing parsing unchanged.
- Named `/opt/ffs/lib` as the container's rpath, so cmake stops guessing
  which of the two conda prefixes will be loaded, and pinned `lz4-c` in
  both environment files since it was matching only by coincidence.
- Told pip not to warn about a root install into a conda prefix.