### PR TITLE
Output xyzcal.px into reflection table from integrators

### DIFF
--- a/baseline/integrator/integrator.cc
+++ b/baseline/integrator/integrator.cc
@@ -699,6 +699,7 @@ int main(int argc, char **argv) {
 
     mdspan_type<double> phi_column;
     mdspan_type<double> s1_vectors;
+    std::vector<double> xyzcal_px;
     std::vector<int> hkl_vectors;
     size_t num_reflections;
     predicted_data_rotation output_data;  // Define here so that members stay in scope
@@ -728,6 +729,7 @@ int main(int argc, char **argv) {
           mdspan_type<double>(output_data.s1.data(), output_data.s1.size() / 3, 3);
         phi_column = mdspan_type<double>(
           output_data.xyz_mm.data(), output_data.xyz_mm.size() / 3, 3);
+        xyzcal_px = output_data.xyz_px;
         num_reflections = output_data.enter.size();
         hkl_vectors = output_data.hkl;
     } else {
@@ -738,6 +740,14 @@ int main(int argc, char **argv) {
             return 1;
         }
         s1_vectors = *s1_vectors_opt;
+        auto xyzcal_px_opt = reflections.column<double>("xyzcal.px");
+        if (!xyzcal_px_opt) {
+            logger.error("Column 'xyzcal.px' not found in reflection data.");
+            return 1;
+        }
+        xyzcal_px = std::vector<double>(
+            xyzcal_px_opt.value().data_handle(),
+            xyzcal_px_opt.value().data_handle() + xyzcal_px_opt.value().size());
         auto phi_column_opt = reflections.column<double>("xyzcal.mm");
         if (!phi_column_opt) {
             logger.error("Column 'xyzcal.mm' not found for phi positions.");
@@ -1081,6 +1091,7 @@ int main(int argc, char **argv) {
       s1_vectors.data_handle(), s1_vectors.data_handle() + s1_vectors.size());
     std::vector<int> id = std::vector<int>(num_reflections, 0);
     integrated_data.add_column("xyzcal.mm", num_reflections, 3, xyzcal_mm);
+    integrated_data.add_column("xyzcal.px", num_reflections, 3, xyzcal_px);
     integrated_data.add_column("xyzobs.px.value", num_reflections, 3, xyzobs_px);
     integrated_data.add_column("s1", num_reflections, 3, s1);
     integrated_data.add_column("id", num_reflections, 1, id);

--- a/baseline/integrator/integrator.cc
+++ b/baseline/integrator/integrator.cc
@@ -746,8 +746,8 @@ int main(int argc, char **argv) {
             return 1;
         }
         xyzcal_px = std::vector<double>(
-            xyzcal_px_opt.value().data_handle(),
-            xyzcal_px_opt.value().data_handle() + xyzcal_px_opt.value().size());
+          xyzcal_px_opt.value().data_handle(),
+          xyzcal_px_opt.value().data_handle() + xyzcal_px_opt.value().size());
         auto phi_column_opt = reflections.column<double>("xyzcal.mm");
         if (!phi_column_opt) {
             logger.error("Column 'xyzcal.mm' not found for phi positions.");

--- a/integrator/integrator.cc
+++ b/integrator/integrator.cc
@@ -515,8 +515,8 @@ int main(int argc, char **argv) {
             return 1;
         }
         xyzcal_px = std::vector<double>(
-            xyzcal_px_opt.value().data_handle(),
-            xyzcal_px_opt.value().data_handle() + xyzcal_px_opt.value().size());
+          xyzcal_px_opt.value().data_handle(),
+          xyzcal_px_opt.value().data_handle() + xyzcal_px_opt.value().size());
         auto phi_column_opt = reflections.column<double>("xyzcal.mm");
         if (!phi_column_opt) {
             logger.error("Column 'xyzcal.mm' not found for phi positions.");
@@ -1320,7 +1320,8 @@ int main(int argc, char **argv) {
     integrated_data.add_column("d", num_reflections, 1, d_values);
     integrated_data.add_column("xyzcal.mm", num_reflections, 3, xyzcal_mm);
     integrated_data.add_column("xyzobs.px.value", num_reflections, 3, xyzobs_px);
-    integrated_data.add_column("xyzcal.px", num_reflections, 3, xyzcal_px); // to allow mtz export
+    integrated_data.add_column(
+      "xyzcal.px", num_reflections, 3, xyzcal_px);  // to allow mtz export
     integrated_data.add_column("s1", num_reflections, 3, s1_out);
     integrated_data.add_column("id", num_reflections, 1, id_col);
     integrated_data.add_column("num_pixels.background", num_reflections, 1, nbg_out);

--- a/integrator/integrator.cc
+++ b/integrator/integrator.cc
@@ -467,6 +467,7 @@ int main(int argc, char **argv) {
 
     mdspan_type<double> phi_column;
     mdspan_type<double> s1_vectors;
+    std::vector<double> xyzcal_px;
     std::vector<int> hkl_vectors;
     size_t num_reflections;
     predicted_data_rotation output_data;  // Define here so that members stay in scope
@@ -497,6 +498,7 @@ int main(int argc, char **argv) {
           mdspan_type<double>(output_data.s1.data(), output_data.s1.size() / 3, 3);
         phi_column = mdspan_type<double>(
           output_data.xyz_mm.data(), output_data.xyz_mm.size() / 3, 3);
+        xyzcal_px = output_data.xyz_px;
         num_reflections = output_data.enter.size();
         hkl_vectors = output_data.hkl;
     } else {
@@ -507,6 +509,14 @@ int main(int argc, char **argv) {
             return 1;
         }
         s1_vectors = *s1_vectors_opt;
+        auto xyzcal_px_opt = reflections.column<double>("xyzcal.px");
+        if (!xyzcal_px_opt) {
+            logger.error("Column 'xyzcal.px' not found in reflection data.");
+            return 1;
+        }
+        xyzcal_px = std::vector<double>(
+            xyzcal_px_opt.value().data_handle(),
+            xyzcal_px_opt.value().data_handle() + xyzcal_px_opt.value().size());
         auto phi_column_opt = reflections.column<double>("xyzcal.mm");
         if (!phi_column_opt) {
             logger.error("Column 'xyzcal.mm' not found for phi positions.");
@@ -1310,6 +1320,7 @@ int main(int argc, char **argv) {
     integrated_data.add_column("d", num_reflections, 1, d_values);
     integrated_data.add_column("xyzcal.mm", num_reflections, 3, xyzcal_mm);
     integrated_data.add_column("xyzobs.px.value", num_reflections, 3, xyzobs_px);
+    integrated_data.add_column("xyzcal.px", num_reflections, 3, xyzcal_px); // to allow mtz export
     integrated_data.add_column("s1", num_reflections, 3, s1_out);
     integrated_data.add_column("id", num_reflections, 1, id_col);
     integrated_data.add_column("num_pixels.background", num_reflections, 1, nbg_out);


### PR DESCRIPTION
Required if we want to be able to run `dials.export integrated.refl indexed.expt` to get an unmerged mtz, for running ccp4 data reduction programs.